### PR TITLE
Simplifying ad blocking syntax

### DIFF
--- a/media/configs/traffic+block-ads+ipv4-google.json
+++ b/media/configs/traffic+block-ads+ipv4-google.json
@@ -71,10 +71,7 @@
         "type": "field",
         "outboundTag": "blocked",
         "domain": [
-          "geosite:category-ads-all",
-          "geosite:category-ads",
-          "geosite:google-ads",
-          "geosite:spotify-ads"
+          "geosite:category-ads-all"
         ]
       },
       {

--- a/media/configs/traffic+block-ads+warp.json
+++ b/media/configs/traffic+block-ads+warp.json
@@ -76,10 +76,7 @@
         "type": "field",
         "outboundTag": "blocked",
         "domain": [
-          "geosite:category-ads-all",
-          "geosite:category-ads",
-          "geosite:google-ads",
-          "geosite:spotify-ads"
+          "geosite:category-ads-all"
         ]
       },
       {

--- a/web/html/xui/settings.html
+++ b/web/html/xui/settings.html
@@ -371,9 +371,6 @@
                 domains: {
                     ads: [
                         "geosite:category-ads-all",
-                        "geosite:category-ads",
-                        "geosite:google-ads",
-                        "geosite:spotify-ads",
                         "ext:iran.dat:ads"
                     ],
                     speedtest: ["geosite:speedtest"],


### PR DESCRIPTION
I simplified the ad blocking syntax.
"category-ads-all" includes "category-ads". Also "category-ads" includes "google-ads" and "spotify-ads". 
So if "category-ads-all" is blocked, there is no need to block 3 other lists (category-ads,google-ads,spotify-ads)

References:
https://github.com/v2fly/domain-list-community/blob/master/data/category-ads
https://github.com/v2fly/domain-list-community/blob/master/data/category-ads-all