### PR TITLE
block cloudflare in IR website blocking setting

### DIFF
--- a/web/html/xui/settings.html
+++ b/web/html/xui/settings.html
@@ -495,7 +495,7 @@
                         "ext:iran.dat:ir",
                         "ext:iran.dat:other",
                         "geosite:category-ir",
-                        "www.cloudflare.com
+                        "cloudflare.com
                     ]
                 },
                 familyProtectDNS: {

--- a/web/html/xui/settings.html
+++ b/web/html/xui/settings.html
@@ -494,7 +494,8 @@
                         "regexp:.*\\.ir$",
                         "ext:iran.dat:ir",
                         "ext:iran.dat:other",
-                        "geosite:category-ir"
+                        "geosite:category-ir",
+                        "www.cloudflare.com
                     ]
                 },
                 familyProtectDNS: {


### PR DESCRIPTION
راه جدیدی شناسایی شده است که با وجود بلاک شدن آی پی و دامین های ایرانی، باز هم آی پی سرور قابل شناسایی و فیلتر شدن باشد. این روش حداقل به صورت مشخص در برنامه ایرانسل من استفاده شده است. به این صورت که برنامه به آدرس زیر کوئری میزند
 cloudflare.com/cdn-cgi/trace
و آی پی سرور را بدست می‌آورد و میتوانند آن را به سرور خود ارسال کند. در این حالت حتی اگر آدرس های ایرانی در کلاینت دیرکت باشد، آی پی سرور بدست می‌آید.
منبع:
https://twitter.com/imMohammad20000/status/1666761832952995841?s=19
 من خودم تست کردم و ادعا درست است.

من برای حل این مشکل آدرس cloudflare.com را بلاک کردم. با این کار عموم خدمات کلودفلر مثل دی ان اس یا ورکرها یا وارپ کماکان روتینگ قبلی را خواهند داشت و بلاک نمی‌شوند. ولی برخی خدمات مانند  پنل کاربری dash.cloudflare.com بلاک می‌شوند که خوشبختانه تحریم یا فیلتر نیستند.
