### PR TITLE
Fixed xray crash

### DIFF
--- a/web/job/check_client_ip_job.go
+++ b/web/job/check_client_ip_job.go
@@ -20,7 +20,6 @@ type CheckClientIpJob struct {}
 var job *CheckClientIpJob
 var disAllowedIps []string
 var ipFiles = []string{
-	xray.GetBlockedIPsPath(),
 	xray.GetIPLimitLogPath(),
 	xray.GetIPLimitBannedLogPath(),
 	xray.GetAccessPersistentLogPath(),
@@ -45,11 +44,6 @@ func (j *CheckClientIpJob) Run() {
 	if j.hasLimitIp() {
 		j.processLogFile()
 	}
-
-	// write to blocked ips
-	blockedIps := []byte(strings.Join(disAllowedIps, ","))
-	err := os.WriteFile(xray.GetBlockedIPsPath(), blockedIps, 0644)
-	j.checkError(err)
 }
 
 func (j *CheckClientIpJob) hasLimitIp() bool {


### PR DESCRIPTION
Was having several crashes every day. Removing writing BlockedIPs from IP job seems to fix it (we don't need it anyway because IP Limit now in separate module).

Crash log I was having:

```
2023/07/25 14:42:35 [Info] infra/conf/serial: Reading config: bin/config.json

panic: runtime error: invalid memory address or nil pointer dereference

[signal SIGSEGV: segmentation violation code=0x1 addr=0x30 pc=0x87a8c3]

goroutine 35049 [running]:

github.com/xtls/xray-core/app/dispatcher.dropRestrictedConnections({0x13b19c0, 0xc004fb8db0}, 0xc0057f6820, 0xc0057f67c0)

github.com/xtls/xray-core/app/dispatcher/default.go:305 +0x83

github.com/xtls/xray-core/app/dispatcher.(*DefaultDispatcher).getLink(0xc00056c180, {0x13b19c0, 0xc004fb8db0}, 0x3, {{0x0, 0x0, 0x0}, {0x0, 0x0, 0x0}, ...})

github.com/xtls/xray-core/app/dispatcher/default.go:224 +0x52d

github.com/xtls/xray-core/app/dispatcher.(*DefaultDispatcher).Dispatch(0xc00056c180, {0x13b1918, 0xc001dfa280}, {{0x13b2da8, 0xc00066c9fc}, 0x35, 0x3})
```