### PR TITLE
change bootmortis project to MasterKia fork

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,7 +58,7 @@ jobs:
           rm -f geoip.dat geosite.dat iran.dat
           wget https://github.com/Loyalsoldier/v2ray-rules-dat/releases/latest/download/geoip.dat
           wget https://github.com/Loyalsoldier/v2ray-rules-dat/releases/latest/download/geosite.dat
-          wget https://github.com/bootmortis/iran-hosted-domains/releases/latest/download/iran.dat
+          wget https://github.com/MasterKia/iran-hosted-domains/releases/latest/download/iran.dat
           mv xray xray-linux-${{ matrix.platform }}
           cd ../..
           

--- a/DockerInit.sh
+++ b/DockerInit.sh
@@ -25,4 +25,4 @@ mv xray "xray-linux-${FNAME}"
 
 wget "https://github.com/Loyalsoldier/v2ray-rules-dat/releases/latest/download/geoip.dat"
 wget "https://github.com/Loyalsoldier/v2ray-rules-dat/releases/latest/download/geosite.dat"
-wget "https://github.com/bootmortis/iran-hosted-domains/releases/latest/download/iran.dat"
+wget "https://github.com/MasterKia/iran-hosted-domains/releases/latest/download/iran.dat"

--- a/x-ui.sh
+++ b/x-ui.sh
@@ -508,7 +508,7 @@ update_geo() {
     rm -f geoip.dat geosite.dat iran.dat
     wget -N https://github.com/Loyalsoldier/v2ray-rules-dat/releases/latest/download/geoip.dat
     wget -N https://github.com/Loyalsoldier/v2ray-rules-dat/releases/latest/download/geosite.dat
-    wget -N https://github.com/bootmortis/iran-hosted-domains/releases/latest/download/iran.dat
+    wget -N https://github.com/MasterKia/iran-hosted-domains/releases/latest/download/iran.dat
     systemctl start x-ui
     echo -e "${green}Geosite.dat + Geoip.dat + Iran.dat have been updated successfully in bin folder '${binfolder}'!${plain}"
     before_show_menu


### PR DESCRIPTION
کامل ترین لیست سایت های تبلیغات ایرانی، پروژه https://github.com/MasterKia/PersianBlocker است که به صورت مستمر نیز آپدیت می‌شود. پروژه https://github.com/bootmortis/iran-hosted-domains هم از همین لیست استفاده می‌کرد. مدتی پیش bootmortis تصمیم گرفت منبع سایت تبلیغات خود را عوض کند، نه به این دلیل که لیست کامل‌تری وجود دارد، بلکه به دلیل اینکه پروژه PersianBlocker از لایسنس GPL استفاده میکرد و پروژه bootmortis/iran-hosted-domains از لایسنس MIT استفاده میکرد و نمی‌توانست بدون تغییر لایسنس از آن منبع استفاده کند. شرح کامل ماجرا:
https://github.com/bootmortis/iran-hosted-domains/issues/27
بعد از آن MasterKia  پروژه iran-hosted-domains را با لایسنس GPL فورک کرد و لیست خود را که کامل تر بود را دوباره برگرداند.
از این جهت که 3x-ui هم لایسنس GPL دارد و محدودیت استفاده از لیست کامل‌تر را ندارد، پیشنهاد می‌کنم پروژه https://github.com/MasterKia/iran-hosted-domains جایگزین https://github.com/bootmortis/iran-hosted-domains/  شود