### PR TITLE
include .ایران TLD for IR domains

### DIFF
--- a/web/html/xui/settings.html
+++ b/web/html/xui/settings.html
@@ -495,6 +495,7 @@
                     ],
                     ir: [
                         "regexp:.*\\.ir$",
+                        "regexp:.*\\.xn--mgba3a4f16a$",  // .ایران
                         "ext:iran.dat:ir",
                         "ext:iran.dat:other",
                         "geosite:category-ir"


### PR DESCRIPTION
با سلام
در این پیشنهاد، در انتخاب دامنه های ایرانی، در کنار دامنه های .ir، دامنه های .ایران را هم اضافه کردم.