### PR TITLE
Fixing build for ARM64

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,52 +1,74 @@
 # ========================================================
 # Stage: Builder
 # ========================================================
-FROM --platform=$BUILDPLATFORM golang:1.21-alpine AS builder
+FROM --platform=$BUILDPLATFORM golang:1.21.5-bookworm AS builder
 WORKDIR /app
+
 ARG TARGETARCH
 ARG TARGETOS
-ENV CGO_ENABLED=0
-ENV GOOS=$TARGETOS
-ENV GOARCH=$TARGETARCH
 
-RUN apk --no-cache --update add \
-  build-base \
-  gcc \
-  wget \
-  unzip
+RUN export DEBIAN_FRONTEND=noninteractive \
+ && apt-get update -qq \
+ && apk add --update --no-cache -qqy \
+        build-base \
+        gcc \
+        wget \
+        unzip \
+ && if [ "${TARGETARCH}" = 'arm64' ]; then \
+        apt-get install -qqy gcc-aarch64-linux-gnu; \
+    fi \
+ && apt-get clean \
+ && rm -rf /var/cache/apt
 
+# Copy the Go Modules manifests
+COPY go.mod go.mod
+COPY go.sum go.sum
+# cache deps before building and copying source so that we don't need to re-download as much
+# and so that source changes don't invalidate our downloaded layer
+RUN go mod download
+# Copy everything else
 COPY . .
 
-RUN go build -o build/x-ui main.go
+ENV CGO_ENABLED=1
+ENV GOOS=$TARGETOS
+ENV GOARCH=$TARGETARCH
+# Build with arm64 crosscompilation if required
+RUN if [ "${TARGETARCH}" = 'arm64' ]; then \
+        export CC=aarch64-linux-gnu-gcc; \
+    fi \
+ && go build -a \
+        -ldflags="-s -w -extldflags=-static" \
+        -trimpath -o build/x-ui main.go
+
 RUN ./DockerInit.sh "$TARGETARCH"
 
 # ========================================================
 # Stage: Final Image of 3x-ui
 # ========================================================
-FROM alpine
+FROM --platform=$TARGETPLATFORM alpine
 ENV TZ=Asia/Tehran
 WORKDIR /app
 
 RUN apk add --no-cache --update \
-  ca-certificates \
-  tzdata \
-  fail2ban
+        ca-certificates \
+        tzdata \
+        fail2ban
 
-COPY --from=builder  /app/build/ /app/
-COPY --from=builder  /app/DockerEntrypoint.sh /app/
-COPY --from=builder  /app/x-ui.sh /usr/bin/x-ui
+COPY --from=builder /app/build/ /app/
+COPY --from=builder /app/DockerEntrypoint.sh /app/
+COPY --from=builder /app/x-ui.sh /usr/bin/x-ui
 
 # Configure fail2ban
 RUN rm -f /etc/fail2ban/jail.d/alpine-ssh.conf \
-  && cp /etc/fail2ban/jail.conf /etc/fail2ban/jail.local \
-  && sed -i "s/^\[ssh\]$/&\nenabled = false/" /etc/fail2ban/jail.local \
-  && sed -i "s/^\[sshd\]$/&\nenabled = false/" /etc/fail2ban/jail.local \
-  && sed -i "s/#allowipv6 = auto/allowipv6 = auto/g" /etc/fail2ban/fail2ban.conf
+ && cp /etc/fail2ban/jail.conf /etc/fail2ban/jail.local \
+ && sed -i "s/^\[ssh\]$/&\nenabled = false/" /etc/fail2ban/jail.local \
+ && sed -i "s/^\[sshd\]$/&\nenabled = false/" /etc/fail2ban/jail.local \
+ && sed -i "s/#allowipv6 = auto/allowipv6 = auto/g" /etc/fail2ban/fail2ban.conf
 
-RUN chmod +x \
-  /app/DockerEntrypoint.sh \
-  /app/x-ui \
-  /usr/bin/x-ui
+RUN chmod 0755 \
+    /app/DockerEntrypoint.sh \
+    /app/x-ui \
+    /usr/bin/x-ui
 
 VOLUME [ "/etc/x-ui" ]
 ENTRYPOINT [ "/app/DockerEntrypoint.sh" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,8 @@
 FROM --platform=$BUILDPLATFORM golang:1.21-alpine AS builder
 WORKDIR /app
 ARG TARGETARCH
-ENV CGO_ENABLED=1
+ARG TARGETPLATFORM
+ENV CGO_ENABLED=0
 
 RUN apk --no-cache --update add \
   build-base \
@@ -14,7 +15,9 @@ RUN apk --no-cache --update add \
 
 COPY . .
 
-RUN go build -o build/x-ui main.go
+RUN GOOS="$(echo "${TARGETPLATFORM}" | cut -d/ -f1)" \
+    GOARCH="$(echo "${TARGETPLATFORM}" | cut -d/ -f2)" \
+    go build -o build/x-ui main.go
 RUN ./DockerInit.sh "$TARGETARCH"
 
 # ========================================================

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,8 +4,10 @@
 FROM --platform=$BUILDPLATFORM golang:1.21-alpine AS builder
 WORKDIR /app
 ARG TARGETARCH
-ARG TARGETPLATFORM
+ARG TARGETOS
 ENV CGO_ENABLED=0
+ENV GOOS=$TARGETOS
+ENV GOARCH=$TARGETARCH
 
 RUN apk --no-cache --update add \
   build-base \
@@ -15,9 +17,7 @@ RUN apk --no-cache --update add \
 
 COPY . .
 
-RUN GOOS="$(echo "${TARGETPLATFORM}" | cut -d/ -f1)" \
-    GOARCH="$(echo "${TARGETPLATFORM}" | cut -d/ -f2)" \
-    go build -o build/x-ui main.go
+RUN go build -o build/x-ui main.go
 RUN ./DockerInit.sh "$TARGETARCH"
 
 # ========================================================


### PR DESCRIPTION
I have found out that your arm64 Docker images does not work because they still contain build for x86_64. I have managed to make Dockerfile build respective version properly basing on TARGETOS and TARGETARCH env variables. I have tested locally - now both amd64 and arm64 images contain proper binaries.

1. I have followed your releases GitHub Actions pipeline and used cross-compilation
2. Switched builder to debian bookworm based image
3. Switched runner to debian:bookworm
4. Set runner platform to TARGETPLATFORM to use arm64 on image layer
5. Copy go.mod first and then everything else - it helps proper build layer caching

Notes about 3:
Dynamically compiled binary on debian, does not work on alpine.

Now I see this on the linux/arm64/v8 build.

![image](https://github.com/MHSanaei/3x-ui/assets/11431149/8803a75c-b2ef-4b6a-9916-0db326fcf966)

And I see this on linux/amd64 build.

![image](https://github.com/MHSanaei/3x-ui/assets/11431149/17d30bcf-174e-4d23-8198-204ee179b50b)
