### PR TITLE
simplify iran Geoip rule

### DIFF
--- a/web/html/xui/xray.html
+++ b/web/html/xui/xray.html
@@ -530,7 +530,7 @@
                 ips: {
                     local: ["geoip:private"],
                     cn: ["geoip:cn"],
-                    ir: ["ext:geoip_IR.dat:ir","ext:geoip_IR.dat:arvancloud","ext:geoip_IR.dat:derakcloud","ext:geoip_IR.dat:iranserver","ext:geoip_IR.dat:parspack"],
+                    ir: ["ext:geoip_IR.dat:ir"],
                     ru: ["geoip:ru"],
                 },
                 domains: {


### PR DESCRIPTION
بعد از این issue دیگه لیست IP تمام CDN های ایرانی هم به کتگوری ir اضافه شد. در نتیجه این موارد رو حذف کردم.

https://github.com/Chocolate4U/Iran-v2ray-rules/issues/14
البته برای افرادی که از قبل routing نوشتند مشکلی پیش نمیاد. چون این دسته بندی برای نگهداشتن backward compatibility توی geoip باقی مونده