### PR TITLE
Fix inbounds with the same port and different IPs

### DIFF
--- a/database/model/model.go
+++ b/database/model/model.go
@@ -37,7 +37,7 @@ type Inbound struct {
 
 	// config part
 	Listen         string   `json:"listen" form:"listen"`
-	Port           int      `json:"port" form:"port" gorm:"unique"`
+	Port           int      `json:"port" form:"port"`
 	Protocol       Protocol `json:"protocol" form:"protocol"`
 	Settings       string   `json:"settings" form:"settings"`
 	StreamSettings string   `json:"streamSettings" form:"streamSettings"`

--- a/web/controller/inbound.go
+++ b/web/controller/inbound.go
@@ -85,7 +85,11 @@ func (a *InboundController) addInbound(c *gin.Context) {
 	}
 	user := session.GetLoginUser(c)
 	inbound.UserId = user.Id
-	inbound.Tag = fmt.Sprintf("inbound-%v", inbound.Port)
+	if inbound.Listen == "" || inbound.Listen == "0.0.0.0" || inbound.Listen == "::" || inbound.Listen == "::0" {
+		inbound.Tag = fmt.Sprintf("inbound-0.0.0.0:%v", inbound.Port)
+	} else {
+		inbound.Tag = fmt.Sprintf("inbound-%v:%v", inbound.Listen, inbound.Port)
+	}
 
 	needRestart := false
 	inbound, needRestart, err = a.inboundService.AddInbound(inbound)
@@ -278,7 +282,11 @@ func (a *InboundController) importInbound(c *gin.Context) {
 	user := session.GetLoginUser(c)
 	inbound.Id = 0
 	inbound.UserId = user.Id
-	inbound.Tag = fmt.Sprintf("inbound-%v", inbound.Port)
+	if inbound.Listen == "" || inbound.Listen == "0.0.0.0" || inbound.Listen == "::" || inbound.Listen == "::0" {
+		inbound.Tag = fmt.Sprintf("inbound-0.0.0.0:%v", inbound.Port)
+	} else {
+		inbound.Tag = fmt.Sprintf("inbound-%v:%v", inbound.Listen, inbound.Port)
+	}
 
 	for index := range inbound.ClientStats {
 		inbound.ClientStats[index].Id = 0


### PR DESCRIPTION
Currently in 3x-ui, we cannot create multiple inbounds on the same port but with different listening IPs, although it is possible in the xray core. related issues: #520 and #1456

The problem is that "checkPortExist" function only checks the database for existence of the said port and doesn't check the listening IP. I've changed this function 
to also take listening IP into consideration.

Basically I've changed the function to check If there's an inbound with listening IP of INADDR_ANY ("", 0.0.0.0, ::, ::0) then no more inbounds are allowed to be created and also if there's an inbound with a specific IP, then no more inbounds with the same IP port or INADDR_ANY and the same port are allowed to be created.

With this approach users who don't use this feature (leave listen field empty) will not be affected and their inbounds will still listen on all IPs and those users who want this feature will be able to use it.

Also unique constraint on port field in inbounds table had to be dropped because there now can be more than one inbound per port.

Screenshot of it in action
![panel](https://github.com/MHSanaei/3x-ui/assets/83173090/9cdb0af7-8703-4965-8979-69d395a90a33)
![terminal](https://github.com/MHSanaei/3x-ui/assets/83173090/852bc533-7ba5-4c09-b4ad-780a856bf357)