### PR TITLE
fix bug in edit SOCKS and HTTP outbound

### DIFF
--- a/web/assets/js/model/outbound.js
+++ b/web/assets/js/model/outbound.js
@@ -861,13 +861,13 @@ Outbound.SocksSettings = class extends CommonClass {
     }
 
     static fromJson(json={}) {
-        servers = json.servers;
+        let servers = json.servers;
         if(ObjectUtil.isArrEmpty(servers)) servers=[{users: [{}]}];
         return new Outbound.SocksSettings(
             servers[0].address,
             servers[0].port,
             ObjectUtil.isArrEmpty(servers[0].users) ? '' : servers[0].users[0].user,
-            ObjectUtil.isArrEmpty(servers[0].pass) ? '' : servers[0].users[0].pass,
+            ObjectUtil.isArrEmpty(servers[0].users) ? '' : servers[0].users[0].pass,
         );
     }
 
@@ -891,13 +891,13 @@ Outbound.HttpSettings = class extends CommonClass {
     }
 
     static fromJson(json={}) {
-        servers = json.servers;
+        let servers = json.servers;
         if(ObjectUtil.isArrEmpty(servers)) servers=[{users: [{}]}];
         return new Outbound.HttpSettings(
             servers[0].address,
             servers[0].port,
             ObjectUtil.isArrEmpty(servers[0].users) ? '' : servers[0].users[0].user,
-            ObjectUtil.isArrEmpty(servers[0].pass) ? '' : servers[0].users[0].pass,
+            ObjectUtil.isArrEmpty(servers[0].users) ? '' : servers[0].users[0].pass,
         );
     }
 


### PR DESCRIPTION
Hi. In the outbound tab, when you want to edit Socks and HTTP, the outbound settings are not loaded, and an error is displayed in the browser console. This problem is fixed in this patch.