### PR TITLE
Enhance IP Limitation using Xray Stdout and iptables

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 *.tar.gz
 access.log
 error.log
+.env
 tmp
 main
 backup/

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/gin-contrib/gzip v0.0.6
 	github.com/gin-gonic/gin v1.9.1
 	github.com/goccy/go-json v0.10.2
+	github.com/joho/godotenv v1.5.1
 	github.com/mymmrac/telego v0.28.0
 	github.com/nicksnyder/go-i18n/v2 v2.4.0
 	github.com/op/go-logging v0.0.0-20160315200505-970db520ece7

--- a/go.sum
+++ b/go.sum
@@ -131,6 +131,8 @@ github.com/jinzhu/inflection v1.0.0 h1:K317FqzuhWc8YvSVlFMCCUb36O/S9MCKRDI7QkRKD
 github.com/jinzhu/inflection v1.0.0/go.mod h1:h+uFLlag+Qp1Va5pdKtLDYj+kHp5pxUVkryuEj+Srlc=
 github.com/jinzhu/now v1.1.5 h1:/o9tlHleP7gOFmsnYNz3RGnqzefHA47wQpKrrdTIwXQ=
 github.com/jinzhu/now v1.1.5/go.mod h1:d3SSVoowX0Lcu0IBviAWJpolVfI5UJVZZ7cO71lE/z8=
+github.com/joho/godotenv v1.5.1 h1:7eLL/+HRGLY0ldzfGMeQkb7vMd0as4CfYvUVzLqw0N0=
+github.com/joho/godotenv v1.5.1/go.mod h1:f4LDr5Voq0i2e/R5DDNOoa2zzDfwtkZa6DnEwAbqwq4=
 github.com/json-iterator/go v1.1.6/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=
 github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=
 github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=

--- a/main.go
+++ b/main.go
@@ -16,6 +16,7 @@ import (
 	"x-ui/web/global"
 	"x-ui/web/service"
 
+	_ "github.com/joho/godotenv/autoload"
 	"github.com/op/go-logging"
 )
 

--- a/web/service/config.json
+++ b/web/service/config.json
@@ -1,8 +1,7 @@
 {
   "log": {
-    "access": "none",
-    "dnsLog": false,
-    "loglevel": "warning"
+    "loglevel": "warning",
+    "error": "./error.log"
   },
   "api": {
     "tag": "api",

--- a/xray/client_ip.go
+++ b/xray/client_ip.go
@@ -1,0 +1,115 @@
+package xray
+
+import (
+	"errors"
+	"os/exec"
+	"regexp"
+	"strings"
+	"x-ui/logger"
+)
+
+var customChain string = "IPLIMIT"
+var listener *ClientIPListener
+
+type ClientIPListener struct {
+	p                *process
+	logWriter        *LogWriter
+	InboundClientIps map[string][]string
+	blacklist        []string
+}
+
+func NewClientIPListener(p *process) *ClientIPListener {
+	listener = &ClientIPListener{
+		p:                p,
+		logWriter:        p.logWriter,
+		InboundClientIps: make(map[string][]string),
+		blacklist:        make([]string, 0),
+	}
+
+	return listener
+}
+
+func GetClientIPListener() (*ClientIPListener, error) {
+	if listener == nil {
+		return nil, errors.New("ClientIPListener is not initialized")
+	}
+
+	return listener, nil
+}
+
+func (l *ClientIPListener) GetOnlineClients() []string {
+	return listener.p.onlineClients
+}
+
+func (l *ClientIPListener) processLine(line string) {
+	ipRegx, _ := regexp.Compile(`((\d+\.\d+\.\d+\.\d+)|(\[.*\])).* accepted`)
+	emailRegx, _ := regexp.Compile(`email:.+`)
+
+	matches := ipRegx.FindStringSubmatch(line)
+	if len(matches) > 1 {
+		ip := matches[1]
+		if ip == "127.0.0.1" || ip == "[::1]" {
+			logger.Debug("Skip localhost IP: ", ip)
+			return
+		}
+
+		matchesEmail := emailRegx.FindString(line)
+		if matchesEmail == "" {
+			return
+		}
+
+		matchesEmail = strings.TrimSpace(strings.Split(matchesEmail, "email: ")[1])
+		if l.InboundClientIps[matchesEmail] != nil {
+			if l.contains(l.InboundClientIps[matchesEmail], ip) {
+				return
+			}
+			l.InboundClientIps[matchesEmail] = append(l.InboundClientIps[matchesEmail], ip)
+		} else {
+			l.InboundClientIps[matchesEmail] = append(l.InboundClientIps[matchesEmail], ip)
+		}
+
+		logger.Info("Client IP: ", ip, " Email: ", matchesEmail)
+	}
+}
+
+func (l *ClientIPListener) ProcessBlacklist() {
+	unbanCmd := exec.Command("iptables", "-F", customChain)
+	_ = unbanCmd.Run()
+
+	for _, ip := range l.blacklist {
+		banCmd := exec.Command("iptables", "-A", customChain, "-s", ip, "-j", "DROP")
+		_ = banCmd.Run()
+	}
+}
+
+func (l *ClientIPListener) contains(s []string, str string) bool {
+	for _, v := range s {
+		if v == str {
+			return true
+		}
+	}
+
+	return false
+}
+
+// Start listening to the xray stdout
+func (l *ClientIPListener) Start() {
+	l.logWriter.SetListener(l.processLine)
+}
+
+func (l *ClientIPListener) UnbanAllIPs() {
+	l.blacklist = make([]string, 0)
+}
+
+func (l *ClientIPListener) UnbanIP(ip string) {
+	for i, v := range l.blacklist {
+		if v == ip {
+			l.blacklist = append(l.blacklist[:i], l.blacklist[i+1:]...)
+			return
+		}
+	}
+}
+
+func (l *ClientIPListener) BanIP(ip string) {
+	l.blacklist = append(l.blacklist, ip)
+}

--- a/xray/process.go
+++ b/xray/process.go
@@ -218,6 +218,12 @@ func (p *process) Start() (err error) {
 	cmd.Stdout = p.logWriter
 	cmd.Stderr = p.logWriter
 
+	// Listen to client connections from the stdout of xray
+	// It is better this way than reading the log file
+	// because reading a file causes a lot of IO operations
+	// and system calls which is not efficient
+	NewClientIPListener(p).Start()
+
 	go func() {
 		err := cmd.Run()
 		if err != nil {


### PR DESCRIPTION
This pull request aims to improve IP limitation mechanisms by replacing the fail2ban tool and log files with a more efficient solution. Instead of relying on external tools and file operations, this enhancement proposes leveraging xray stdout to extract client email and connected IP addresses.

Key Changes:
1. **Direct Xray Integration:** Instead of relying on intermediate log files, the system now reads IP events directly from the stdout of the xray tool. This eliminates the need for file I/O operations and simplifies the overall process.
2. **Native iptables Commands:** The IP limitation mechanism now utilizes native iptables commands to ban disallowed IPs. This approach improves efficiency and reduces latency by avoiding external tools and file operations.
3. **Real-time Response:** With direct integration and native command usage, the system can respond to IP events in real-time as they occur, enhancing the responsiveness of the IP limitation mechanism.
4. **Simplified Workflow:** The new flow significantly simplifies the workflow by removing unnecessary intermediate steps.
5. **Enhanced Reliability:** By eliminating potential points of failure associated with file I/O operations, the reliability of the IP limitation mechanism is improved, ensuring consistent and accurate enforcement of IP restrictions.
6. **Elimination of fail2ban:** there is no need of fail2ban or any kind of log files.
7. **Improved Efficiency:** By avoiding unnecessary I/O operations and utilizing system-native functionalities, this enhancement offers a more streamlined and efficient IP limitation mechanism.
8. **Better for lower specs machines:** This potentially can prevent the database look, because of lower I/O operations.
9. **Fallback to Previous Mechanism:** If the access log is populated, the system will revert to using fail2ban and log files for IP limitation.

Your review and feedback on these proposed changes are highly appreciated.