### PR TITLE
Update default.json

### DIFF
--- a/sub/default.json
+++ b/sub/default.json
@@ -25,7 +25,7 @@
           "tls",
           "fakedns"
         ],
-        "enabled": true
+        "enabled": false
       },
       "tag": "socks"
     },
@@ -74,7 +74,7 @@
     }
   },
   "routing": {
-    "domainStrategy": "AsIs",
+    "domainStrategy": "IPIfNonMatch",
     "rules": [
       {
         "type": "field",


### PR DESCRIPTION
In scenarios where using domainStrategy: "AsIs", the geoip database is sometimes ignored, and only the geosite database is checked. To ensure that both geosite and geoip databases are considered, it’s recommended to use domainStrategy: "IPIfNonMatch".

Surprisingly, I discovered that when client-side sniffing is enabled, multi-routing does not work properly (just sometimes). However, after disabling sniffing at the client side, multi-routing works perfectly without any issues.