### PR TITLE
fix wrong splithttp default

### DIFF
--- a/web/assets/js/model/xray.js
+++ b/web/assets/js/model/xray.js
@@ -523,7 +523,7 @@ class HTTPUpgradeStreamSettings extends XrayCommonClass {
 }
 
 class SplitHTTPStreamSettings extends XrayCommonClass {
-    constructor(path='/', host='', headers=[] , maxUploadSize= 1, maxConcurrentUploads= 10) {
+    constructor(path='/', host='', headers=[] , maxUploadSize= 1000000, maxConcurrentUploads= 10) {
         super();
         this.path = path;
         this.host = host;


### PR DESCRIPTION
This default is defined as 1MB, but maxUploadSize is to be specified in bytes. This confusion could've come from poorly written documentation in xray, but it has been updated.

in general I wish that panels would not set defaults at all and instead just omit parameters (in sharelinks, inbounds, ...) that the user didn't set explicitly. If I want to change the defaults in xray's codebase, it seems that all the panels will have to update the default too.

I see marzban doing the same kind of things.