### PR TITLE
Update session.go revert f21c293

### DIFF
--- a/web/session/session.go
+++ b/web/session/session.go
@@ -17,10 +17,6 @@ func init() {
 
 func SetLoginUser(c *gin.Context, user *model.User) error {
 	s := sessions.Default(c)
-	s.Options(sessions.Options{
-		Path:     "/",
-		HttpOnly: true,
-	})
 	s.Set(loginUser, user)
 	return s.Save()
 }


### PR DESCRIPTION
i reverted your changes to session.go
i think this cause returning empty [] cookie jar.
cant store session cookies in versions upper than 2.3.8