### PR TITLE
Fixed description of NetflixWARPDesc in Russian version

### DIFF
--- a/web/translation/translate.ru_RU.toml
+++ b/web/translation/translate.ru_RU.toml
@@ -398,7 +398,7 @@
 "OpenAIWARP" = "OpenAI (ChatGPT)"
 "OpenAIWARPDesc" = "Направляет трафик в OpenAI (ChatGPT) через WARP."
 "NetflixWARP" = "Netflix"
-"NetflixWARPDesc" = "Направляет трафик в Apple через WARP."
+"NetflixWARPDesc" = "Направляет трафик в Netflix через WARP."
 "MetaWARP" = "Мета"
 "MetaWARPDesc" = "Направляет трафик в Meta (Instagram, Facebook, WhatsApp, Threads...) через WARP."
 "AppleWARP" = "Apple"


### PR DESCRIPTION
On the “Xray Configs” page, under “WARP Routing”, the “Netflix” switch had an incorrect description in the Russian version.

<img width="1012" alt="image" src="https://github.com/user-attachments/assets/817d1414-ee07-46ff-a3d8-9f6d1db12bbb">
