### PR TITLE
fix TypeError: this.shortIds.split is not a function

### DIFF
--- a/web/assets/js/model/xray.js
+++ b/web/assets/js/model/xray.js
@@ -914,18 +914,20 @@ class RealityStreamSettings extends XrayCommonClass {
         minClient = '',
         maxClient = '',
         maxTimediff = 0,
-        shortIds = RandomUtil.randomShortId(),
+        shortIds = RandomUtil.randomShortIds(),
         settings = new RealityStreamSettings.Settings()
     ) {
         super();
         this.show = show;
         this.xver = xver;
         this.dest = dest;
+        /** @type {string} */
         this.serverNames = Array.isArray(serverNames) ? serverNames.join(",") : serverNames;
         this.privateKey = privateKey;
         this.minClient = minClient;
         this.maxClient = maxClient;
         this.maxTimediff = maxTimediff;
+        /** @type {string} */
         this.shortIds = Array.isArray(shortIds) ? shortIds.join(",") : shortIds; 
         this.settings = settings;
     }

--- a/web/assets/js/util/utils.js
+++ b/web/assets/js/util/utils.js
@@ -99,13 +99,15 @@ class RandomUtil {
         return str;
     }
 
-    static randomShortId() {
+    /** @return {string} */
+    static randomShortIds() {
         const lengths = [2, 4, 6, 8, 10, 12, 14, 16];
         for (let i = lengths.length - 1; i > 0; i--) {
             const j = Math.floor(Math.random() * (i + 1));
             [lengths[i], lengths[j]] = [lengths[j], lengths[i]];
         }
 
+        /** @type {string[]} */
         let shortIds = [];
         for (let length of lengths) {
             let shortId = '';
@@ -114,7 +116,7 @@ class RandomUtil {
             }
             shortIds.push(shortId);
         }
-        return shortIds;
+        return shortIds.join(',');
     }    
 
     static randomLowerAndNum(len) {

--- a/web/html/xui/form/tls_settings.html
+++ b/web/html/xui/form/tls_settings.html
@@ -189,7 +189,7 @@
         <a-tooltip>
           <template slot="title">
             <span>{{ i18n "reset" }}</span>
-          </template> Short ID <a-icon @click="inbound.stream.reality.shortIds = RandomUtil.randomShortId()" type="sync"></a-icon>
+          </template> Short IDs <a-icon @click="inbound.stream.reality.shortIds = RandomUtil.randomShortIds()" type="sync"></a-icon>
         </a-tooltip>
       </template>
       <a-input v-model.trim="inbound.stream.reality.shortIds"></a-input>


### PR DESCRIPTION
This PR fixes a bug with the following repro steps:
1. Open page "Inbounds"
2. Click "Add Inbound"
3. Select option "Reality" in field "Security"
4. Reset field "Short ID" via the icon button
5. Click button "Create"
  Expected: A new item is created
  Actual: Nothing happends and there is an error in the console: "TypeError: this.shortIds.split is not a function"
  
I've not tested the fix, but I don't see what it can break