### PR TITLE
added amazon linux support

### DIFF
--- a/README.es_ES.md
+++ b/README.es_ES.md
@@ -225,6 +225,7 @@ location /sub {
 - AlmaLinux 9+
 - Rockylinux 9+
 - OpenSUSE Tubleweed
+- Amazon Linux 2023
 
 ## Arquitecturas y Dispositivos Compatibles
 

--- a/README.md
+++ b/README.md
@@ -254,6 +254,7 @@ location /sub {
 - Rocky Linux 9+
 - Oracle Linux 8+
 - OpenSUSE Tubleweed
+- Amazon Linux 2023
 
 ## Supported Architectures and Devices
 

--- a/README.ru_RU.md
+++ b/README.ru_RU.md
@@ -253,6 +253,7 @@ location /sub {
 - Rocky Linux 9+
 - Oracle Linux 8+
 - OpenSUSE Tubleweed
+- Amazon Linux 2023
 
 ## Поддерживаемые архитектуры и устройства
 

--- a/README.zh_CN.md
+++ b/README.zh_CN.md
@@ -248,6 +248,7 @@ location /sub {
 - AlmaLinux 9+
 - Rockylinux 9+
 - OpenSUSE Tubleweed
+- Amazon Linux 2023
 
 ## 支持的架构和设备
 <details>

--- a/install.sh
+++ b/install.sh
@@ -44,7 +44,7 @@ os_version=$(grep "^VERSION_ID" /etc/os-release | cut -d '=' -f2 | tr -d '"')
 if [[ "${release}" == "arch" ]]; then
     echo "Your OS is Arch Linux"
 elif [[ "${release}" == "parch" ]]; then
-    echo "Your OS is Parch linux"
+    echo "Your OS is Parch Linux"
 elif [[ "${release}" == "manjaro" ]]; then
     echo "Your OS is Manjaro"
 elif [[ "${release}" == "armbian" ]]; then
@@ -59,10 +59,13 @@ elif [[ "${release}" == "ubuntu" ]]; then
     if [[ ${os_version} -lt 20 ]]; then
         echo -e "${red} Please use Ubuntu 20 or higher version!${plain}\n" && exit 1
     fi
-elif [[ "${release}" == "fedora" || "${release}" == "amzn" ]]; then
-    # For Amazon Linux, use the same branch as for Fedora
-    if [[ ${os_version} -lt 36 && "${release}" == "fedora" ]]; then
+elif [[ "${release}" == "fedora" ]]; then
+    if [[ ${os_version} -lt 36 ]]; then
         echo -e "${red} Please use Fedora 36 or higher version!${plain}\n" && exit 1
+    fi
+elif [[ "${release}" == "amzn" ]]; then
+    if [[ ${os_version} != "2023" ]]; then
+        echo -e "${red} Please use Amazon Linux 2023!${plain}\n" && exit 1
     fi
 elif [[ "${release}" == "debian" ]]; then
     if [[ ${os_version} -lt 11 ]]; then

--- a/install.sh
+++ b/install.sh
@@ -39,7 +39,7 @@ arch() {
 echo "arch: $(arch)"
 
 os_version=""
-os_version=$(grep -i version_id /etc/os-release | cut -d \" -f2 | cut -d . -f1)
+os_version=$(grep "^VERSION_ID" /etc/os-release | cut -d '=' -f2 | tr -d '"')
 
 if [[ "${release}" == "arch" ]]; then
     echo "Your OS is Arch Linux"
@@ -59,8 +59,9 @@ elif [[ "${release}" == "ubuntu" ]]; then
     if [[ ${os_version} -lt 20 ]]; then
         echo -e "${red} Please use Ubuntu 20 or higher version!${plain}\n" && exit 1
     fi
-elif [[ "${release}" == "fedora" ]]; then
-    if [[ ${os_version} -lt 36 ]]; then
+elif [[ "${release}" == "fedora" || "${release}" == "amzn" ]]; then
+    # Для Amazon Linux используем ту же ветку, что и для Fedora
+    if [[ ${os_version} -lt 36 && "${release}" == "fedora" ]]; then
         echo -e "${red} Please use Fedora 36 or higher version!${plain}\n" && exit 1
     fi
 elif [[ "${release}" == "debian" ]]; then
@@ -94,8 +95,8 @@ else
     echo "- Rocky Linux 9+"
     echo "- Oracle Linux 8+"
     echo "- OpenSUSE Tumbleweed"
+    echo "- Amazon Linux 2023"
     exit 1
-
 fi
 
 install_base() {

--- a/install.sh
+++ b/install.sh
@@ -60,7 +60,7 @@ elif [[ "${release}" == "ubuntu" ]]; then
         echo -e "${red} Please use Ubuntu 20 or higher version!${plain}\n" && exit 1
     fi
 elif [[ "${release}" == "fedora" || "${release}" == "amzn" ]]; then
-    # Для Amazon Linux используем ту же ветку, что и для Fedora
+    # For Amazon Linux, use the same branch as for Fedora
     if [[ ${os_version} -lt 36 && "${release}" == "fedora" ]]; then
         echo -e "${red} Please use Fedora 36 or higher version!${plain}\n" && exit 1
     fi

--- a/x-ui.sh
+++ b/x-ui.sh
@@ -36,7 +36,7 @@ fi
 echo "The OS release is: $release"
 
 os_version=""
-os_version=$(grep -i version_id /etc/os-release | cut -d \" -f2 | cut -d . -f1)
+os_version=$(grep "^VERSION_ID" /etc/os-release | cut -d '=' -f2 | tr -d '"')
 
 if [[ "${release}" == "arch" ]]; then
     echo "Your OS is Arch Linux"
@@ -56,8 +56,9 @@ elif [[ "${release}" == "ubuntu" ]]; then
     if [[ ${os_version} -lt 20 ]]; then
         echo -e "${red} Please use Ubuntu 20 or higher version!${plain}\n" && exit 1
     fi
-elif [[ "${release}" == "fedora" ]]; then
-    if [[ ${os_version} -lt 36 ]]; then
+elif [[ "${release}" == "fedora" || "${release}" == "amzn" ]]; then
+    # Для Amazon Linux используем ту же ветку, что и для Fedora
+    if [[ ${os_version} -lt 36 && "${release}" == "fedora" ]]; then
         echo -e "${red} Please use Fedora 36 or higher version!${plain}\n" && exit 1
     fi
 elif [[ "${release}" == "debian" ]]; then
@@ -91,8 +92,8 @@ else
     echo "- Rocky Linux 9+"
     echo "- Oracle Linux 8+"
     echo "- OpenSUSE Tumbleweed"
+    echo "- Amazon Linux 2023"
     exit 1
-
 fi
 
 # Declare Variables

--- a/x-ui.sh
+++ b/x-ui.sh
@@ -57,7 +57,6 @@ elif [[ "${release}" == "ubuntu" ]]; then
         echo -e "${red} Please use Ubuntu 20 or higher version!${plain}\n" && exit 1
     fi
 elif [[ "${release}" == "fedora" || "${release}" == "amzn" ]]; then
-    # Для Amazon Linux используем ту же ветку, что и для Fedora
     if [[ ${os_version} -lt 36 && "${release}" == "fedora" ]]; then
         echo -e "${red} Please use Fedora 36 or higher version!${plain}\n" && exit 1
     fi

--- a/x-ui.sh
+++ b/x-ui.sh
@@ -57,6 +57,7 @@ elif [[ "${release}" == "ubuntu" ]]; then
         echo -e "${red} Please use Ubuntu 20 or higher version!${plain}\n" && exit 1
     fi
 elif [[ "${release}" == "fedora" || "${release}" == "amzn" ]]; then
+    # For Amazon Linux, use the same branch as for Fedora
     if [[ ${os_version} -lt 36 && "${release}" == "fedora" ]]; then
         echo -e "${red} Please use Fedora 36 or higher version!${plain}\n" && exit 1
     fi

--- a/x-ui.sh
+++ b/x-ui.sh
@@ -41,7 +41,7 @@ os_version=$(grep "^VERSION_ID" /etc/os-release | cut -d '=' -f2 | tr -d '"')
 if [[ "${release}" == "arch" ]]; then
     echo "Your OS is Arch Linux"
 elif [[ "${release}" == "parch" ]]; then
-    echo "Your OS is Parch linux"
+    echo "Your OS is Parch Linux"
 elif [[ "${release}" == "manjaro" ]]; then
     echo "Your OS is Manjaro"
 elif [[ "${release}" == "armbian" ]]; then
@@ -56,10 +56,13 @@ elif [[ "${release}" == "ubuntu" ]]; then
     if [[ ${os_version} -lt 20 ]]; then
         echo -e "${red} Please use Ubuntu 20 or higher version!${plain}\n" && exit 1
     fi
-elif [[ "${release}" == "fedora" || "${release}" == "amzn" ]]; then
-    # For Amazon Linux, use the same branch as for Fedora
-    if [[ ${os_version} -lt 36 && "${release}" == "fedora" ]]; then
+elif [[ "${release}" == "fedora" ]]; then
+    if [[ ${os_version} -lt 36 ]]; then
         echo -e "${red} Please use Fedora 36 or higher version!${plain}\n" && exit 1
+    fi
+elif [[ "${release}" == "amzn" ]]; then
+    if [[ ${os_version} != "2023" ]]; then
+        echo -e "${red} Please use Amazon Linux 2023!${plain}\n" && exit 1
     fi
 elif [[ "${release}" == "debian" ]]; then
     if [[ ${os_version} -lt 11 ]]; then


### PR DESCRIPTION
I added Amazon Linux support, because we can use the same branch as for Fedora

```
$ cat /etc/os-release
NAME="Amazon Linux"
VERSION="2023"
ID="amzn"
ID_LIKE="fedora"