### PR TITLE
Fix code scanning alert no. 55: Clear-text logging of sensitive information

### DIFF
--- a/main.go
+++ b/main.go
@@ -150,7 +150,7 @@ func showSetting(show bool) {
 
 		fmt.Println("current panel settings as follows:")
 		fmt.Println("username:", username)
-		fmt.Println("password:", userpasswd)
+		fmt.Println("password: [REDACTED]")
 		fmt.Println("port:", port)
 		if webBasePath != "" {
 			fmt.Println("webBasePath:", webBasePath)


### PR DESCRIPTION
Fixes [https://github.com/MHSanaei/3x-ui/security/code-scanning/55](https://github.com/MHSanaei/3x-ui/security/code-scanning/55)

To fix the problem, we should avoid printing the password in clear text. Instead, we can either obfuscate the password or omit it entirely from the output. In this case, we will replace the password with a placeholder text to indicate that the password exists without revealing its actual value.

- **General Fix:** Avoid logging or printing sensitive information in clear text. Use placeholders or obfuscation techniques.
- **Detailed Fix:** Modify the `showSetting` function to replace the clear-text password with a placeholder.
- **Specific Changes:** Update the `fmt.Println("password:", userpasswd)` line to print a placeholder instead of the actual password.
- **Required Changes:** No new imports or methods are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
