### PR TITLE
feat(tgbot): Add the option to change the telegram API server

### DIFF
--- a/web/assets/js/model/setting.js
+++ b/web/assets/js/model/setting.js
@@ -16,6 +16,7 @@ class AllSetting {
         this.tgBotEnable = false;
         this.tgBotToken = "";
         this.tgBotProxy = "";
+        this.tgBotAPIServer = "";
         this.tgBotChatId = "";
         this.tgRunTime = "@daily";
         this.tgBotBackup = false;

--- a/web/entity/entity.go
+++ b/web/entity/entity.go
@@ -30,6 +30,7 @@ type AllSetting struct {
 	TgBotEnable      bool   `json:"tgBotEnable" form:"tgBotEnable"`
 	TgBotToken       string `json:"tgBotToken" form:"tgBotToken"`
 	TgBotProxy       string `json:"tgBotProxy" form:"tgBotProxy"`
+	TgBotAPIServer   string `json:"tgBotAPIServer" form:"tgBotAPIServer"`
 	TgBotChatId      string `json:"tgBotChatId" form:"tgBotChatId"`
 	TgRunTime        string `json:"tgRunTime" form:"tgRunTime"`
 	TgBotBackup      bool   `json:"tgBotBackup" form:"tgBotBackup"`

--- a/web/html/xui/settings.html
+++ b/web/html/xui/settings.html
@@ -246,6 +246,7 @@
                   <setting-list-item type="switch" title='{{ i18n "pages.settings.tgNotifyLogin" }}' desc='{{ i18n "pages.settings.tgNotifyLoginDesc" }}' v-model="allSetting.tgBotLoginNotify"></setting-list-item>
                   <setting-list-item type="number" title='{{ i18n "pages.settings.tgNotifyCpu" }}' desc='{{ i18n "pages.settings.tgNotifyCpuDesc" }}' v-model="allSetting.tgCpu" :min="0" :max="100"></setting-list-item>
                   <setting-list-item type="text" title='{{ i18n "pages.settings.telegramProxy"}}' desc='{{ i18n "pages.settings.telegramProxyDesc"}}' v-model="allSetting.tgBotProxy" placeholder="socks5://user:pass@host:port"></setting-list-item>
+                  <setting-list-item type="text" title='{{ i18n "pages.settings.telegramAPIServer"}}' desc='{{ i18n "pages.settings.telegramAPIServerDesc"}}' v-model="allSetting.tgBotAPIServer" placeholder="https://api.example.com"></setting-list-item>
                   <a-list-item>
                     <a-row style="padding: 20px">
                       <a-col :lg="24" :xl="12">

--- a/web/service/setting.go
+++ b/web/service/setting.go
@@ -41,6 +41,7 @@ var defaultValueMap = map[string]string{
 	"tgBotEnable":        "false",
 	"tgBotToken":         "",
 	"tgBotProxy":         "",
+	"tgBotAPIServer":     "",
 	"tgBotChatId":        "",
 	"tgRunTime":          "@daily",
 	"tgBotBackup":        "false",
@@ -260,6 +261,14 @@ func (s *SettingService) GetTgBotProxy() (string, error) {
 
 func (s *SettingService) SetTgBotProxy(token string) error {
 	return s.setString("tgBotProxy", token)
+}
+
+func (s *SettingService) GetTgBotAPIServer() (string, error) {
+	return s.getString("tgBotAPIServer")
+}
+
+func (s *SettingService) SetTgBotAPIServer(token string) error {
+	return s.setString("tgBotAPIServer", token)
 }
 
 func (s *SettingService) GetTgBotChatId() (string, error) {

--- a/web/service/tgbot.go
+++ b/web/service/tgbot.go
@@ -153,12 +153,12 @@ func (t *Tgbot) NewBot(token string, proxyUrl string, apiServerUrl string) (*tel
 			Dial: fasthttpproxy.FasthttpSocksDialer(proxyUrl),
 		}))
 	} else {
-		if !strings.HasPrefix(proxyUrl, "http") {
+		if !strings.HasPrefix(apiServerUrl, "http") {
 			logger.Warning("Invalid http(s) URL, starting with default")
 			return telego.NewBot(token)
 		}
 
-		_, err := url.Parse(proxyUrl)
+		_, err := url.Parse(apiServerUrl)
 		if err != nil {
 			logger.Warning("Can't parse API server URL, using default instance for tgbot:", err)
 			return telego.NewBot(token)

--- a/web/service/tgbot.go
+++ b/web/service/tgbot.go
@@ -137,22 +137,33 @@ func (t *Tgbot) NewBot(token string, proxyUrl string, apiServerUrl string) (*tel
 		return telego.NewBot(token)
 	}
 
-	if !strings.HasPrefix(proxyUrl, "socks5://") {
-		logger.Warning("Invalid socks5 URL, starting with default")
-		return telego.NewBot(token)
-	}
-
-	_, err := url.Parse(proxyUrl)
-	if err != nil {
-		logger.Warning("Can't parse proxy URL, using default instance for tgbot:", err)
-		return telego.NewBot(token)
-	}
-
 	if proxyUrl != "" {
+		if !strings.HasPrefix(proxyUrl, "socks5://") {
+			logger.Warning("Invalid socks5 URL, starting with default")
+			return telego.NewBot(token)
+		}
+
+		_, err := url.Parse(proxyUrl)
+		if err != nil {
+			logger.Warning("Can't parse proxy URL, using default instance for tgbot:", err)
+			return telego.NewBot(token)
+		}
+
 		return telego.NewBot(token, telego.WithFastHTTPClient(&fasthttp.Client{
 			Dial: fasthttpproxy.FasthttpSocksDialer(proxyUrl),
 		}))
 	} else {
+		if !strings.HasPrefix(proxyUrl, "http") {
+			logger.Warning("Invalid http(s) URL, starting with default")
+			return telego.NewBot(token)
+		}
+
+		_, err := url.Parse(proxyUrl)
+		if err != nil {
+			logger.Warning("Can't parse API server URL, using default instance for tgbot:", err)
+			return telego.NewBot(token)
+		}
+
 		return telego.NewBot(token, telego.WithAPIServer(apiServerUrl))
 	}
 

--- a/web/service/tgbot.go
+++ b/web/service/tgbot.go
@@ -133,40 +133,38 @@ func (t *Tgbot) Start(i18nFS embed.FS) error {
 
 func (t *Tgbot) NewBot(token string, proxyUrl string, apiServerUrl string) (*telego.Bot, error) {
 	if proxyUrl == "" && apiServerUrl == "" {
-		// No proxy or API server URL provided, use default instance
 		return telego.NewBot(token)
 	}
 
 	if proxyUrl != "" {
 		if !strings.HasPrefix(proxyUrl, "socks5://") {
-			logger.Warning("Invalid socks5 URL, starting with default")
+			logger.Warning("Invalid socks5 URL, using default")
 			return telego.NewBot(token)
 		}
 
 		_, err := url.Parse(proxyUrl)
 		if err != nil {
-			logger.Warning("Can't parse proxy URL, using default instance for tgbot:", err)
+			logger.Warningf("Can't parse proxy URL, using default instance for tgbot: %v", err)
 			return telego.NewBot(token)
 		}
 
 		return telego.NewBot(token, telego.WithFastHTTPClient(&fasthttp.Client{
 			Dial: fasthttpproxy.FasthttpSocksDialer(proxyUrl),
 		}))
-	} else {
-		if !strings.HasPrefix(apiServerUrl, "http") {
-			logger.Warning("Invalid http(s) URL, starting with default")
-			return telego.NewBot(token)
-		}
-
-		_, err := url.Parse(apiServerUrl)
-		if err != nil {
-			logger.Warning("Can't parse API server URL, using default instance for tgbot:", err)
-			return telego.NewBot(token)
-		}
-
-		return telego.NewBot(token, telego.WithAPIServer(apiServerUrl))
 	}
 
+	if !strings.HasPrefix(apiServerUrl, "http") {
+		logger.Warning("Invalid http(s) URL, using default")
+		return telego.NewBot(token)
+	}
+
+	_, err := url.Parse(apiServerUrl)
+	if err != nil {
+		logger.Warningf("Can't parse API server URL, using default instance for tgbot: %v", err)
+		return telego.NewBot(token)
+	}
+
+	return telego.NewBot(token, telego.WithAPIServer(apiServerUrl))
 }
 
 func (t *Tgbot) IsRunning() bool {

--- a/web/translation/translate.en_US.toml
+++ b/web/translation/translate.en_US.toml
@@ -265,6 +265,8 @@
 "telegramTokenDesc" = "The Telegram bot token obtained from '@BotFather'."
 "telegramProxy" = "SOCKS Proxy"
 "telegramProxyDesc" = "Enables SOCKS5 proxy for connecting to Telegram. (adjust settings as per guide)"
+"telegramAPIServer" = "Telegram API Server"
+"telegramAPIServerDesc" = "The Telegram API server to use. Leave blank to use the default server."
 "telegramChatId" = "Admin Chat ID"
 "telegramChatIdDesc" = "The Telegram Admin Chat ID(s). (comma-separated)(get it here @userinfobot) or (use '/id' command in the bot)"
 "telegramNotifyTime" = "Notification Time"

--- a/web/translation/translate.es_ES.toml
+++ b/web/translation/translate.es_ES.toml
@@ -265,6 +265,8 @@
 "telegramTokenDesc" = "Debe obtener el token del administrador de bots de Telegram @botfather."
 "telegramProxy" = "Socks5 Proxy"
 "telegramProxyDesc" = "Si necesita el proxy Socks5 para conectarse a Telegram. Ajuste su configuración según la guía."
+"telegramAPIServer" = "API Server de Telegram"
+"telegramAPIServerDesc" = "El servidor API de Telegram a utilizar. Déjelo en blanco para utilizar el servidor predeterminado."
 "telegramChatId" = "IDs de Chat de Telegram para Administradores"
 "telegramChatIdDesc" = "IDs de Chat múltiples separados por comas. Use @userinfobot o use el comando '/id' en el bot para obtener sus IDs de Chat."
 "telegramNotifyTime" = "Hora de Notificación del Bot de Telegram"

--- a/web/translation/translate.fa_IR.toml
+++ b/web/translation/translate.fa_IR.toml
@@ -265,6 +265,8 @@
 "telegramTokenDesc" = "دریافت کنید @botfather توکن را می‌توانید از"
 "telegramProxy" = "SOCKS پراکسی"
 "telegramProxyDesc" = "را برای اتصال به تلگرام فعال می کند SOCKS5 پراکسی"
+"telegramAPIServer" = "سرور API تلگرام"
+"telegramAPIServerDesc" = "API سرور تلگرام برای اتصال را تغییر میدهد. برای استفاده از سرور پیش فرض خالی بگذارید"
 "telegramChatId" = "آی‌دی چت مدیر"
 "telegramChatIdDesc" = "دریافت ‌کنید ('/id'یا (دستور (@userinfobot) آی‌دی(های) چت تلگرام مدیر، از"
 "telegramNotifyTime" = "زمان نوتیفیکیشن"

--- a/web/translation/translate.id_ID.toml
+++ b/web/translation/translate.id_ID.toml
@@ -265,6 +265,8 @@
 "telegramTokenDesc" = "Token bot Telegram yang diperoleh dari '@BotFather'."
 "telegramProxy" = "Proxy SOCKS"
 "telegramProxyDesc" = "Mengaktifkan proxy SOCKS5 untuk terhubung ke Telegram. (sesuaikan pengaturan sesuai panduan)"
+"telegramAPIServer" = "Telegram API Server"
+"telegramAPIServerDesc" = "Server API Telegram yang akan digunakan. Biarkan kosong untuk menggunakan server default."
 "telegramChatId" = "ID Obrolan Admin"
 "telegramChatIdDesc" = "ID Obrolan Admin Telegram. (dipisahkan koma)(dapatkan di sini @userinfobot) atau (gunakan perintah '/id' di bot)"
 "telegramNotifyTime" = "Waktu Notifikasi"

--- a/web/translation/translate.pt_BR.toml
+++ b/web/translation/translate.pt_BR.toml
@@ -265,6 +265,8 @@
 "telegramTokenDesc" = "O token do bot do Telegram obtido de '@BotFather'."
 "telegramProxy" = "Proxy SOCKS"
 "telegramProxyDesc" = "Ativa o proxy SOCKS5 para conectar ao Telegram. (ajuste as configurações conforme o guia)"
+"telegramAPIServer" = "API Server do Telegram"
+"telegramAPIServerDesc" = "O servidor API do Telegram a ser usado. Deixe em branco para usar o servidor padrão."
 "telegramChatId" = "ID de Chat do Administrador"
 "telegramChatIdDesc" = "O(s) ID(s) de Chat do Administrador no Telegram. (separado por vírgulas)(obtenha aqui @userinfobot) ou (use o comando '/id' no bot)"
 "telegramNotifyTime" = "Hora da Notificação"

--- a/web/translation/translate.ru_RU.toml
+++ b/web/translation/translate.ru_RU.toml
@@ -265,6 +265,8 @@
 "telegramTokenDesc" = "Необходимо получить токен у менеджера ботов Telegram @botfather"
 "telegramProxy" = "Прокси Socks5"
 "telegramProxyDesc" = "Если для подключения к Telegram вам нужен прокси Socks5. Настройте его параметры согласно руководству."
+"telegramAPIServer" = "API-сервер Telegram"
+"telegramAPIServerDesc" = "Используемый API-сервер Telegram. Оставьте пустым, чтобы использовать сервер по умолчанию."
 "telegramChatId" = "Идентификатор Telegram администратора бота"
 "telegramChatIdDesc" = "Один или несколько идентификаторов администратора бота. Чтобы получить идентификатор, используйте @userinfobot или команду '/id' в боте."
 "telegramNotifyTime" = "Частота уведомлений бота Telegram"

--- a/web/translation/translate.tr_TR.toml
+++ b/web/translation/translate.tr_TR.toml
@@ -265,6 +265,8 @@
 "telegramTokenDesc" = "'@BotFather'dan alınan Telegram bot token."
 "telegramProxy" = "SOCKS Proxy"
 "telegramProxyDesc" = "Telegram'a bağlanmak için SOCKS5 proxy'sini etkinleştirir. (ayarları kılavuzda belirtilen şekilde ayarlayın)"
+"telegramAPIServer" = "Telegram API Server"
+"telegramAPIServerDesc" = "Kullanılacak Telegram API sunucusu. Varsayılan sunucuyu kullanmak için boş bırakın."
 "telegramChatId" = "Yönetici Sohbet Kimliği"
 "telegramChatIdDesc" = "Telegram Yönetici Sohbet Kimliği(leri). (virgülle ayrılmış)(buradan alın @userinfobot) veya (botta '/id' komutunu kullanın)"
 "telegramNotifyTime" = "Bildirim Zamanı"

--- a/web/translation/translate.uk_UA.toml
+++ b/web/translation/translate.uk_UA.toml
@@ -265,6 +265,8 @@
 "telegramTokenDesc" = "Токен бота Telegram, отриманий від '@BotFather'."
 "telegramProxy" = "SOCKS Проксі"
 "telegramProxyDesc" = "Вмикає проксі-сервер SOCKS5 для підключення до Telegram. (відкоригуйте параметри відповідно до посібника)"
+"telegramAPIServer" = "Сервер Telegram API"
+"telegramAPIServerDesc" = "Сервер Telegram API для використання. Залиште поле порожнім, щоб використовувати сервер за умовчанням."
 "telegramChatId" = "Ідентифікатор чату адміністратора"
 "telegramChatIdDesc" = "Ідентифікатори чату адміністратора Telegram. (розділені комами) (отримайте тут @userinfobot) або (використовуйте команду '/id' у боті)"
 "telegramNotifyTime" = "Час сповіщення"

--- a/web/translation/translate.vi_VN.toml
+++ b/web/translation/translate.vi_VN.toml
@@ -265,6 +265,8 @@
 "telegramTokenDesc" = "Bạn phải nhận token từ quản lý bot Telegram @botfather"
 "telegramProxy" = "Socks5 Proxy"
 "telegramProxyDesc" = "Nếu bạn cần socks5 proxy để kết nối với Telegram. Điều chỉnh cài đặt của nó theo hướng dẫn."
+"telegramAPIServer" = "Telegram API Server"
+"telegramAPIServerDesc" = "Máy chủ API Telegram để sử dụng. Để trống để sử dụng máy chủ mặc định."
 "telegramChatId" = "Chat ID Telegram của quản trị viên"
 "telegramChatIdDesc" = "Nhiều Chat ID phân tách bằng dấu phẩy. Sử dụng @userinfobot hoặc sử dụng lệnh '/id' trong bot để lấy Chat ID của bạn."
 "telegramNotifyTime" = "Thời gian thông báo của bot Telegram"

--- a/web/translation/translate.zh_CN.toml
+++ b/web/translation/translate.zh_CN.toml
@@ -265,6 +265,8 @@
 "telegramTokenDesc" = "从 '@BotFather' 获取的 Telegram 机器人令牌"
 "telegramProxy" = "SOCKS5 Proxy"
 "telegramProxyDesc" = "启用 SOCKS5 代理连接到 Telegram（根据指南调整设置）"
+"telegramAPIServer" = "Telegram API Server"
+"telegramAPIServerDesc" = "要使用的 Telegram API 服务器。留空以使用默认服务器。"
 "telegramChatId" = "管理员聊天 ID"
 "telegramChatIdDesc" = "Telegram 管理员聊天 ID (多个以逗号分隔)（可通过 @userinfobot 获取，或在机器人中使用 '/id' 命令获取）"
 "telegramNotifyTime" = "通知时间"

--- a/web/translation/translate.zh_TW.toml
+++ b/web/translation/translate.zh_TW.toml
@@ -265,6 +265,8 @@
 "telegramTokenDesc" = "從 '@BotFather' 獲取的 Telegram 機器人令牌"
 "telegramProxy" = "SOCKS5 Proxy"
 "telegramProxyDesc" = "啟用 SOCKS5 代理連線到 Telegram（根據指南調整設定）"
+"telegramAPIServer" = "Telegram API Server"
+"telegramAPIServerDesc" = "要使用的 Telegram API 伺服器。留空以使用預設伺服器。"
 "telegramChatId" = "管理員聊天 ID"
 "telegramChatIdDesc" = "Telegram 管理員聊天 ID (多個以逗號分隔)（可通過 @userinfobot 獲取，或在機器人中使用 '/id' 命令獲取）"
 "telegramNotifyTime" = "通知時間"


### PR DESCRIPTION
If someone has a [custom bot API  server](https://core.telegram.org/bots/api#using-a-local-bot-api-server) or proxied API server this lets them use it.