### PR TITLE
Error: "No Such File or Directory" While Installing Certs

### DIFF
--- a/x-ui.sh
+++ b/x-ui.sh
@@ -1183,8 +1183,10 @@ ssl_cert_issue_CF() {
         fi
 
         # Install the certificate
+        mkdir -p ${certPath}/${CF_Domain}
+
         ~/.acme.sh/acme.sh --installcert -d ${CF_Domain} -d *.${CF_Domain} \
-            --cert-file ${certPath}/${CF_Domain}/fullchain.pem \
+            --fullchain-file ${certPath}/${CF_Domain}/fullchain.pem \
             --key-file ${certPath}/${CF_Domain}/privkey.pem
 
         if [ $? -ne 0 ]; then

--- a/x-ui.sh
+++ b/x-ui.sh
@@ -1184,6 +1184,10 @@ ssl_cert_issue_CF() {
 
         # Install the certificate
         mkdir -p ${certPath}/${CF_Domain}
+        if [ $? -ne 0 ]; then
+            LOGE "Failed to create directory: ${certPath}/${CF_Domain}"
+            exit 1
+        fi
 
         ~/.acme.sh/acme.sh --installcert -d ${CF_Domain} -d *.${CF_Domain} \
             --fullchain-file ${certPath}/${CF_Domain}/fullchain.pem \


### PR DESCRIPTION
Hello, I found an issue with the "update - CF SSL Certificate" feature in the 3x-ui v2.4.7 update. During script execution, the following error occurs: 
"[INF] Certificate issued successfully, Installing... 
[Sat Nov 16 01:54:41 AM PST 2024] The domain 'example.com' seems to already have an ECC cert, let's use it.
[Sat Nov 16 01:54:41 AM PST 2024] Installing cert to: /root/cert-CF/example.com/fullchain.pem
/root/.acme.sh/acme.sh: line 5925: /root/cert-CF/example.com/fullchain.pem: No such file or directory
[ERR] Certificate installation failed, script exiting...
". 

Later, I discovered that the directory "${certPath}/${CF_Domain}" must exist before installing the certificate; otherwise, acme will throw such error. Therefore, I am submitting this PR and hope you can review it as soon as possible.