### PR TITLE
fix typo

### DIFF
--- a/x-ui.sh
+++ b/x-ui.sh
@@ -700,23 +700,23 @@ firewall_menu() {
         firewall_menu
         ;;
     2)
-        sudo ufw status numbered
+        ufw status numbered
         firewall_menu
         ;;
     3)
-        sudo open_ports
+        open_ports
         firewall_menu
         ;;
     4)
-        sudo delete_ports
+        delete_ports
         firewall_menu
         ;;
     5)
-        sudo ufw disable
+        ufw disable
         firewall_menu
         ;;
     6)
-        sudo ufw status verbose
+        ufw status verbose
         firewall_menu
         ;;
     *) 


### PR DESCRIPTION
All the commands do not work exactly, but since we already work in the beginning on behalf of root, then sudo is not necessary at the beginning. Is that right? 
+sudo, as I understood it, broke the functions?

P.S. when selected in the menu, it says that "command not found".