### PR TITLE
Fixed ru translation

### DIFF
--- a/web/translation/translate.ru_RU.toml
+++ b/web/translation/translate.ru_RU.toml
@@ -147,7 +147,7 @@
 "meansNoLimit" = "= Без ограничений (значение: ГБ)"
 "totalFlow" = "Общий расход"
 "leaveBlankToNeverExpire" = "Оставьте пустым, чтобы не истекало"
-"noRecommendKeepDefault" = "Не рекомендуется оставлять настройки по умолчанию"
+"noRecommendKeepDefault" = "Рекомендуется оставить настройки по умолчанию"
 "certificatePath" = "Путь к файлу"
 "certificateContent" = "Содержимое файла"
 "publicKey" = "Публичный ключ"


### PR DESCRIPTION
"noRecommendKeepDefault" = "Не рекомендуется оставлять настройки по умолчанию"  The meaning here is distorted. The phrase translates to 'It is not recommended to keep the default settings,' which contradicts the original meaning. The correct translation is: -"Рекомендуется оставить настройки по умолчанию"
of course, if the original English phrase is translated correctly - 'It is recommended to keep the default'