### PR TITLE
wireguard modal fix

### DIFF
--- a/web/html/xui/inbound_info_modal.html
+++ b/web/html/xui/inbound_info_modal.html
@@ -427,7 +427,7 @@
           </tr>
           <tr>
             <td colspan="2">
-              <tr-info-row v-for="(link,index) in infoModal.links" class="tr-info-row">
+              <tr-info-row class="tr-info-row">
                 <tr-info-title class="tr-info-title">
                   <a-tag color="blue">Config</a-tag>
                   <a-tooltip title='{{ i18n "copy" }}'>


### PR DESCRIPTION
There was a bug with listing all configs in the wireguard modal window, now under each peer there is only its config