### PR TITLE
Make wget verify certificates

### DIFF
--- a/x-ui.sh
+++ b/x-ui.sh
@@ -180,7 +180,7 @@ update_menu() {
         return 0
     fi
 
-    wget --no-check-certificate -O /usr/bin/x-ui https://raw.githubusercontent.com/MHSanaei/3x-ui/main/x-ui.sh
+    wget -O /usr/bin/x-ui https://raw.githubusercontent.com/MHSanaei/3x-ui/main/x-ui.sh
     chmod +x /usr/local/x-ui/x-ui.sh
     chmod +x /usr/bin/x-ui
 
@@ -575,7 +575,7 @@ enable_bbr() {
 }
 
 update_shell() {
-    wget -O /usr/bin/x-ui -N --no-check-certificate https://github.com/MHSanaei/3x-ui/raw/main/x-ui.sh
+    wget -O /usr/bin/x-ui -N https://github.com/MHSanaei/3x-ui/raw/main/x-ui.sh
     if [[ $? != 0 ]]; then
         echo ""
         LOGE "Failed to download script, Please check whether the machine can connect Github"


### PR DESCRIPTION
I don't know why `--no-check-certificate` was added to the wget commands in the first place. This option introduces a security vulnerability.

Without certificate validation in these update functions, users can be MITM'ed and served malicious binaries/scripts. There is no further integrity checking such as checksum comparisons later on too.

This PR makes wget verify certificates by removing the `--no-check-certificate` option.
