### PR TITLE
fix warning "docker-compose.yml: the attribute 'version' is obsolete"

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,3 @@
----
-version: "3"
-
 services:
   3x-ui:
     image: ghcr.io/mhsanaei/3x-ui:latest


### PR DESCRIPTION
I've tested on ubuntu WSL.
"docker compose pull" and "docker compose up -d" runs succesfully, panel starts, login works