### PR TITLE
fix: issue 2953. Restore from .db file fails

### DIFF
--- a/web/service/server.go
+++ b/web/service/server.go
@@ -524,9 +524,6 @@ func (s *ServerService) ImportDB(file multipart.File) error {
 	}
 	defer tempFile.Close()
 
-	// Remove temp file before returning
-	defer os.Remove(tempPath)
-
 	// Save uploaded file to temporary file
 	_, err = io.Copy(tempFile, file)
 	if err != nil {
@@ -572,14 +569,6 @@ func (s *ServerService) ImportDB(file multipart.File) error {
 	}
 
 	// Migrate DB
-	err = database.InitDB(config.GetDBPath())
-	if err != nil {
-		errRename := os.Rename(fallbackPath, config.GetDBPath())
-		if errRename != nil {
-			return common.NewErrorf("Error migrating db and restoring fallback: %v", errRename)
-		}
-		return common.NewErrorf("Error migrating db: %v", err)
-	}
 	s.inboundService.MigrateDB()
 
 	// Start Xray


### PR DESCRIPTION
## What is the pull request?

In "web\service\server.go" "ImportDB(file multipart.File)" removed defer os.Remove(tempPath) because later in method it will be renamed "err = os.Rename(tempPath, config.GetDBPath())"
Also removed err = database.InitDB(config.GetDBPath()) and error condition because earlier it already has been inited when it was tempPath.

## Which part of the application is affected by the change?

- [ ] Frontend
- [ ] Backend

## Type of Changes

- [ ] Bug fix
- [ ] New feature
- [ ] Refactoring
- [ ] Other

## Screenshots

<!-- Add screenshots to illustrate the changes -->
<!-- Remove this section if it is not applicable. -->