### PR TITLE
fix: handle inbounds interaction errors

### DIFF
--- a/web/controller/inbound.go
+++ b/web/controller/inbound.go
@@ -104,6 +104,10 @@ func (a *InboundController) addInbound(c *gin.Context) {
 
 	needRestart := false
 	inbound, needRestart, err = a.inboundService.AddInbound(inbound)
+	if err != nil {
+		jsonMsg(c, I18nWeb(c, "somethingWentWrong"), err)
+		return
+	}
 	jsonMsgObj(c, I18nWeb(c, "pages.inbounds.toasts.inboundCreateSuccess"), inbound, err)
 	if err == nil && needRestart {
 		a.xrayService.SetToNeedRestart()
@@ -118,6 +122,10 @@ func (a *InboundController) delInbound(c *gin.Context) {
 	}
 	needRestart := true
 	needRestart, err = a.inboundService.DelInbound(id)
+	if err != nil {
+		jsonMsg(c, I18nWeb(c, "somethingWentWrong"), err)
+		return
+	}
 	jsonMsgObj(c, I18nWeb(c, "pages.inbounds.toasts.inboundDeleteSuccess"), id, err)
 	if err == nil && needRestart {
 		a.xrayService.SetToNeedRestart()
@@ -140,6 +148,10 @@ func (a *InboundController) updateInbound(c *gin.Context) {
 	}
 	needRestart := true
 	inbound, needRestart, err = a.inboundService.UpdateInbound(inbound)
+	if err != nil {
+		jsonMsg(c, I18nWeb(c, "somethingWentWrong"), err)
+		return
+	}
 	jsonMsgObj(c, I18nWeb(c, "pages.inbounds.toasts.inboundUpdateSuccess"), inbound, err)
 	if err == nil && needRestart {
 		a.xrayService.SetToNeedRestart()


### PR DESCRIPTION
## What is the pull request?

This pull request adds the error handle of creating/modifying/deleting inbounds.

It eliminates messages such as: “Inbound created successfully (port 100 is already busy)”.

## Which part of the application is affected by the change?

- [ ] Frontend
- [X] Backend

## Type of Changes

- [X] Bug fix
- [ ] New feature
- [ ] Refactoring
- [ ] Other

## Screenshots

| Before | After |
| - | - |
| ![image](https://github.com/user-attachments/assets/e166a7b9-db98-4a23-80c0-a296f5b55089) | ![image](https://github.com/user-attachments/assets/5ebd010a-0884-4b53-95c6-9404cfc4e957) |