### PR TITLE
chore: reset two-factor authentication after changing admin credentials

### DIFF
--- a/main.go
+++ b/main.go
@@ -232,7 +232,7 @@ func updateTgbotSetting(tgBotToken string, tgBotChatid string, tgBotRuntime stri
 	}
 }
 
-func updateSetting(port int, username string, password string, webBasePath string, listenIP string) {
+func updateSetting(port int, username string, password string, webBasePath string, listenIP string, resetTwoFactor bool) {
 	err := database.InitDB(config.GetDBPath())
 	if err != nil {
 		fmt.Println("Database initialization failed:", err)
@@ -266,6 +266,17 @@ func updateSetting(port int, username string, password string, webBasePath strin
 			fmt.Println("Failed to set base URI path:", err)
 		} else {
 			fmt.Println("Base URI path set successfully")
+		}
+	}
+
+	if resetTwoFactor {
+		err := settingService.SetTwoFactorEnable(false)
+
+		if err != nil {
+			fmt.Println("Failed to reset two-factor authentication:", err)
+		} else {
+			settingService.SetTwoFactorToken("")
+			fmt.Println("Two-factor authentication reset successfully")
 		}
 	}
 
@@ -376,6 +387,7 @@ func main() {
 	var reset bool
 	var show bool
 	var getCert bool
+	var resetTwoFactor bool
 	settingCmd.BoolVar(&reset, "reset", false, "Reset all settings")
 	settingCmd.BoolVar(&show, "show", false, "Display current settings")
 	settingCmd.IntVar(&port, "port", 0, "Set panel port number")
@@ -383,6 +395,7 @@ func main() {
 	settingCmd.StringVar(&password, "password", "", "Set login password")
 	settingCmd.StringVar(&webBasePath, "webBasePath", "", "Set base path for Panel")
 	settingCmd.StringVar(&listenIP, "listenIP", "", "set panel listenIP IP")
+	settingCmd.BoolVar(&resetTwoFactor, "resetTwoFactor", false, "Reset two-factor authentication settings")
 	settingCmd.BoolVar(&getListen, "getListen", false, "Display current panel listenIP IP")
 	settingCmd.BoolVar(&getCert, "getCert", false, "Display current certificate settings")
 	settingCmd.StringVar(&webCertFile, "webCert", "", "Set path to public key file for panel")
@@ -427,7 +440,7 @@ func main() {
 		if reset {
 			resetSetting()
 		} else {
-			updateSetting(port, username, password, webBasePath, listenIP)
+			updateSetting(port, username, password, webBasePath, listenIP, resetTwoFactor)
 		}
 		if show {
 			showSetting(show)

--- a/web/html/modals/two_factor_modal.html
+++ b/web/html/modals/two_factor_modal.html
@@ -15,8 +15,8 @@
         <p>{{ i18n "pages.settings.security.twoFactorModalSecondStep" }}</p>
         <a-input v-model.trim="twoFactorModal.enteredCode" :style="{ width: '100%' }"></a-input>
     </template>
-    <template v-if="twoFactorModal.type === 'remove'">
-        <p>{{ i18n "pages.settings.security.twoFactorModalRemoveStep" }}</p>
+    <template v-if="twoFactorModal.type === 'confirm'">
+        <p>[[ twoFactorModal.description ]]</p>
         <a-input v-model.trim="twoFactorModal.enteredCode" :style="{ width: '100%' }"></a-input>
     </template>
     <template slot="footer">
@@ -32,6 +32,7 @@
 <script>
     const twoFactorModal = {
         title: '',
+        description: '',
         fileName: '',
         token: '',
         enteredCode: '',
@@ -45,17 +46,6 @@
                 ObjectUtil.execute(twoFactorModal.confirm, true)
 
                 twoFactorModal.close()
-
-                switch (twoFactorModal.type) {
-                    case 'set':
-                        Vue.prototype.$message['success']('{{ i18n "pages.settings.security.twoFactorModalSetSuccess" }}')
-                        break;
-                    case 'remove':
-                        Vue.prototype.$message['success']('{{ i18n "pages.settings.security.twoFactorModalDeleteSuccess" }}')
-                        break;
-                    default:
-                        break;
-                }
             } else {
                 Vue.prototype.$message['error']('{{ i18n "pages.settings.security.twoFactorModalError" }}')
             }
@@ -67,11 +57,13 @@
         },
         show: function ({
             title = '',
+            description = '',
             token = '',
             type = 'set',
             confirm = (success) => { }
         }) {
             this.title = title;
+            this.description = description;
             this.token = token;
             this.visible = true;
             this.confirm = confirm;

--- a/web/html/settings.html
+++ b/web/html/settings.html
@@ -270,12 +270,30 @@
         }
       },
       async updateUser() {
-        this.loading(true);
-        const msg = await HttpUtil.post("/panel/setting/updateUser", this.user);
-        this.loading(false);
-        if (msg.success) {
-          this.user = {};
-          window.location.replace(basePath + "logout");
+        const sendUpdateUserRequest = async () => {
+          this.loading(true);
+          const msg = await HttpUtil.post("/panel/setting/updateUser", this.user);
+          this.loading(false);
+          if (msg.success) {
+            this.user = {};
+            window.location.replace(basePath + "logout");
+          }
+        }
+
+        if (this.allSetting.twoFactorEnable) {
+          twoFactorModal.show({
+            title: '{{ i18n "pages.settings.security.twoFactorModalChangeCredentialsTitle" }}',
+            description: '{{ i18n "pages.settings.security.twoFactorModalChangeCredentialsStep" }}',
+            token: this.allSetting.twoFactorToken,
+            type: 'confirm',
+            confirm: (success) => {
+              if (success) {
+                sendUpdateUserRequest();
+              }
+            }
+          })
+        } else {
+          sendUpdateUserRequest();
         }
       },
       async restartPanel() {
@@ -313,6 +331,8 @@
             type: 'set',
             confirm: (success) => {
               if (success) {
+                Vue.prototype.$message['success']('{{ i18n "pages.settings.security.twoFactorModalSetSuccess" }}')
+
                 this.allSetting.twoFactorToken = newTwoFactorToken
               }
 
@@ -322,10 +342,13 @@
         } else {
           twoFactorModal.show({
             title: '{{ i18n "pages.settings.security.twoFactorModalDeleteTitle" }}',
+            description: '{{ i18n "pages.settings.security.twoFactorModalRemoveStep" }}',
             token: this.allSetting.twoFactorToken,
-            type: 'remove',
+            type: 'confirm',
             confirm: (success) => {
               if (success) {
+                Vue.prototype.$message['success']('{{ i18n "pages.settings.security.twoFactorModalDeleteSuccess" }}')
+
                 this.allSetting.twoFactorEnable = false
                 this.allSetting.twoFactorToken = ""
               }

--- a/web/service/setting.go
+++ b/web/service/setting.go
@@ -322,8 +322,16 @@ func (s *SettingService) GetTwoFactorEnable() (bool, error) {
 	return s.getBool("twoFactorEnable")
 }
 
+func (s *SettingService) SetTwoFactorEnable(value bool) error {
+	return s.setBool("twoFactorEnable", value)
+}
+
 func (s *SettingService) GetTwoFactorToken() (string, error) {
 	return s.getString("twoFactorToken")
+}
+
+func (s *SettingService) SetTwoFactorToken(value string) error {
+	return s.setString("twoFactorToken", value)
 }
 
 func (s *SettingService) GetPort() (int, error) {

--- a/web/service/user.go
+++ b/web/service/user.go
@@ -79,6 +79,16 @@ func (s *UserService) UpdateUser(id int, username string, password string) error
 		return err
 	}
 
+	twoFactorEnable, err := s.settingService.GetTwoFactorEnable()
+	if err != nil {
+		return err
+	}
+
+	if twoFactorEnable {
+		s.settingService.SetTwoFactorEnable(false)
+		s.settingService.SetTwoFactorToken("")
+	}
+
 	return db.Model(model.User{}).
 		Where("id = ?", id).
 		Updates(map[string]any{"username": username, "password": hashedPassword}).

--- a/web/translation/translate.ar_EG.toml
+++ b/web/translation/translate.ar_EG.toml
@@ -539,6 +539,8 @@
 "twoFactorModalFirstStep" = "1. امسح رمز QR هذا في تطبيق المصادقة أو انسخ الرمز الموجود بجانب رمز QR والصقه في التطبيق"
 "twoFactorModalSecondStep" = "2. أدخل الرمز من التطبيق"
 "twoFactorModalRemoveStep" = "أدخل الرمز من التطبيق لإزالة المصادقة الثنائية."
+"twoFactorModalChangeCredentialsTitle" = "تغيير بيانات الاعتماد"
+"twoFactorModalChangeCredentialsStep" = "أدخل الرمز من التطبيق لتغيير بيانات اعتماد المسؤول."
 "twoFactorModalSetSuccess" = "تم إنشاء المصادقة الثنائية بنجاح"
 "twoFactorModalDeleteSuccess" = "تم حذف المصادقة الثنائية بنجاح"
 "twoFactorModalError" = "رمز خاطئ"

--- a/web/translation/translate.en_US.toml
+++ b/web/translation/translate.en_US.toml
@@ -538,6 +538,8 @@
 "twoFactorModalFirstStep" = "1. Scan this QR code in the app for authentication or copy the token near the QR code and paste it into the app"
 "twoFactorModalSecondStep" = "2. Enter the code from the app"
 "twoFactorModalRemoveStep" = "Enter the code from the application to remove two-factor authentication."
+"twoFactorModalChangeCredentialsTitle" = "Change credentials"
+"twoFactorModalChangeCredentialsStep" = "Enter the code from the application to change administrator credentials."
 "twoFactorModalSetSuccess" = "Two-factor authentication has been successfully established"
 "twoFactorModalDeleteSuccess" = "Two-factor authentication has been successfully deleted"
 "twoFactorModalError" = "Wrong code"

--- a/web/translation/translate.es_ES.toml
+++ b/web/translation/translate.es_ES.toml
@@ -541,6 +541,8 @@
 "twoFactorModalFirstStep" = "1. Escanea este código QR en la aplicación de autenticación o copia el token cerca del código QR y pégalo en la aplicación"
 "twoFactorModalSecondStep" = "2. Ingresa el código de la aplicación"
 "twoFactorModalRemoveStep" = "Ingresa el código de la aplicación para eliminar la autenticación de dos factores."
+"twoFactorModalChangeCredentialsTitle" = "Cambiar credenciales"
+"twoFactorModalChangeCredentialsStep" = "Ingrese el código de la aplicación para cambiar las credenciales del administrador."
 "twoFactorModalSetSuccess" = "La autenticación de dos factores se ha establecido con éxito"
 "twoFactorModalDeleteSuccess" = "La autenticación de dos factores se ha eliminado con éxito"
 "twoFactorModalError" = "Código incorrecto"

--- a/web/translation/translate.fa_IR.toml
+++ b/web/translation/translate.fa_IR.toml
@@ -541,6 +541,8 @@
 "twoFactorModalFirstStep" = "1. این کد QR را در برنامه احراز هویت اسکن کنید یا توکن کنار کد QR را کپی کرده و در برنامه بچسبانید"
 "twoFactorModalSecondStep" = "2. کد را از برنامه وارد کنید"
 "twoFactorModalRemoveStep" = "برای حذف احراز هویت دو مرحله‌ای، کد را از برنامه وارد کنید."
+"twoFactorModalChangeCredentialsTitle" = "تغییر اعتبارنامه‌ها"
+"twoFactorModalChangeCredentialsStep" = "برای تغییر اعتبارنامه‌های مدیر، کد را از برنامه وارد کنید."
 "twoFactorModalSetSuccess" = "احراز هویت دو مرحله‌ای با موفقیت برقرار شد"
 "twoFactorModalDeleteSuccess" = "احراز هویت دو مرحله‌ای با موفقیت حذف شد"
 "twoFactorModalError" = "کد نادرست"

--- a/web/translation/translate.id_ID.toml
+++ b/web/translation/translate.id_ID.toml
@@ -541,6 +541,8 @@
 "twoFactorModalFirstStep" = "1. Pindai kode QR ini di aplikasi autentikasi atau salin token di dekat kode QR dan tempelkan ke aplikasi"
 "twoFactorModalSecondStep" = "2. Masukkan kode dari aplikasi"
 "twoFactorModalRemoveStep" = "Masukkan kode dari aplikasi untuk menghapus autentikasi dua faktor."
+"twoFactorModalChangeCredentialsTitle" = "Ubah kredensial"
+"twoFactorModalChangeCredentialsStep" = "Masukkan kode dari aplikasi untuk mengubah kredensial administrator."
 "twoFactorModalSetSuccess" = "Autentikasi dua faktor telah berhasil dibuat"
 "twoFactorModalDeleteSuccess" = "Autentikasi dua faktor telah berhasil dihapus"
 "twoFactorModalError" = "Kode salah"

--- a/web/translation/translate.ja_JP.toml
+++ b/web/translation/translate.ja_JP.toml
@@ -541,6 +541,8 @@
 "twoFactorModalFirstStep" = "1. 認証アプリでこのQRコードをスキャンするか、QRコード近くのトークンをコピーしてアプリに貼り付けます"
 "twoFactorModalSecondStep" = "2. アプリからコードを入力してください"
 "twoFactorModalRemoveStep" = "二段階認証を削除するには、アプリからコードを入力してください。"
+"twoFactorModalChangeCredentialsTitle" = "認証情報の変更"
+"twoFactorModalChangeCredentialsStep" = "管理者の認証情報を変更するには、アプリケーションからコードを入力してください。"
 "twoFactorModalSetSuccess" = "二要素認証が正常に設定されました"
 "twoFactorModalDeleteSuccess" = "二要素認証が正常に削除されました"
 "twoFactorModalError" = "コードが間違っています"

--- a/web/translation/translate.pt_BR.toml
+++ b/web/translation/translate.pt_BR.toml
@@ -541,6 +541,8 @@
 "twoFactorModalFirstStep" = "1. Escaneie este QR code no aplicativo de autenticação ou copie o token próximo ao QR code e cole no aplicativo"
 "twoFactorModalSecondStep" = "2. Digite o código do aplicativo"
 "twoFactorModalRemoveStep" = "Digite o código do aplicativo para remover a autenticação de dois fatores."
+"twoFactorModalChangeCredentialsTitle" = "Alterar credenciais"
+"twoFactorModalChangeCredentialsStep" = "Insira o código do aplicativo para alterar as credenciais do administrador."
 "twoFactorModalSetSuccess" = "A autenticação de dois fatores foi estabelecida com sucesso"
 "twoFactorModalDeleteSuccess" = "A autenticação de dois fatores foi excluída com sucesso"
 "twoFactorModalError" = "Código incorreto"

--- a/web/translation/translate.ru_RU.toml
+++ b/web/translation/translate.ru_RU.toml
@@ -541,6 +541,8 @@
 "twoFactorModalFirstStep" = "1. Отсканируйте этот QR-код в приложении для аутентификации или скопируйте токен рядом с QR-кодом и вставьте его в приложение"
 "twoFactorModalSecondStep" = "2. Введите код из приложения"
 "twoFactorModalRemoveStep" = "Введите код из приложения, чтобы отключить двухфакторную аутентификацию."
+"twoFactorModalChangeCredentialsTitle" = "Изменить учетные данные"
+"twoFactorModalChangeCredentialsStep" = "Введите код из приложения, чтобы изменить учетные данные администратора."
 "twoFactorModalSetSuccess" = "Двухфакторная аутентификация была успешно установлена"
 "twoFactorModalDeleteSuccess" = "Двухфакторная аутентификация была успешно удалена"
 "twoFactorModalError" = "Неверный код"

--- a/web/translation/translate.tr_TR.toml
+++ b/web/translation/translate.tr_TR.toml
@@ -541,6 +541,8 @@
 "twoFactorModalFirstStep" = "1. Bu QR kodunu doğrulama uygulamasında tarayın veya QR kodunun yanındaki token'ı kopyalayıp uygulamaya yapıştırın"
 "twoFactorModalSecondStep" = "2. Uygulamadaki kodu girin"
 "twoFactorModalRemoveStep" = "İki adımlı doğrulamayı kaldırmak için uygulamadaki kodu girin."
+"twoFactorModalChangeCredentialsTitle" = "Kimlik bilgilerini değiştir"
+"twoFactorModalChangeCredentialsStep" = "Yönetici kimlik bilgilerini değiştirmek için uygulamadaki kodu girin."
 "twoFactorModalSetSuccess" = "İki faktörlü kimlik doğrulama başarıyla kuruldu"
 "twoFactorModalDeleteSuccess" = "İki faktörlü kimlik doğrulama başarıyla silindi"
 "twoFactorModalError" = "Yanlış kod"

--- a/web/translation/translate.uk_UA.toml
+++ b/web/translation/translate.uk_UA.toml
@@ -541,6 +541,8 @@
 "twoFactorModalFirstStep" = "1. Відскануйте цей QR-код у програмі для аутентифікації або скопіюйте токен біля QR-коду та вставте його в програму"
 "twoFactorModalSecondStep" = "2. Введіть код з програми"
 "twoFactorModalRemoveStep" = "Введіть код з програми, щоб вимкнути двофакторну аутентифікацію."
+"twoFactorModalChangeCredentialsTitle" = "Змінити облікові дані"
+"twoFactorModalChangeCredentialsStep" = "Введіть код з додатку, щоб змінити облікові дані адміністратора."
 "twoFactorModalSetSuccess" = "Двофакторна аутентифікація була успішно встановлена"
 "twoFactorModalDeleteSuccess" = "Двофакторна аутентифікація була успішно видалена"
 "twoFactorModalError" = "Невірний код"

--- a/web/translation/translate.vi_VN.toml
+++ b/web/translation/translate.vi_VN.toml
@@ -541,6 +541,8 @@
 "twoFactorModalFirstStep" = "1. Quét mã QR này trong ứng dụng xác thực hoặc sao chép mã token gần mã QR và dán vào ứng dụng"
 "twoFactorModalSecondStep" = "2. Nhập mã từ ứng dụng"
 "twoFactorModalRemoveStep" = "Nhập mã từ ứng dụng để xóa xác thực hai yếu tố."
+"twoFactorModalChangeCredentialsTitle" = "Thay đổi thông tin xác thực"
+"twoFactorModalChangeCredentialsStep" = "Nhập mã từ ứng dụng để thay đổi thông tin xác thực quản trị viên."
 "twoFactorModalSetSuccess" = "Xác thực hai yếu tố đã được thiết lập thành công"
 "twoFactorModalDeleteSuccess" = "Xác thực hai yếu tố đã được xóa thành công"
 "twoFactorModalError" = "Mã sai"

--- a/web/translation/translate.zh_CN.toml
+++ b/web/translation/translate.zh_CN.toml
@@ -541,6 +541,8 @@
 "twoFactorModalFirstStep" = "1. 在认证应用程序中扫描此QR码，或复制QR码附近的令牌并粘贴到应用程序中"
 "twoFactorModalSecondStep" = "2. 输入应用程序中的验证码"
 "twoFactorModalRemoveStep" = "输入应用程序中的验证码以移除双重认证。"
+"twoFactorModalChangeCredentialsTitle" = "更改凭据"
+"twoFactorModalChangeCredentialsStep" = "输入应用程序中的代码以更改管理员凭据。"
 "twoFactorModalSetSuccess" = "双因素认证已成功建立"
 "twoFactorModalDeleteSuccess" = "双因素认证已成功删除"
 "twoFactorModalError" = "验证码错误"

--- a/web/translation/translate.zh_TW.toml
+++ b/web/translation/translate.zh_TW.toml
@@ -543,6 +543,8 @@
 "twoFactorModalFirstStep" = "1. 在認證應用程式中掃描此QR碼，或複製QR碼附近的令牌並貼到應用程式中"
 "twoFactorModalSecondStep" = "2. 輸入應用程式中的驗證碼"
 "twoFactorModalRemoveStep" = "輸入應用程式中的驗證碼以移除雙重認證。"
+"twoFactorModalChangeCredentialsTitle" = "更改憑證"
+"twoFactorModalChangeCredentialsStep" = "輸入應用程式中的代碼以更改管理員憑證。"
 "twoFactorModalSetSuccess" = "雙重身份驗證已成功建立"
 "twoFactorModalDeleteSuccess" = "雙重身份驗證已成功刪除"
 "twoFactorModalError" = "驗證碼錯誤"

--- a/x-ui.sh
+++ b/x-ui.sh
@@ -179,11 +179,20 @@ reset_user() {
         fi
         return 0
     fi
+    
     read -rp "Please set the login username [default is a random username]: " config_account
     [[ -z $config_account ]] && config_account=$(date +%s%N | md5sum | cut -c 1-8)
     read -rp "Please set the login password [default is a random password]: " config_password
     [[ -z $config_password ]] && config_password=$(date +%s%N | md5sum | cut -c 1-8)
-    /usr/local/x-ui/x-ui setting -username ${config_account} -password ${config_password} >/dev/null 2>&1
+
+    read -rp "Are you sure you want to reset the two factor? (y/n): " twoFactorConfirm
+    if [[ $twoFactorConfirm != "y" && $twoFactorConfirm != "Y" ]]; then
+        /usr/local/x-ui/x-ui setting -username ${config_account} -password ${config_password} -resetTwoFactor false >/dev/null 2>&1
+    else
+        /usr/local/x-ui/x-ui setting -username ${config_account} -password ${config_password} -resetTwoFactor true >/dev/null 2>&1
+        echo -e "Two factor authentication has been disabled."
+    fi
+    
     echo -e "Panel login username has been reset to: ${green} ${config_account} ${plain}"
     echo -e "Panel login password has been reset to: ${green} ${config_password} ${plain}"
     echo -e "${green} Please use the new login username and password to access the X-UI panel. Also remember them! ${plain}"


### PR DESCRIPTION
## What is the pull request?

This pull request adds a mechanism where two-factor authentication is reset when admin credentials are changed. 

Also now if two-factor authentication is enabled and a user tries to change admin credentials through the panel, a confirmation will be requested.

Fixes #3025 

## Which part of the application is affected by the change?

- [X] Frontend
- [X] Backend

## Type of Changes

- [X] Bug fix
- [ ] New feature
- [X] Refactoring
- [ ] Other