### PR TITLE
fix: don't show ip limit for some protocols

### DIFF
--- a/web/html/modals/inbound_info_modal.html
+++ b/web/html/modals/inbound_info_modal.html
@@ -478,10 +478,19 @@
       this.isExpired = this.inbound.clients ? this.inbound.isExpiry(index) : this.dbInbound.isExpiry;
       this.clientStats = this.inbound.clients ? this.dbInbound.clientStats.find(row => row.email === this.clientSettings.email) : [];
 
-      if (app.ipLimitEnable && this.clientSettings.limitIp) {
-        refreshIPs(this.clientStats.email).then((ips) => {
-          this.clientIps = ips;
-        })
+      if (
+        [
+          Protocols.VMESS, 
+          Protocols.VLESS,
+          Protocols.TROJAN, 
+          Protocols.SHADOWSOCKS
+        ].includes(this.inbound.protocol)
+      ) {
+        if (app.ipLimitEnable && this.clientSettings.limitIp) {
+          refreshIPs(this.clientStats.email).then((ips) => {
+            this.clientIps = ips;
+          })
+        }
       }
       if (this.inbound.protocol == Protocols.WIREGUARD) {
         this.links = this.inbound.genInboundLinks(dbInbound.remark).split('\r\n')


### PR DESCRIPTION
## What is the pull request?

This PR fixes #3062 

This bug occurred because the modal window would not open because protocols like wireguard, dokodemo, etc. do not have clients (such as vless/vmess, shadowsocks, etc.).

## Which part of the application is affected by the change?

- [X] Frontend
- [ ] Backend

## Type of Changes

- [X] Bug fix
- [ ] New feature
- [ ] Refactoring
- [ ] Other