### PR TITLE
refactor: use `math.MaxUint16` when checking port

### DIFF
--- a/web/entity/entity.go
+++ b/web/entity/entity.go
@@ -5,6 +5,7 @@ import (
 	"net"
 	"strings"
 	"time"
+	"math"
 
 	"x-ui/util/common"
 )
@@ -78,11 +79,11 @@ func (s *AllSetting) CheckValid() error {
 		}
 	}
 
-	if s.WebPort <= 0 || s.WebPort > 65535 {
+	if s.WebPort <= 0 || s.WebPort > math.MaxUint16 {
 		return common.NewError("web port is not a valid port:", s.WebPort)
 	}
 
-	if s.SubPort <= 0 || s.SubPort > 65535 {
+	if s.SubPort <= 0 || s.SubPort > math.MaxUint16 {
 		return common.NewError("Sub port is not a valid port:", s.SubPort)
 	}
 

--- a/xray/api.go
+++ b/xray/api.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"regexp"
 	"time"
+	"math"
 
 	"x-ui/logger"
 	"x-ui/util/common"
@@ -32,7 +33,7 @@ type XrayAPI struct {
 }
 
 func (x *XrayAPI) Init(apiPort int) error {
-	if apiPort <= 0 {
+	if apiPort <= 0 || apiPort > math.MaxUint16 {
 		return fmt.Errorf("invalid Xray API port: %d", apiPort)
 	}
 


### PR DESCRIPTION
## What is the pull request?

This pull request changes the hardcoded value (65535) to `math.MaxUint16` in the port check

## Which part of the application is affected by the change?

- [ ] Frontend
- [X] Backend

## Type of Changes

- [ ] Bug fix
- [ ] New feature
- [X] Refactoring
- [ ] Other