### PR TITLE
fix writeCrashReport() typo

### DIFF
--- a/xray/log_writer.go
+++ b/xray/log_writer.go
@@ -25,7 +25,7 @@ func (lw *LogWriter) Write(m []byte) (n int, err error) {
 	if crashRegex.MatchString(message) {
 		logger.Debug("Core crash detected:\n", message)
 		lw.lastLine = message
-		err1 := writeCrachReport(m)
+		err1 := writeCrashReport(m)
 		if err1 != nil {
 			logger.Error("Unable to write crash report:", err1)
 		}

--- a/xray/process.go
+++ b/xray/process.go
@@ -242,7 +242,7 @@ func (p *process) Stop() error {
 	return p.cmd.Process.Signal(syscall.SIGTERM)
 }
 
-func writeCrachReport(m []byte) error {
+func writeCrashReport(m []byte) error {
 	crashReportPath := config.GetBinFolderPath() + "/core_crash_" + time.Now().Format("20060102_150405") + ".log"
 	return os.WriteFile(crashReportPath, m, os.ModePerm)
 }


### PR DESCRIPTION
## What is the pull request?

Fixes a typo in the function name `writeCrachReport()` by renaming it to the correct spelling: `writeCrashReport()`.

## Which part of the application is affected by the change?

- [ ] Frontend
- [x] Backend

## Files Affected

- `xray/process.go`
- `xray/log_writter.go`

## Type of Changes

- [ ] Bug fix
- [ ] New feature
- [x] Refactoring (code style/cleanup)
- [ ] Other
