### PR TITLE
Kill process instead of sending SIGTERM on Windows

### DIFF
--- a/xray/process.go
+++ b/xray/process.go
@@ -239,7 +239,12 @@ func (p *process) Stop() error {
 	if !p.IsRunning() {
 		return errors.New("xray is not running")
 	}
-	return p.cmd.Process.Signal(syscall.SIGTERM)
+	
+	if runtime.GOOS == "windows" {
+		return p.cmd.Process.Kill()
+	} else {
+		return p.cmd.Process.Signal(syscall.SIGTERM)
+	}
 }
 
 func writeCrashReport(m []byte) error {


### PR DESCRIPTION
## What is the pull request?

Windows doesn't support SIGTERM, so instead, we simply kill the process.

## Which part of the application is affected by the change?

- [ ] Frontend
- [x] Backend

## Type of Changes

- [x] Bug fix
- [ ] New feature
- [ ] Refactoring
- [ ] Other

closes #3303