### PR TITLE
Fixed Xray restarting after being manually stopped

### DIFF
--- a/web/html/index.html
+++ b/web/html/index.html
@@ -169,9 +169,6 @@
                             <a-col>
                               <a-icon type="bars" :style="{ cursor: 'pointer', float: 'right' }" @click="openLogs()"></a-icon>
                             </a-col>
-                            <a-col>
-                              <a-icon type="bars" :style="{ cursor: 'pointer', float: 'right' }" @click="openXrayLogs()"></a-icon>
-                            </a-col>
                           </a-row>
                         </span>
                         <template slot="content">

--- a/web/job/check_xray_running_job.go
+++ b/web/job/check_xray_running_job.go
@@ -16,7 +16,7 @@ func NewCheckXrayRunningJob() *CheckXrayRunningJob {
 }
 
 func (j *CheckXrayRunningJob) Run() {
-	if !j.xrayService.IsNeedToResurrect() {
+	if !j.xrayService.DidXrayCrash() {
 		j.checkTime = 0
 	} else {
 		j.checkTime++

--- a/web/job/check_xray_running_job.go
+++ b/web/job/check_xray_running_job.go
@@ -16,7 +16,7 @@ func NewCheckXrayRunningJob() *CheckXrayRunningJob {
 }
 
 func (j *CheckXrayRunningJob) Run() {
-	if j.xrayService.IsXrayRunning() {
+	if !j.xrayService.IsNeedToResurrect() {
 		j.checkTime = 0
 	} else {
 		j.checkTime++

--- a/web/service/server.go
+++ b/web/service/server.go
@@ -347,7 +347,6 @@ func (s *ServerService) StopXrayService() error {
 }
 
 func (s *ServerService) RestartXrayService() error {
-	s.xrayService.StopXray()
 	err := s.xrayService.RestartXray(true)
 	if err != nil {
 		logger.Error("start xray failed:", err)

--- a/web/service/xray.go
+++ b/web/service/xray.go
@@ -3,6 +3,7 @@ package service
 import (
 	"encoding/json"
 	"errors"
+	"runtime"
 	"sync"
 
 	"x-ui/logger"
@@ -14,7 +15,8 @@ import (
 var (
 	p                 *xray.Process
 	lock              sync.Mutex
-	isNeedXrayRestart atomic.Bool
+	isNeedXrayRestart atomic.Bool // Indicates that restart was requested for Xray
+	isManuallyStopped atomic.Bool // Indicates that Xray was stopped manually (i.e. didn't crash)
 	result            string
 )
 
@@ -32,7 +34,15 @@ func (s *XrayService) GetXrayErr() error {
 	if p == nil {
 		return nil
 	}
-	return p.GetErr()
+
+	err := p.GetErr()
+
+	if runtime.GOOS == "windows" && err.Error() == "exit status 1" {
+		// exit status 1 on Windows means that Xray process was killed
+		return nil
+	}
+
+	return err
 }
 
 func (s *XrayService) GetXrayResult() string {
@@ -45,7 +55,14 @@ func (s *XrayService) GetXrayResult() string {
 	if p == nil {
 		return ""
 	}
+
 	result = p.GetResult()
+
+	if runtime.GOOS == "windows" && result == "exit status 1" {
+		// exit status 1 on Windows means that Xray process was killed
+		return ""
+	}
+
 	return result
 }
 
@@ -184,7 +201,8 @@ func (s *XrayService) GetXrayTraffic() ([]*xray.Traffic, []*xray.ClientTraffic, 
 func (s *XrayService) RestartXray(isForce bool) error {
 	lock.Lock()
 	defer lock.Unlock()
-	logger.Debug("restart xray, force:", isForce)
+	logger.Debug("restart Xray, force:", isForce)
+	isManuallyStopped.Store(false)
 
 	xrayConfig, err := s.GetXrayConfig()
 	if err != nil {
@@ -192,8 +210,8 @@ func (s *XrayService) RestartXray(isForce bool) error {
 	}
 
 	if s.IsXrayRunning() {
-		if !isForce && p.GetConfig().Equals(xrayConfig) {
-			logger.Debug("It does not need to restart xray")
+		if !isForce && p.GetConfig().Equals(xrayConfig) && !isNeedXrayRestart.Load() {
+			logger.Debug("It does not need to restart Xray")
 			return nil
 		}
 		p.Stop()
@@ -205,12 +223,14 @@ func (s *XrayService) RestartXray(isForce bool) error {
 	if err != nil {
 		return err
 	}
+
 	return nil
 }
 
 func (s *XrayService) StopXray() error {
 	lock.Lock()
 	defer lock.Unlock()
+	isManuallyStopped.Store(true)
 	logger.Debug("Attempting to stop Xray...")
 	if s.IsXrayRunning() {
 		return p.Stop()
@@ -224,4 +244,9 @@ func (s *XrayService) SetToNeedRestart() {
 
 func (s *XrayService) IsNeedRestartAndSetFalse() bool {
 	return isNeedXrayRestart.CompareAndSwap(true, false)
+}
+
+// Check if Xray is not running and wasn't stopped manually
+func (s *XrayService) IsNeedToResurrect() bool {
+	return !s.IsXrayRunning() && !isManuallyStopped.Load()
 }


### PR DESCRIPTION
## What is the pull request?

Closes #2896

Cron job restarts Xray even if it was manually stopped by the user.

Added check if Xray was stopped manually and prevent cron from restarting it.

## Which part of the application is affected by the change?

- [ ] Frontend
- [x] Backend

## Type of Changes

- [x] Bug fix
- [ ] New feature
- [ ] Refactoring
- [ ] Other