### PR TITLE
Fixed highlight of Xray log entries that contain email

### DIFF
--- a/web/html/index.html
+++ b/web/html/index.html
@@ -676,16 +676,16 @@
 
             const parts = log.split(' ');
 
-            if(parts.length === 10) {
+            if(parts.length >= 10) {
               const dateTime = `<b>${parts[0]} ${parts[1]}</b>`;
               const from = `<b>${parts[3]}</b>`;
               const to = `<b>${parts[5].replace(/^\/+/, "")}</b>`;
 
               let outboundColor = '';
-              if (parts[9] === "b") {
+              if (parts[parts.length - 1] === "b") {
                 outboundColor = ' style="color: #e04141;"'; //red for blocked
               }
-              else if (parts[9] === "p") {
+              else if (parts[parts.length - 1] === "p") {
                 outboundColor = ' style="color: #3c89e8;"'; //blue for proxies
               }
 
@@ -695,10 +695,10 @@ ${dateTime}
  ${from}
  ${parts[4]}
  ${to}
- ${parts.slice(6, 9).join(' ')}
+ ${parts.slice(6, parts.length - 2).join(' ')}
 </span>`;
             } else {
-              formattedLogs += `<span>${log}</span>`;
+              formattedLogs += `<span>${parts.slice(0, parts.length - 2).join(' ')}</span>`;
             }
           });
 

--- a/web/service/server.go
+++ b/web/service/server.go
@@ -520,12 +520,12 @@ func (s *ServerService) GetXrayLogs(
 		}
 
 		//adding suffixes to further distinguish entries by outbound
-		if hasSuffix(line, freedoms) {
+		if stringContains(line, freedoms) {
 			if showDirect == "false" {
 				continue
 			}
 			line = line + " f"
-		} else if hasSuffix(line, blackholes) {
+		} else if stringContains(line, blackholes) {
 			if showBlocked == "false" {
 				continue
 			}
@@ -547,9 +547,9 @@ func (s *ServerService) GetXrayLogs(
 	return lines
 }
 
-func hasSuffix(line string, suffixes []string) bool {
+func stringContains(line string, suffixes []string) bool {
 	for _, sfx := range suffixes {
-		if strings.HasSuffix(line, sfx+"]") {
+		if strings.Contains(line, sfx+"]") {
 			return true
 		}
 	}


### PR DESCRIPTION
## What is the pull request?

Improved Xray log entries handling. How entries that contain user email

`2025/08/17 08:37:40.333370 from ip accepted tcp:ip [inbound-ip >> direct] email: user`

should highlight properly. 

## Which part of the application is affected by the change?

- [x] Frontend
- [x] Backend

## Type of Changes

- [x] Bug fix
- [ ] New feature
- [ ] Refactoring
- [ ] Other