### PR TITLE
feat: add "Last Online" column to client list and modal (Closes #3402)

### DIFF
--- a/web/assets/js/util/date-util.js
+++ b/web/assets/js/util/date-util.js
@@ -134,7 +134,7 @@ class DateUtil {
     }
 
     static formatMillis(millis) {
-        return moment(millis).format('YYYY-M-D H:m:s');
+        return moment(millis).format('YYYY-M-D HH:mm:ss');
     }
 
     static firstDayOfMonth() {

--- a/web/controller/api.go
+++ b/web/controller/api.go
@@ -47,6 +47,7 @@ func (a *APIController) initRouter(g *gin.RouterGroup) {
 		{"POST", "/resetAllClientTraffics/:id", a.inboundController.resetAllClientTraffics},
 		{"POST", "/delDepletedClients/:id", a.inboundController.delDepletedClients},
 		{"POST", "/onlines", a.inboundController.onlines},
+		{"POST", "/lastOnline", a.inboundController.lastOnline},
 		{"POST", "/updateClientTraffic/:email", a.inboundController.updateClientTraffic},
 	}
 

--- a/web/controller/inbound.go
+++ b/web/controller/inbound.go
@@ -340,6 +340,11 @@ func (a *InboundController) onlines(c *gin.Context) {
 	jsonObj(c, a.inboundService.GetOnlineClients(), nil)
 }
 
+func (a *InboundController) lastOnline(c *gin.Context) {
+	data, err := a.inboundService.GetClientsLastOnline()
+	jsonObj(c, data, err)
+}
+
 func (a *InboundController) updateClientTraffic(c *gin.Context) {
 	email := c.Param("email")
 

--- a/web/html/component/aClientTable.html
+++ b/web/html/component/aClientTable.html
@@ -33,12 +33,17 @@
   <a-switch v-model="client.enable" @change="switchEnableClient(record.id,client)"></a-switch>
 </template>
 <template slot="online" slot-scope="text, client, index">
-  <template v-if="client.enable && isClientOnline(client.email)">
-    <a-tag color="green">{{ i18n "online" }}</a-tag>
-  </template>
-  <template v-else>
-    <a-tag>{{ i18n "offline" }}</a-tag>
-  </template>
+  <a-popover :overlay-class-name="themeSwitcher.currentTheme">
+    <template slot="content" >
+      {{ i18n "lastOnline" }}: [[ formatLastOnline(client.email) ]]
+    </template>
+    <template v-if="client.enable && isClientOnline(client.email)">
+      <a-tag color="green">{{ i18n "online" }}</a-tag>
+    </template>
+    <template v-else>
+      <a-tag>{{ i18n "offline" }}</a-tag>
+    </template>
+  </a-popover>
 </template>
 <template slot="client" slot-scope="text, client">
   <a-space direction="horizontal" :size="2">

--- a/web/html/inbounds.html
+++ b/web/html/inbounds.html
@@ -807,6 +807,7 @@
             defaultKey: '',
             clientCount: [],
             onlineClients: [],
+            lastOnlineMap: {},
             isRefreshEnabled: localStorage.getItem("isRefreshEnabled") === "true" ? true : false,
             refreshing: false,
             refreshInterval: Number(localStorage.getItem("refreshInterval")) || 5000,
@@ -835,6 +836,7 @@
                     return;
                 }
 
+                await this.getLastOnlineMap();
                 await this.getOnlineUsers();
                 
                 this.setInbounds(msg.obj);
@@ -848,6 +850,11 @@
                     return;
                 }
                 this.onlineClients = msg.obj != null ? msg.obj : [];
+            },
+            async getLastOnlineMap() {
+                const msg = await HttpUtil.post('/panel/api/inbounds/lastOnline');
+                if (!msg.success || !msg.obj) return;
+                this.lastOnlineMap = msg.obj || {}
             },
             async getDefaultSettings() {
                 const msg = await HttpUtil.post('/panel/setting/defaultSettings');
@@ -1492,6 +1499,17 @@
             },
             isClientOnline(email) {
                 return this.onlineClients.includes(email);
+            },
+            getLastOnline(email) {
+                return this.lastOnlineMap[email] || null
+            },
+            formatLastOnline(email) {
+                const ts = this.getLastOnline(email)
+                if (!ts) return '-'
+                if (this.datepicker === 'gregorian') {
+                    return DateUtil.formatMillis(ts)
+                }
+                return DateUtil.convertToJalalian(moment(ts))
             },
             isRemovable(dbInboundId) {
                 return this.getInboundClients(this.dbInbounds.find(row => row.id === dbInboundId)).length > 1;

--- a/web/html/modals/inbound_info_modal.html
+++ b/web/html/modals/inbound_info_modal.html
@@ -217,6 +217,12 @@
             </template>
           </td>
         </tr>
+        <tr>
+          <td>{{ i18n "lastOnline" }}</td>
+          <td>
+            <a-tag>[[ app.formatLastOnline(infoModal.clientSettings && infoModal.clientSettings.email ? infoModal.clientSettings.email : '') ]]</a-tag>
+          </td>
+        </tr>
         <tr v-if="infoModal.clientSettings.comment">
           <td>{{ i18n "comment" }}</td>
           <td>

--- a/web/translation/translate.ar_EG.toml
+++ b/web/translation/translate.ar_EG.toml
@@ -50,6 +50,7 @@
 "fail" = "فشل"
 "comment" = "تعليق"
 "success" = "تم بنجاح"
+"lastOnline" = "آخر متصل"
 "getVersion" = "جيب النسخة"
 "install" = "تثبيت"
 "clients" = "عملاء"

--- a/web/translation/translate.en_US.toml
+++ b/web/translation/translate.en_US.toml
@@ -50,6 +50,7 @@
 "fail" = "Failed"
 "comment" = "Comment"
 "success" = "Successfully"
+"lastOnline" = "Last Online"
 "getVersion" = "Get Version"
 "install" = "Install"
 "clients" = "Clients"

--- a/web/translation/translate.es_ES.toml
+++ b/web/translation/translate.es_ES.toml
@@ -50,6 +50,7 @@
 "fail" = "Falló"
 "comment" = "Comentario"
 "success" = "Éxito"
+"lastOnline" = "Última conexión"
 "getVersion" = "Obtener versión"
 "install" = "Instalar"
 "clients" = "Clientes"

--- a/web/translation/translate.fa_IR.toml
+++ b/web/translation/translate.fa_IR.toml
@@ -50,6 +50,7 @@
 "fail" = "ناموفق"
 "comment" = "توضیحات"
 "success" = "موفق"
+"lastOnline" = "آخرین فعالیت"
 "getVersion" = "دریافت نسخه"
 "install" = "نصب"
 "clients" = "کاربران"

--- a/web/translation/translate.id_ID.toml
+++ b/web/translation/translate.id_ID.toml
@@ -50,6 +50,7 @@
 "fail" = "Gagal"
 "comment" = "Komentar"
 "success" = "Berhasil"
+"lastOnline" = "Terakhir online"
 "getVersion" = "Dapatkan Versi"
 "install" = "Instal"
 "clients" = "Klien"

--- a/web/translation/translate.ja_JP.toml
+++ b/web/translation/translate.ja_JP.toml
@@ -50,6 +50,7 @@
 "fail" = "失敗"
 "comment" = "コメント"
 "success" = "成功"
+"lastOnline" = "最終オンライン"
 "getVersion" = "バージョン取得"
 "install" = "インストール"
 "clients" = "クライアント"

--- a/web/translation/translate.pt_BR.toml
+++ b/web/translation/translate.pt_BR.toml
@@ -50,6 +50,7 @@
 "fail" = "Falhou"
 "comment" = "Comentário"
 "success" = "Com Sucesso"
+"lastOnline" = "Última vez online"
 "getVersion" = "Obter Versão"
 "install" = "Instalar"
 "clients" = "Clientes"

--- a/web/translation/translate.ru_RU.toml
+++ b/web/translation/translate.ru_RU.toml
@@ -50,6 +50,7 @@
 "fail" = "Ошибка"
 "comment" = "Комментарий"
 "success" = "Успешно"
+"lastOnline" = "Был(а) в сети"
 "getVersion" = "Узнать версию"
 "install" = "Установка"
 "clients" = "Клиенты"

--- a/web/translation/translate.tr_TR.toml
+++ b/web/translation/translate.tr_TR.toml
@@ -50,6 +50,7 @@
 "fail" = "Başarısız"
 "comment" = "Yorum"
 "success" = "Başarılı"
+"lastOnline" = "Son çevrimiçi"
 "getVersion" = "Sürümü Al"
 "install" = "Yükle"
 "clients" = "Müşteriler"

--- a/web/translation/translate.uk_UA.toml
+++ b/web/translation/translate.uk_UA.toml
@@ -50,6 +50,7 @@
 "fail" = "Помилка"
 "comment" = "Коментар"
 "success" = "Успішно"
+"lastOnline" = "Був(ла) онлайн"
 "getVersion" = "Отримати версію"
 "install" = "Встановити"
 "clients" = "Клієнти"

--- a/web/translation/translate.vi_VN.toml
+++ b/web/translation/translate.vi_VN.toml
@@ -50,6 +50,7 @@
 "fail" = "Thất bại"
 "comment" = "Bình luận"
 "success" = "Thành công"
+"lastOnline" = "Lần online gần nhất"
 "getVersion" = "Lấy phiên bản"
 "install" = "Cài đặt"
 "clients" = "Các khách hàng"

--- a/web/translation/translate.zh_CN.toml
+++ b/web/translation/translate.zh_CN.toml
@@ -50,6 +50,7 @@
 "fail" = "失败"
 "comment" = "评论"
 "success" = "成功"
+"lastOnline" = "上次在线"
 "getVersion" = "获取版本"
 "install" = "安装"
 "clients" = "客户端"

--- a/web/translation/translate.zh_TW.toml
+++ b/web/translation/translate.zh_TW.toml
@@ -50,6 +50,7 @@
 "fail" = "失敗"
 "comment" = "評論"
 "success" = "成功"
+"lastOnline" = "上次上線"
 "getVersion" = "獲取版本"
 "install" = "安裝"
 "clients" = "客戶端"

--- a/xray/client_traffic.go
+++ b/xray/client_traffic.go
@@ -11,4 +11,5 @@ type ClientTraffic struct {
 	ExpiryTime int64  `json:"expiryTime" form:"expiryTime"`
 	Total      int64  `json:"total" form:"total"`
 	Reset      int    `json:"reset" form:"reset" gorm:"default:0"`
+	LastOnline int64  `json:"lastOnline" form:"lastOnline" gorm:"default:0"`
 }


### PR DESCRIPTION
## What is the pull request?

This pull request implements the **"Last Online"** feature for clients, as requested in issue #3402.  
It introduces backend support to store and retrieve the last online timestamp for each client and updates the frontend UI to display this information in the client list and inbound info modal.  
Additionally, it adds proper date formatting and translations for the new label in all supported languages.

Closes #3402

## Which part of the application is affected by the change?

- [x] Frontend
- [x] Backend

## Type of Changes

- [ ] Bug fix
- [x] New feature
- [ ] Refactoring
- [ ] Other

## Screenshots

**Client Table with "Last Online" Column**  
<img width="653" height="550" alt="image" src="https://github.com/user-attachments/assets/f88a0be4-47c9-4cab-b636-45d34c96f4bc" />
<img width="639" height="517" alt="image" src="https://github.com/user-attachments/assets/671b325e-fe83-44ef-a3f1-053231b3ca74" />

**Inbound Info Modal showing Last Online**  
<img width="640" height="350" alt="image" src="https://github.com/user-attachments/assets/6ea79df8-9bb1-482a-aaa1-7b0cb681303d" />