### PR TITLE
Fix: Shadowrocket link using base64 encoding

### DIFF
--- a/web/html/subscription.html
+++ b/web/html/subscription.html
@@ -233,7 +233,7 @@
                                         <a-menu slot="overlay"
                                             :class="themeSwitcher.currentTheme">
                                             <a-menu-item key="ios-shadowrocket"
-                                                @click="open('shadowrocket://add/subscription?url=' + encodeURIComponent(app.subUrl) + '&remark=' + encodeURIComponent(app.sId))">Shadowrocket</a-menu-item>
+                                                @click="open(shadowrocketUrl)">Shadowrocket</a-menu-item>
                                             <a-menu-item key="ios-v2box"
                                                 @click="open('v2box://install-sub?url=' + encodeURIComponent(app.subUrl) + '&name=' + encodeURIComponent(app.sId))">V2Box</a-menu-item>
                                             <a-menu-item key="ios-streisand"


### PR DESCRIPTION
## What is the pull request?

This pull request fixes the Shadowrocket subscription URL generation in the frontend.  
The Shadowrocket link is now properly encoded using base64, matching the expected format:  
`shadowrocket://add/sub/<base64_encoded_url>?remark=<subscription_id>`,  
ensuring that Shadowrocket on iOS can correctly import the subscription.

## Which part of the application is affected by the change?

- [x] Frontend  
- [ ] Backend

## Type of Changes

- [x] Bug fix  
- [ ] New feature  
- [ ] Refactoring  
- [ ] Other


