### PR TITLE
[Security] Replace timestamp-based password generation with random generator

### DIFF
--- a/x-ui.sh
+++ b/x-ui.sh
@@ -191,7 +191,7 @@ reset_user() {
     read -rp "Please set the login username [default is a random username]: " config_account
     [[ -z $config_account ]] && config_account=$(gen_random_string 10)
     read -rp "Please set the login password [default is a random password]: " config_password
-    [[ -z $config_password ]] && config_password=$(gen_random_string 16)
+    [[ -z $config_password ]] && config_password=$(gen_random_string 18)
 
     read -rp "Do you want to disable currently configured two-factor authentication? (y/n): " twoFactorConfirm
     if [[ $twoFactorConfirm != "y" && $twoFactorConfirm != "Y" ]]; then


### PR DESCRIPTION
## What is the pull request?

Improve security of default credential generation.  

Old: predictable timestamp-based method (~32 bits entropy)  
New: random string generator with much stronger entropy  

This change prevents weak and predictable default credentials.  

After changing the password, x-ui service restarts, which allows others to easily infer the time.

According to investigation, this issue has already been exploited.

## Which part of the application is affected by the change?

- [ ] Frontend
- [x] Backend

## Type of Changes

- [x] Bug fix
- [ ] New feature
- [ ] Refactoring
- [ ] Other

## Screenshots

Not applicable. 