### PR TITLE
feat: add file logger support

### DIFF
--- a/sub/sub.go
+++ b/sub/sub.go
@@ -103,7 +103,7 @@ func (s *Server) initRouter() (*gin.Engine, error) {
 	if basePath != "/" && !strings.HasSuffix(basePath, "/") {
 		basePath += "/"
 	}
-	logger.Debug("sub: Setting base_path to:", basePath)
+	// logger.Debug("sub: Setting base_path to:", basePath)
 	engine.Use(func(c *gin.Context) {
 		c.Set("base_path", basePath)
 	})


### PR DESCRIPTION
Hey there!

## What is the pull request?

I faced a problem when using 3x-ui in Docker. I use this in my homelab along with other containers, so I don't want to setup it directly on the host. I want to ban those who try to access 3xui panel. But I found that the panel logs were only stored in memory, so fail2ban running on the host couldn't track them. This change adds a small modification to the logger to write each entry to `${XUI_LOG_FOLDER}/3xui.log`. With this file, fail2ban can monitor the container logs just as it does today for IP Limit logs.

I'm not a go developer, so if it looks bad, let me know if it's possible to add logs to file in another way. Thank you!

## Which part of the application is affected by the change?

- [ ] Frontend
- [x] Backend

## Type of Changes

- [ ] Bug fix
- [x] New feature
- [x] Refactoring
- [ ] Other