### PR TITLE
Fix: Complete graceful Telegram bot shutdown and concurrency hardening

### DIFF
--- a/main.go
+++ b/main.go
@@ -78,6 +78,10 @@ func runWebServer() {
 		case syscall.SIGHUP:
 			logger.Info("Received SIGHUP signal. Restarting servers...")
 
+			// --- FIX FOR TELEGRAM BOT CONFLICT (409): Stop bot before restart ---
+			service.StopBot()
+			// --			
+			
 			err := server.Stop()
 			if err != nil {
 				logger.Debug("Error stopping web server:", err)
@@ -106,6 +110,10 @@ func runWebServer() {
 			log.Println("Sub server restarted successfully.")
 
 		default:
+			// --- FIX FOR TELEGRAM BOT CONFLICT (409) on full shutdown ---
+			service.StopBot()
+			// ------------------------------------------------------------
+			
 			server.Stop()
 			subServer.Stop()
 			log.Println("Shutting down servers.")


### PR DESCRIPTION
## Description
This comprehensive fix addresses the Telegram bot conflict (409) during panel restarts and ensures robust thread safety in bot operation.

## Changes
1.  **Graceful Shutdown (main.go):**
    * Added calls to `service.StopBot()` in `main.go` for both `SIGHUP` (restart) and service shutdown, ensuring the bot's Long Polling stops before the process is terminated/restarted.
2.  **Robust Synchronization (tgbot.go):**
    * Introduced `botWG sync.WaitGroup` to replace unreliable `time.Sleep()`, guaranteeing explicit waiting for the Long Polling goroutine to exit cleanly.
    * Added `tgBotMutex sync.Mutex` and logic to protect concurrent access to the global `botCancel` variable in `tgbot.go`.
    * Modified `Tgbot.OnReceive()` to correctly use context cancellation and manage `botWG` within the Long Polling goroutine.