### PR TITLE
Fix int64 for 32-bit arch

### DIFF
--- a/web/service/tgbot.go
+++ b/web/service/tgbot.go
@@ -906,7 +906,7 @@ func (t *Tgbot) answerCallback(callbackQuery *telego.CallbackQuery, isAdmin bool
 				t.searchClient(chatId, email, callbackQuery.Message.GetMessageID())
 			case "add_client_limit_traffic_c":
 				limitTraffic, _ := strconv.ParseInt(dataArray[1], 10, 64)
-				client_TotalGB = int64(limitTraffic) * 1024 * 1024 * 1024
+				client_TotalGB = limitTraffic * 1024 * 1024 * 1024
 				messageId := callbackQuery.Message.GetMessageID()
 				inbound, err := t.inboundService.GetInbound(receiver_inbound_ID)
 				if err != nil {


### PR DESCRIPTION
## What is the pull request?

Fix error:
> X-UI: Failed to parse admin ID from Telegram bot chat ID:strconv.Atoi: parsing "xxx": value out of range

caused by using Atoi to parse int64 on 32-bit arch

## Which part of the application is affected by the change?

- [ ] Frontend
- [x] Backend

## Type of Changes

- [x] Bug fix
- [ ] New feature
- [ ] Refactoring
- [ ] Other

## Screenshots

<!-- Add screenshots to illustrate the changes -->
<!-- Remove this section if it is not applicable. -->