### PR TITLE
feat: Add etckeeper compatibility (ignore x-ui.db in /etc)

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -219,6 +219,20 @@ install_x-ui() {
     mv -f /usr/bin/x-ui-temp /usr/bin/x-ui
     chmod +x /usr/bin/x-ui
     config_after_install
+
+    # Etckeeper compatibility
+    if [ -d "/etc/.git" ]; then
+        if [ -f "/etc/.gitignore" ]; then
+            if ! grep -q "x-ui/x-ui.db" "/etc/.gitignore"; then
+                echo "" >> "/etc/.gitignore"
+                echo "x-ui/x-ui.db" >> "/etc/.gitignore"
+                echo -e "${green}Added x-ui.db to /etc/.gitignore for etckeeper${plain}"
+            fi
+        else
+            echo "x-ui/x-ui.db" > "/etc/.gitignore"
+            echo -e "${green}Created /etc/.gitignore and added x-ui.db for etckeeper${plain}"
+        fi
+    fi
     
     if [[ $release == "alpine" ]]; then
         wget --inet4-only -O /etc/init.d/x-ui https://raw.githubusercontent.com/MHSanaei/3x-ui/main/x-ui.rc


### PR DESCRIPTION
## What is the pull request?

Prevents etckeeper from tracking the database (x-ui.db), which changes often and keeps the /etc repo in a constant "dirty" state.

Logic added to install.sh: Checks if /etc/.git exists. If so, appends x-ui/x-ui.db to /etc/.gitignore (avoiding duplicates) before the service starts.

## Which part of the application is affected by the change?

- [ ] Frontend
- [x] Backend

## Type of Changes

- [ ] Bug fix
- [x] New feature
- [ ] Refactoring
- [x] Other