### PR TITLE
fix: handle CPU threshold error to prevent false notifications

### DIFF
--- a/web/job/check_cpu_usage.go
+++ b/web/job/check_cpu_usage.go
@@ -22,7 +22,11 @@ func NewCheckCpuJob() *CheckCpuJob {
 
 // Run checks CPU usage over the last minute and sends a Telegram alert if it exceeds the threshold.
 func (j *CheckCpuJob) Run() {
-	threshold, _ := j.settingService.GetTgCpu()
+	threshold, err := j.settingService.GetTgCpu()
+	if err != nil || threshold <= 0 {
+		// If threshold cannot be retrieved or is not set, skip sending notifications
+		return
+	}
 
 	// get latest status of server
 	percent, err := cpu.Percent(1*time.Minute, false)


### PR DESCRIPTION
This PR fixes a bug in the CPU monitoring job where Telegram notifications were being sent with incorrect threshold values (showing 0% instead of the configured threshold).

Previously, when `GetTgCpu()` failed, the error was ignored and threshold defaulted to 0, causing notifications to be sent for any CPU usage.

Now the job properly checks for errors and skips notifications if:
- The threshold cannot be retrieved (error)
- The threshold is not set or is 0

This ensures notifications are only sent when CPU usage exceeds the configured threshold value from settings.

## Which part of the application is affected by the change?

- [ ] Frontend
- [x] Backend

## Type of Changes

- [x] Bug fix
- [ ] New feature
- [ ] Refactoring
- [ ] Other

## Screenshots
<img width="495" height="227" alt="image" src="https://github.com/user-attachments/assets/9780d9a4-2664-4433-b1ae-74562539f74a" />
<img width="505" height="123" alt="image" src="https://github.com/user-attachments/assets/98abdcda-08cf-448d-adb8-dd3b8516719f" />

## Additional Notes

**Problem:**
Users were receiving Telegram notifications showing "CPU load exceeds threshold value 0%" even though they had configured a different threshold value (e.g., 85%) in the settings.

**Root Cause:**
In `CheckCpuJob.Run()`, the error from `GetTgCpu()` was ignored using `threshold, _ := ...`. When an error occurred, the threshold defaulted to 0, causing the condition `percent[0] > float64(threshold)` to be true for any positive CPU usage.

**Solution:**
- Added proper error handling for `GetTgCpu()` call
- Added validation to skip notifications if threshold is 0 or cannot be retrieved
- Notifications are now only sent when CPU usage actually exceeds the configured threshold

**Testing:**
- Code compiles successfully
- The fix prevents false notifications with 0% threshold
- Notifications will only be sent when CPU usage exceeds the configured value from settings

