### PR TITLE
fix: handle GitHub API error responses in GetXrayVersions

### DIFF
--- a/web/service/server.go
+++ b/web/service/server.go
@@ -529,6 +529,18 @@ func (s *ServerService) GetXrayVersions() ([]string, error) {
 	}
 	defer resp.Body.Close()
 
+	// Check HTTP status code - GitHub API returns object instead of array on error
+	if resp.StatusCode != http.StatusOK {
+		bodyBytes, _ := io.ReadAll(resp.Body)
+		var errorResponse struct {
+			Message string `json:"message"`
+		}
+		if json.Unmarshal(bodyBytes, &errorResponse) == nil && errorResponse.Message != "" {
+			return nil, fmt.Errorf("GitHub API error: %s", errorResponse.Message)
+		}
+		return nil, fmt.Errorf("GitHub API returned status %d: %s", resp.StatusCode, resp.Status)
+	}
+
 	buffer := bytes.NewBuffer(make([]byte, bufferSize))
 	buffer.Reset()
 	if _, err := buffer.ReadFrom(resp.Body); err != nil {


### PR DESCRIPTION
GitHub API returns JSON object instead of array when encountering errors (e.g., rate limit exceeded). This causes JSON unmarshal error: 'cannot unmarshal object into Go value of type []service.Release'

Add HTTP status code check to handle error responses gracefully and return user-friendly error messages instead of JSON parsing errors.

Fixes issue where getXrayVersion fails with unmarshal error when GitHub API rate limit is exceeded.

## What is the pull request?

This PR fixes a bug in `GetXrayVersions()` function where GitHub API error responses (e.g., rate limit exceeded) cause JSON unmarshal errors. When GitHub API returns an error (status code 403, etc.), it returns a JSON object instead of an array, causing the code to fail with "cannot unmarshal object into Go value of type []service.Release".

The fix adds HTTP status code validation before parsing the response. When a non-200 status is detected, the code now reads and parses the error message from the response body, returning a user-friendly error message instead of a JSON parsing error.

## Which part of the application is affected by the change?

- [ ] Frontend
- [x] Backend

## Type of Changes

- [x] Bug fix
- [ ] New feature
- [ ] Refactoring
- [ ] Other

## Screenshots

<img width="600" height="52" alt="image" src="https://github.com/user-attachments/assets/5ebe3709-9463-4ab9-bb5f-e61b789b7202" />
