### PR TITLE
vless: use Inbound Listen address in Subscription service

### DIFF
--- a/sub/subService.go
+++ b/sub/subService.go
@@ -179,9 +179,15 @@ func (s *SubService) genVmessLink(inbound *model.Inbound, email string) string {
 	if inbound.Protocol != model.VMESS {
 		return ""
 	}
+	var address string
+	if inbound.Listen == "" || inbound.Listen == "0.0.0.0" || inbound.Listen == "::" || inbound.Listen == "::0" {
+		address = s.address
+	} else {
+		address = inbound.Listen
+	}
 	obj := map[string]any{
 		"v":    "2",
-		"add":  s.address,
+		"add":  address,
 		"port": inbound.Port,
 		"type": "none",
 	}
@@ -529,7 +535,12 @@ func (s *SubService) genVlessLink(inbound *model.Inbound, email string) string {
 }
 
 func (s *SubService) genTrojanLink(inbound *model.Inbound, email string) string {
-	address := s.address
+	var address string
+	if inbound.Listen == "" || inbound.Listen == "0.0.0.0" || inbound.Listen == "::" || inbound.Listen == "::0" {
+		address = s.address
+	} else {
+		address = inbound.Listen
+	}
 	if inbound.Protocol != model.Trojan {
 		return ""
 	}
@@ -725,7 +736,12 @@ func (s *SubService) genTrojanLink(inbound *model.Inbound, email string) string 
 }
 
 func (s *SubService) genShadowsocksLink(inbound *model.Inbound, email string) string {
-	address := s.address
+	var address string
+	if inbound.Listen == "" || inbound.Listen == "0.0.0.0" || inbound.Listen == "::" || inbound.Listen == "::0" {
+		address = s.address
+	} else {
+		address = inbound.Listen
+	}
 	if inbound.Protocol != model.Shadowsocks {
 		return ""
 	}


### PR DESCRIPTION
## What is the pull request?
When Subscription service is enabled and available, say, via https://example.com:26334/ with all TLS/certificates configured,
but Vless Inbound is configured using IP Address, say, 9.9.9.9, then, currently, the Vless configuration link, generated by subscription service, differs from that generated for manual distribution, particularly, in the end point address:

subscription service generated link:
vless://04497175-5876-41cc-9299-80e47839e675@example.com:46252....

a link for manual distribution:
vless://04497175-5876-41cc-9299-80e47839e675@9.9.9.9:46252....

The changes suggested eliminate this difference in favor of using Inbound Listen address (similar to the way of generating a link for manual distribution): the address where clients need to connect by their VPN client may differ from the address where the subscription service is accessible.

## Which part of the application is affected by the change?

- [ ] Frontend
- [X] Backend

## Type of Changes

- [X] Bug fix
- [ ] New feature
- [ ] Refactoring
- [ ] Other

## Screenshots

<!-- Add screenshots to illustrate the changes -->
<!-- Remove this section if it is not applicable. -->