### PR TITLE
fix: add missing is_domain helper function to x-ui.sh

### DIFF
--- a/x-ui.sh
+++ b/x-ui.sh
@@ -19,6 +19,20 @@ function LOGI() {
     echo -e "${green}[INF] $* ${plain}"
 }
 
+# Simple helpers for domain/IP validation
+is_ipv4() {
+    [[ "$1" =~ ^([0-9]{1,3}\.){3}[0-9]{1,3}$ ]] && return 0 || return 1
+}
+is_ipv6() {
+    [[ "$1" =~ : ]] && return 0 || return 1
+}
+is_ip() {
+    is_ipv4 "$1" || is_ipv6 "$1"
+}
+is_domain() {
+    [[ "$1" =~ ^([A-Za-z0-9](-*[A-Za-z0-9])*\.)+[A-Za-z]{2,}$ ]] && return 0 || return 1
+}
+
 # check root
 [[ $EUID -ne 0 ]] && LOGE "ERROR: You must be root to run this script! \n" && exit 1
 


### PR DESCRIPTION
## What is the pull request?

The is_domain function was being called in ssl_cert_issue() in x-ui.sh but was never defined, causing "[ERR] Invalid domain format" errors even when users enter valid domain names.

This bug was introduced in commit 75aed7f (PR #3611 - Self-signed SSL).

Fix: Added the missing helper functions (is_ipv4, is_ipv6, is_ip, is_domain) to x-ui.sh, matching the definitions already present in install.sh and update.sh.

## Which part of the application is affected by the change?

- [ ] Frontend
- [x] Backend

## Type of Changes

- [x] Bug fix
- [ ] New feature
- [ ] Refactoring
- [ ] Other

## Screenshots

Not applicable - this is a shell script fix with no UI changes.