### PR TITLE
Fix: mask passwords in logs of failed login attempts

### DIFF
--- a/web/controller/index.go
+++ b/web/controller/index.go
@@ -77,8 +77,8 @@ func (a *IndexController) login(c *gin.Context) {
 	safePass := template.HTMLEscapeString(form.Password)
 
 	if user == nil {
-		logger.Warningf("wrong username: \"%s\", password: \"%s\", IP: \"%s\"", safeUser, safePass, getRemoteIp(c))
-		a.tgbot.UserLoginNotify(safeUser, safePass, getRemoteIp(c), timeStr, 0)
+		logger.Warningf("wrong username: \"%s\", password: \"****\", IP: \"%s\"", safeUser, getRemoteIp(c))
+		a.tgbot.UserLoginNotify(safeUser, "****", getRemoteIp(c), timeStr, 0)
 		pureJsonMsg(c, http.StatusOK, false, I18nWeb(c, "pages.login.toasts.wrongUsernameOrPassword"))
 		return
 	}


### PR DESCRIPTION
This PR fixes security issue #3644 by masking passwords in logs and Telegram notifications.
Passwords are no longer stored or transmitted in plaintext, reducing the risk of credential leakage.

Fixes #3644

## What is the pull request?

This PR removes plaintext password logging from failed login attempts in the backend.
Passwords are replaced with masked values ("****") in logs and Telegram notifications.

## Which part of the application is affected by the change?

- [ ] Frontend
- [x] Backend

## Type of Changes

- [x] Bug fix
- [ ] New feature
- [ ] Refactoring
- [ ] Other