### PR TITLE
Fixed incorrect filtering for Punycode domains form

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -53,7 +53,7 @@ is_ip() {
     is_ipv4 "$1" || is_ipv6 "$1"
 }
 is_domain() {
-    [[ "$1" =~ ^([A-Za-z0-9](-*[A-Za-z0-9])*)\.([A-Za-z]{2,})$ ]] && return 0 || return 1
+    [[ "$1" =~ ^([A-Za-z0-9](-*[A-Za-z0-9])*\.)+(xn--[a-z0-9]{2,}|[A-Za-z]{2,})$ ]] && return 0 || return 1
 }
 
 # Port helpers

--- a/update.sh
+++ b/update.sh
@@ -78,7 +78,7 @@ is_ip() {
     is_ipv4 "$1" || is_ipv6 "$1"
 }
 is_domain() {
-    [[ "$1" =~ ^([A-Za-z0-9](-*[A-Za-z0-9])*\.)+[A-Za-z]{2,}$ ]] && return 0 || return 1
+    [[ "$1" =~ ^([A-Za-z0-9](-*[A-Za-z0-9])*\.)+(xn--[a-z0-9]{2,}|[A-Za-z]{2,})$ ]] && return 0 || return 1
 }
 
 # Port helpers

--- a/x-ui.sh
+++ b/x-ui.sh
@@ -47,7 +47,7 @@ is_ip() {
     is_ipv4 "$1" || is_ipv6 "$1"
 }
 is_domain() {
-    [[ "$1" =~ ^([A-Za-z0-9](-*[A-Za-z0-9])*\.)+[A-Za-z]{2,}$ ]] && return 0 || return 1
+    [[ "$1" =~ ^([A-Za-z0-9](-*[A-Za-z0-9])*\.)+(xn--[a-z0-9]{2,}|[A-Za-z]{2,})$ ]] && return 0 || return 1
 }
 
 # check root


### PR DESCRIPTION
## What is the pull request?
CLI scripts for create SSL certs use a simple domain check that does not allow IDN domains and Punycode domains form. Since the code creates folders with domain names, I'm not sure if the domain written in the local language will not break any of the scripts. So I just fixed the filtering for Punycode representation of IDN domains. Also the regex in all 3 files have been unified.

Example:
- Punycode `xn--e1afmkfd.xn--p1ai` for IDN domain `пример.рф` previously failed to pass filtering and an SSL certificate could not be issued for it. This problem has now been fixed.
- However, this fix still does not allow simple use IDN domain `пример.рф`, since it is not clear whether a Unicode domain will break anything.

## Which part of the application is affected by the change?

- [ ] Frontend
- [x] Backend

## Type of Changes

- [x] Bug fix
- [ ] New feature
- [ ] Refactoring
- [ ] Other

## Screenshots
<img width="881" height="141" alt="image" src="https://github.com/user-attachments/assets/d5234070-0ad3-41e1-9939-7e2e813fa4e5" />