### PR TITLE
fix: rename `verifyPeerCertInNames` to `verifyPeerCertByName`

### DIFF
--- a/web/assets/js/model/inbound.js
+++ b/web/assets/js/model/inbound.js
@@ -554,7 +554,7 @@ class TlsStreamSettings extends XrayCommonClass {
         maxVersion = TLS_VERSION_OPTION.TLS13,
         cipherSuites = '',
         rejectUnknownSni = false,
-        verifyPeerCertInNames = ['dns.google', 'cloudflare-dns.com'],
+        verifyPeerCertByName = ['dns.google', 'cloudflare-dns.com'],
         disableSystemRoot = false,
         enableSessionResumption = false,
         certificates = [new TlsStreamSettings.Cert()],
@@ -569,7 +569,7 @@ class TlsStreamSettings extends XrayCommonClass {
         this.maxVersion = maxVersion;
         this.cipherSuites = cipherSuites;
         this.rejectUnknownSni = rejectUnknownSni;
-        this.verifyPeerCertInNames = Array.isArray(verifyPeerCertInNames) ? verifyPeerCertInNames.join(",") : verifyPeerCertInNames;
+        this.verifyPeerCertByName = Array.isArray(verifyPeerCertByName) ? verifyPeerCertByName.join(",") : verifyPeerCertByName;
         this.disableSystemRoot = disableSystemRoot;
         this.enableSessionResumption = enableSessionResumption;
         this.certs = certificates;
@@ -603,7 +603,7 @@ class TlsStreamSettings extends XrayCommonClass {
             json.maxVersion,
             json.cipherSuites,
             json.rejectUnknownSni,
-            json.verifyPeerCertInNames,
+            json.verifyPeerCertByName,
             json.disableSystemRoot,
             json.enableSessionResumption,
             certs,
@@ -621,7 +621,7 @@ class TlsStreamSettings extends XrayCommonClass {
             maxVersion: this.maxVersion,
             cipherSuites: this.cipherSuites,
             rejectUnknownSni: this.rejectUnknownSni,
-            verifyPeerCertInNames: this.verifyPeerCertInNames.split(","),
+            verifyPeerCertByName: this.verifyPeerCertByName.split(","),
             disableSystemRoot: this.disableSystemRoot,
             enableSessionResumption: this.enableSessionResumption,
             certificates: TlsStreamSettings.toJsonArray(this.certs),

--- a/web/html/form/tls_settings.html
+++ b/web/html/form/tls_settings.html
@@ -57,8 +57,8 @@
     <a-form-item label="Session Resumption">
       <a-switch v-model="inbound.stream.tls.enableSessionResumption"></a-switch>
     </a-form-item>
-    <a-form-item label="VerifyPeerCertInNames">
-      <a-input v-model.trim="inbound.stream.tls.verifyPeerCertInNames"></a-input>
+    <a-form-item label="verifyPeerCertByName">
+      <a-input v-model.trim="inbound.stream.tls.verifyPeerCertByName"></a-input>
     </a-form-item>
     <a-divider :style="{ margin: '3px 0' }"></a-divider>
     <template v-for="cert,index in inbound.stream.tls.certs">


### PR DESCRIPTION
to be ompatible with xray-core v26.1.31

## What is the pull request?

<!-- Briefly describe the changes introduced by this pull request -->

## Which part of the application is affected by the change?

- [x] Frontend
- [ ] Backend

## Type of Changes

- [x] Bug fix
- [ ] New feature
- [ ] Refactoring
- [ ] Other

## Screenshots

<!-- Add screenshots to illustrate the changes -->
<!-- Remove this section if it is not applicable. -->