### PR TITLE
Better Random Reality - Update

### DIFF
--- a/web/assets/js/model/reality_targets.js
+++ b/web/assets/js/model/reality_targets.js
@@ -1,18 +1,15 @@
 // List of popular services for VLESS Reality Target/SNI randomization
 const REALITY_TARGETS = [
-    { target: 'www.icloud.com:443', sni: 'www.icloud.com,icloud.com' },
-    { target: 'www.apple.com:443', sni: 'www.apple.com,apple.com' },
-    { target: 'www.tesla.com:443', sni: 'www.tesla.com,tesla.com' },
-    { target: 'www.sony.com:443', sni: 'www.sony.com,sony.com' },
-    { target: 'www.nvidia.com:443', sni: 'www.nvidia.com,nvidia.com' },
-    { target: 'www.amd.com:443', sni: 'www.amd.com,amd.com' },
-    { target: 'azure.microsoft.com:443', sni: 'azure.microsoft.com,www.azure.com' },
-    { target: 'aws.amazon.com:443', sni: 'aws.amazon.com,amazon.com' },
-    { target: 'www.bing.com:443', sni: 'www.bing.com,bing.com' },
-    { target: 'www.oracle.com:443', sni: 'www.oracle.com,oracle.com' },
-    { target: 'www.intel.com:443', sni: 'www.intel.com,intel.com' },
-    { target: 'www.microsoft.com:443', sni: 'www.microsoft.com,microsoft.com' },
-    { target: 'www.amazon.com:443', sni: 'www.amazon.com,amazon.com' }
+    { target: 'www.apple.com:443', sni: 'www.apple.com' },
+    { target: 'www.icloud.com:443', sni: 'www.icloud.com' },
+    { target: 'www.amazon.com:443', sni: 'www.amazon.com' },
+    { target: 'aws.amazon.com:443', sni: 'aws.amazon.com' },
+    { target: 'www.oracle.com:443', sni: 'www.oracle.com' },
+    { target: 'www.nvidia.com:443', sni: 'www.nvidia.com' },
+    { target: 'www.amd.com:443', sni: 'www.amd.com' },
+    { target: 'www.intel.com:443', sni: 'www.intel.com' },
+    { target: 'www.tesla.com:443', sni: 'www.tesla.com' },
+    { target: 'www.sony.com:443', sni: 'www.sony.com' }
 ];
 
 /**
@@ -28,4 +25,3 @@ function getRandomRealityTarget() {
         sni: selected.sni
     };
 }
-


### PR DESCRIPTION
## What is the pull request?

This pull request removes Microsoft-related domains from the configuration due to reproducible connection failures caused by upstream blocking.
Specifically:
When the SNI is set to microsoft.com, the connection consistently times out.
When the SNI is changed to othe, the connection succeeds instantly.

Failure chain
Microsoft risk control triggered
Microsoft identifies the VPS IP as a data center IP and detects non-browser TLS behavior.
Upstream blocking
Microsoft’s firewall rejects or silently drops TLS connections originating from the VPS.
Certificate forwarding failure
The VPS cannot establish a TLS connection to Microsoft → cannot obtain the certificate → cannot complete the Reality handshake.
Observed result
TCP connection: successful (VPS is reachable)
TLS handshake: fails (VPS cannot prove it is Microsoft)

And the target and sni are modified to be consistent. 

## Which part of the application is affected by the change?

- [x] Frontend
- [ ] Backend

## Type of Changes

- [ ] Bug fix
- [ ] New feature
- [ ] Refactoring
- [x] Other

## Screenshots

<!-- Add screenshots to illustrate the changes -->
<!-- Remove this section if it is not applicable. -->