### PR TITLE
fix: trim whitespace from comma-separated list values in routing rules

### DIFF
--- a/web/html/modals/xray_rule_modal.html
+++ b/web/html/modals/xray_rule_modal.html
@@ -219,14 +219,14 @@
       rule = {};
       newRule = {};
       rule.type = "field";
-      rule.domain = value.domain.length > 0 ? value.domain.split(',') : [];
-      rule.ip = value.ip.length > 0 ? value.ip.split(',') : [];
+      rule.domain = value.domain.length > 0 ? value.domain.split(',').map(s => s.trim()) : [];
+      rule.ip = value.ip.length > 0 ? value.ip.split(',').map(s => s.trim()) : [];
       rule.port = value.port;
       rule.sourcePort = value.sourcePort;
       rule.vlessRoute = value.vlessRoute;
       rule.network = value.network;
-      rule.sourceIP = value.sourceIP.length > 0 ? value.sourceIP.split(',') : [];
-      rule.user = value.user.length > 0 ? value.user.split(',') : [];
+      rule.sourceIP = value.sourceIP.length > 0 ? value.sourceIP.split(',').map(s => s.trim()) : [];
+      rule.user = value.user.length > 0 ? value.user.split(',').map(s => s.trim()) : [];
       rule.inboundTag = value.inboundTag;
       rule.protocol = value.protocol;
       rule.attrs = Object.fromEntries(value.attrs);


### PR DESCRIPTION
## What is the pull request?

This pull request fixes a bug where comma-separated values in routing rule fields were not properly trimmed of whitespace. When users entered values like `"user1, user2"` in the User field (or other comma-separated fields), the space after the comma was preserved, resulting in `["user1", " user2"]` instead of `["user1", "user2"]`.

The fix adds `.map(s => s.trim())` to the `getResult()` function in the routing rule modal to trim whitespace from each element after splitting comma-separated values. This affects the `user`, `domain`, `ip`, and `sourceIP` fields.

## Which part of the application is affected by the change?

- [x] Frontend
- [ ] Backend

## Type of Changes

- [x] Bug fix
- [ ] New feature
- [ ] Refactoring
- [ ] Other