### PR TITLE
feat: add openssl to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,8 @@ RUN apk add --no-cache --update \
   tzdata \
   fail2ban \
   bash \
-  curl
+  curl \
+  openssl
 
 COPY --from=builder /app/build/ /app/
 COPY --from=builder /app/DockerEntrypoint.sh /app/


### PR DESCRIPTION
When working with the `x-ui` docker image we cannot use SSL option(number 18) in x-ui command because it requires `openssl`. 
I just wanted to install it so there is no need to wrap `x-ui` image.