### PR TITLE
Only send headers if they are not empty

### DIFF
--- a/sub/subController.go
+++ b/sub/subController.go
@@ -182,10 +182,24 @@ func (a *SUBController) ApplyCommonHeaders(
 ) {
 	c.Writer.Header().Set("Subscription-Userinfo", header)
 	c.Writer.Header().Set("Profile-Update-Interval", updateInterval)
-	c.Writer.Header().Set("Profile-Title", "base64:"+base64.StdEncoding.EncodeToString([]byte(profileTitle)))
-	c.Writer.Header().Set("Support-Url", profileSupportUrl)
-	c.Writer.Header().Set("Profile-Web-Page-Url", profileUrl)
-	c.Writer.Header().Set("Announce", "base64:"+base64.StdEncoding.EncodeToString([]byte(profileAnnounce)))
+
+	//Basics
+	if profileTitle != "" {
+		c.Writer.Header().Set("Profile-Title", "base64:"+base64.StdEncoding.EncodeToString([]byte(profileTitle)))
+	}
+	if profileSupportUrl != "" {
+		c.Writer.Header().Set("Support-Url", profileSupportUrl)
+	}
+	if profileUrl != "" {
+		c.Writer.Header().Set("Profile-Web-Page-Url", profileUrl)
+	}
+	if profileAnnounce != "" {
+		c.Writer.Header().Set("Announce", "base64:"+base64.StdEncoding.EncodeToString([]byte(profileAnnounce)))
+	}
+
+	//Advanced (Happ)
 	c.Writer.Header().Set("Routing-Enable", strconv.FormatBool(profileEnableRouting))
-	c.Writer.Header().Set("Routing", profileRoutingRules)
+	if profileRoutingRules != "" {
+		c.Writer.Header().Set("Routing", profileRoutingRules)
+	}
 }


### PR DESCRIPTION
## What is the pull request?

Refactoring/fix: if the value is empty (not set), the panel will not send this header. 

Before:
```
curl -I ...
...
< profile-web-page-url:                                            // from panel (empty string in settings)
< profile-web-page-url: https://mysite.com/sub/jnfkjnfeknferjfnrkj // from nginx
```
As a result - no info about profile web page in client (Happ)

After:
```
curl -I ...
...
< profile-web-page-url: https://mysite.com/sub/jnfkjnfeknferjfnrkj // from nginx
```
Now client gets correctly info about profile page.

In case you want to set headers using `add_header ...`  only in nginx.conf. And, of course, for a clear HTTP response.

## Which part of the application is affected by the change?

- [ ] Frontend
- [X] Backend

## Type of Changes

- [ ] Bug fix
- [ ] New feature
- [x] Refactoring
- [ ] Other
