### PR TITLE
Set default profile-web-page-url in headers

### DIFF
--- a/sub/subController.go
+++ b/sub/subController.go
@@ -143,7 +143,11 @@ func (a *SUBController) subs(c *gin.Context) {
 
 		// Add headers
 		header := fmt.Sprintf("upload=%d; download=%d; total=%d; expire=%d", traffic.Up, traffic.Down, traffic.Total, traffic.ExpiryTime/1000)
-		a.ApplyCommonHeaders(c, header, a.updateInterval, a.subTitle, a.subSupportUrl, a.subProfileUrl, a.subAnnounce, a.subEnableRouting, a.subRoutingRules)
+		profileUrl := a.subProfileUrl  
+		if profileUrl == "" {
+			profileUrl = fmt.Sprintf("%s://%s%s", scheme, hostWithPort, c.Request.RequestURI)
+		}
+		a.ApplyCommonHeaders(c, header, a.updateInterval, a.subTitle, a.subSupportUrl, profileUrl, a.subAnnounce, a.subEnableRouting, a.subRoutingRules)  
 
 		if a.subEncrypt {
 			c.String(200, base64.StdEncoding.EncodeToString([]byte(result)))
@@ -156,13 +160,17 @@ func (a *SUBController) subs(c *gin.Context) {
 // subJsons handles HTTP requests for JSON subscription configurations.
 func (a *SUBController) subJsons(c *gin.Context) {
 	subId := c.Param("subid")
-	_, host, _, _ := a.subService.ResolveRequest(c)
+	scheme, host, hostWithPort, _ := a.subService.ResolveRequest(c)
 	jsonSub, header, err := a.subJsonService.GetJson(subId, host)
 	if err != nil || len(jsonSub) == 0 {
 		c.String(400, "Error!")
 	} else {
 		// Add headers
-		a.ApplyCommonHeaders(c, header, a.updateInterval, a.subTitle, a.subSupportUrl, a.subProfileUrl, a.subAnnounce, a.subEnableRouting, a.subRoutingRules)
+		profileUrl := a.subProfileUrl
+		if profileUrl == "" {
+			profileUrl = fmt.Sprintf("%s://%s%s", scheme, hostWithPort, c.Request.RequestURI)
+		}
+		a.ApplyCommonHeaders(c, header, a.updateInterval, a.subTitle, a.subSupportUrl, profileUrl, a.subAnnounce, a.subEnableRouting, a.subRoutingRules)
 
 		c.String(200, jsonSub)
 	}


### PR DESCRIPTION
## What is the pull request?

A minor improvement: if `Profile URL` is not set in the settings, send the `profile-web-page-url` header with a link to the subscription. If it is set, send it as is.

Before:
```
curl -I ...
...
< profile-web-page-url: https://mysite.com/sub/jnfkjnfeknferjfnrkj // dynamic header from nginx
```

After:
```
curl -I ...
...
< profile-web-page-url: https://mysite.com/sub/jnfkjnfeknferjfnrkj // dynamic header from panel (nginx not needed)

or

curl -I ...
...
< profile-web-page-url: https://stat.mysite.com // static header from panel (it's set in settings)
```

## Which part of the application is affected by the change?

- [ ] Frontend
- [x] Backend

## Type of Changes

- [ ] Bug fix
- [ ] New feature
- [x] Refactoring
- [ ] Other
