### PR TITLE
fix:Add 'default' runlevel to x-ui service in Alpine

### DIFF
--- a/x-ui.sh
+++ b/x-ui.sh
@@ -421,7 +421,7 @@ status() {
 
 enable() {
     if [[ $release == "alpine" ]]; then
-        rc-update add x-ui
+        rc-update add x-ui default
     else
         systemctl enable x-ui
     fi


### PR DESCRIPTION
## What is the pull request?

it should be 'default' runlevel when add x-ui service to openrc, default is 'sysinit' runlevel. 'sysinit' runlevel is unnecessary,maybe. if not, there is an error when call to function 'check_enabled()' as command 'grep default -c' can`t print 'default' runlevel.

check_enabled() {
    if [[ $release == "alpine" ]]; then
        if [[ $(rc-update show | grep -F 'x-ui' | grep default -c) == 1 ]]; then
            return 0
        else
            return 1
        fi

## Which part of the application is affected by the change?

- [ ] Frontend
- [x] Backend

## Type of Changes

- [x] Bug fix
- [ ] New feature
- [ ] Refactoring
- [ ] Other

## Screenshots

<img width="375" height="260" alt="图片" src="https://github.com/user-attachments/assets/1e9959b7-f892-407b-80ae-a791f73fa0b6" />