### PR TITLE
fix: remove excluded paths from gzip middleware in router initialization

### DIFF
--- a/web/web.go
+++ b/web/web.go
@@ -200,7 +200,7 @@ func (s *Server) initRouter() (*gin.Engine, error) {
 	if err != nil {
 		return nil, err
 	}
-	engine.Use(gzip.Gzip(gzip.DefaultCompression, gzip.WithExcludedPaths([]string{basePath + "panel/api/"})))
+	engine.Use(gzip.Gzip(gzip.DefaultCompression))
 	assetsBasePath := basePath + "assets/"
 
 	store := cookie.NewStore(secret)


### PR DESCRIPTION
## What is the pull request?

Previously, the `panel/api/` path was included in the gzip middleware excluded paths list for an unknown reason. I could not find any functional or technical justification for excluding this API endpoint from compression, so it has been removed from the exclusion list.

Before:
```go
engine.Use(gzip.Gzip(gzip.DefaultCompression, gzip.WithExcludedPaths([]string{basePath + "panel/api/"})))
```

After:
```go
engine.Use(gzip.Gzip(gzip.DefaultCompression))
```

By allowing gzip compression for `panel/api/`, the API responses are now properly compressed. As shown in the screenshots, this resulted in approximately **81% reduction in download size and about 71% improvement in transfer speed**, improving overall API performance and efficiency.

## Which part of the application is affected by the change?

- [ ] Frontend
- [x] Backend

## Type of Changes

- [x] Bug fix
- [ ] New feature
- [ ] Refactoring
- [ ] Other

## Screenshots

See attached screenshots demonstrating the reduction in response size and improved transfer speed after enabling gzip compression for the API endpoints.
<img width="811" height="402" alt="fYBSatzCBa" src="https://github.com/user-attachments/assets/fba02c54-51cf-4877-b6cb-222f605e79f5" />

