### PR TITLE
Fix DeepLink for Happ, remove encoding URL

### DIFF
--- a/web/assets/js/subscription.js
+++ b/web/assets/js/subscription.js
@@ -144,7 +144,7 @@
         return this.app.subUrl;
       },
       happUrl() {
-        return `happ://add/${encodeURIComponent(this.app.subUrl)}`;
+        return `happ://add/${this.app.subUrl}`;
       }
     },
     methods: {

--- a/web/html/settings/panel/subscription/subpage.html
+++ b/web/html/settings/panel/subscription/subpage.html
@@ -206,7 +206,7 @@
                                             <a-menu-item key="android-npvtunnel" @click="copy(app.subUrl)">NPV
                                                 Tunnel</a-menu-item>
                                             <a-menu-item key="android-happ"
-                                                @click="open('happ://add/' + encodeURIComponent(app.subUrl))">Happ</a-menu-item>
+                                                @click="open('happ://add/' + app.subUrl)">Happ</a-menu-item>
                                         </a-menu>
                                     </a-dropdown>
                                 </a-col>


### PR DESCRIPTION
Little fix, remove encoding URL in deeplink for happ client