### PR TITLE
Add cron to ubuntu packages

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -76,7 +76,7 @@ is_port_in_use() {
 install_base() {
     case "${release}" in
         ubuntu | debian | armbian)
-            apt-get update && apt-get install -y -q curl tar tzdata socat ca-certificates
+            apt-get update && apt-get install -y -q cron curl tar tzdata socat ca-certificates
         ;;
         fedora | amzn | virtuozzo | rhel | almalinux | rocky | ol)
             dnf -y update && dnf install -y -q curl tar tzdata socat ca-certificates


### PR DESCRIPTION
## What is the pull request?

Add cron to ubuntu packages for install.
If you are trying to run install script on ubuntu without cron installed - acme installation fails silently and you unable to setup x-ui successfully.
After cron installation all works just fine

## Which part of the application is affected by the change?

- [ ] Frontend
- [x] Backend

## Type of Changes

- [x] Bug fix
- [ ] New feature
- [ ] Refactoring
- [ ] Other

