### PR TITLE
fix: escape html characters in tgbot start command

### DIFF
--- a/web/service/tgbot.go
+++ b/web/service/tgbot.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"html"
 	"io"
 	"math/big"
 	"net"
@@ -651,7 +652,7 @@ func (t *Tgbot) answerCommand(message *telego.Message, chatId int64, isAdmin boo
 		msg += t.I18nBot("tgbot.commands.help")
 		msg += t.I18nBot("tgbot.commands.pleaseChoose")
 	case "start":
-		msg += t.I18nBot("tgbot.commands.start", "Firstname=="+message.From.FirstName)
+		msg += t.I18nBot("tgbot.commands.start", "Firstname=="+html.EscapeString(message.From.FirstName))
 		if isAdmin {
 			msg += t.I18nBot("tgbot.commands.welcome", "Hostname=="+hostname)
 		}


### PR DESCRIPTION
## What is the pull request?

This pull request fixes a bug where the Telegram bot fails to reply to the `/start` command if a user's Telegram First Name contains HTML-sensitive characters (such as `<`). 

Previously, an unescaped `<` in the user's name would cause the Telegram API to return a `400 Bad Request: can't parse entities: Unsupported start tag` error because the bot sends messages with `ParseMode: "HTML"`. This completely broke the bot's functionality for those users, preventing the inline keyboard menu from appearing.

The fix sanitizes the user's name by escaping HTML characters before formatting the welcome message in `tgbot.go`.

## Which part of the application is affected by the change?

- [ ] Frontend
- [x] Backend

## Type of Changes

- [x] Bug fix
- [ ] New feature
- [ ] Refactoring
- [ ] Other

## Screenshots

### Before:
<img width="298" height="212" alt="image" src="https://github.com/user-attachments/assets/26cfd9c8-863a-4a3a-9a31-685a17727461" />
<img width="279" height="233" alt="image" src="https://github.com/user-attachments/assets/07bec7a3-d0c8-4e10-8904-0ac0185999b1" />
<img width="924" height="270" alt="image" src="https://github.com/user-attachments/assets/c8f27e13-f8c5-45f0-a4f2-ab13f3dfe6d9" />

### After:
<img width="697" height="523" alt="image" src="https://github.com/user-attachments/assets/55888c14-91de-4808-9a22-82c4cd13983a" />
