### PR TITLE
fix: Ban new IPs with fail2ban  instead of disconnected the client.

### DIFF
--- a/web/job/check_client_ip_job.go
+++ b/web/job/check_client_ip_job.go
@@ -349,10 +349,10 @@ func (j *CheckClientIpJob) updateInboundClientIps(inboundClientIps *model.Inboun
 		keptIps := allIps[:limitIp]
 		bannedIps := allIps[limitIp:]
 
-		// Log banned IPs in the format fail2ban filters expect: [LIMIT_IP] Email = X || SRC = Y
+		// Log banned IPs in the format fail2ban filters expect: [LIMIT_IP] Email = X || Disconnecting OLD IP = Y || Timestamp = Z
 		for _, ipTime := range bannedIps {
 			j.disAllowedIps = append(j.disAllowedIps, ipTime.IP)
-			log.Printf("[LIMIT_IP] Email = %s || SRC = %s", clientEmail, ipTime.IP)
+			log.Printf("[LIMIT_IP] Email = %s || Disconnecting OLD IP = %s || Timestamp = %d", clientEmail, ipTime.IP, ipTime.Timestamp)
 		}
 
 		// Update database with only the currently active (kept) IPs


### PR DESCRIPTION
## What is the pull request?

Fix #3895 — Preserve the original IP while logging new IPs for Fail2Ban. The sorting logic was incorrect and reversed. Also remove the disconnectClientTemporarily function and all related usages to ban the new IPs instead of disconnecting the client.

## Which part of the application is affected by the change?

- [ ] Frontend
- [x] Backend

## Type of Changes

- [x] Bug fix
- [ ] New feature
- [ ] Refactoring
- [ ] Other

## Screenshots

<!-- Add screenshots to illustrate the changes -->
<!-- Remove this section if it is not applicable. -->