### PR TITLE
fix: stop overwriting client_traffics.enable with JSON enable in GetC…

### DIFF
--- a/web/service/inbound.go
+++ b/web/service/inbound.go
@@ -2032,7 +2032,6 @@ func (s *InboundService) GetClientTrafficByEmail(email string) (traffic *xray.Cl
 		return nil, err
 	}
 	if t != nil && client != nil {
-		t.Enable = client.Enable
 		t.UUID = client.ID
 		t.SubId = client.SubID
 		return t, nil


### PR DESCRIPTION
## What is the pull request?

Fix client traffic reset for quota-disabled clients by preserving the DB runtime `enable` flag in `GetClientTrafficByEmail`.

When a client hit traffic/expiry limit, `disableInvalidClients` sets `client_traffics.enable=false` and removes the user from Xray. `GetClientTrafficByEmail` was overwriting that with `settings.clients[].enable` (admin config), so `ResetClientTraffic` never saw the client as disabled and did not re-add the user. Clients could not connect until manually disabled/re-enabled. Now the DB runtime enable flag is preserved; reset correctly re-adds the user to Xray.

## Which part of the application is affected by the change?

- [ ] Frontend
- [x] Backend

## Type of Changes

- [x] Bug fix
- [ ] New feature
- [ ] Refactoring
- [ ] Other

## Screenshots

N/A — backend-only logic fix; no UI change.