### PR TITLE
fix(sub): use safe type assertion for xhttp mode field

### DIFF
--- a/sub/subService.go
+++ b/sub/subService.go
@@ -247,7 +247,7 @@ func (s *SubService) genVmessLink(inbound *model.Inbound, email string) string {
 			headers, _ := xhttp["headers"].(map[string]any)
 			obj["host"] = searchHost(headers)
 		}
-		obj["mode"] = xhttp["mode"].(string)
+		obj["mode"], _ = xhttp["mode"].(string)
 	}
 	security, _ := stream["security"].(string)
 	obj["tls"] = security
@@ -405,7 +405,7 @@ func (s *SubService) genVlessLink(inbound *model.Inbound, email string) string {
 			headers, _ := xhttp["headers"].(map[string]any)
 			params["host"] = searchHost(headers)
 		}
-		params["mode"] = xhttp["mode"].(string)
+		params["mode"], _ = xhttp["mode"].(string)
 	}
 	security, _ := stream["security"].(string)
 	if security == "tls" {
@@ -601,7 +601,7 @@ func (s *SubService) genTrojanLink(inbound *model.Inbound, email string) string 
 			headers, _ := xhttp["headers"].(map[string]any)
 			params["host"] = searchHost(headers)
 		}
-		params["mode"] = xhttp["mode"].(string)
+		params["mode"], _ = xhttp["mode"].(string)
 	}
 	security, _ := stream["security"].(string)
 	if security == "tls" {
@@ -800,7 +800,7 @@ func (s *SubService) genShadowsocksLink(inbound *model.Inbound, email string) st
 			headers, _ := xhttp["headers"].(map[string]any)
 			params["host"] = searchHost(headers)
 		}
-		params["mode"] = xhttp["mode"].(string)
+		params["mode"], _ = xhttp["mode"].(string)
 	}
 
 	security, _ := stream["security"].(string)


### PR DESCRIPTION
## Summary

Fix HTTP 500 on subscription endpoint for XHTTP/SplitHTTP inbounds.

Unsafe type assertion `xhttp["mode"].(string)` panics when `mode` is nil (key absent from stored JSON). This happens when `xhttpSettings` only contains `path` without an explicit `mode` field. The panic is caught by Gin's recovery middleware and returned as HTTP 500 with an empty body. The error is invisible in logs because the subscription server sets `gin.DefaultErrorWriter = io.Discard`.

## Fix

Change all 4 occurrences from unsafe assertion to comma-ok pattern:

```go
// Before (panics on nil)
params["mode"] = xhttp["mode"].(string)

// After (returns "" on nil)
params["mode"], _ = xhttp["mode"].(string)
```

This matches the fix already applied to gRPC's `authority` field in commit 21d98813.

## Affected functions

- `genVmessLink` (line 250)
- `genVlessLink` (line 408)
- `genTrojanLink` (line 604)
- `genShadowsocksLink` (line 803)

Fixes #3987