### PR TITLE
fix(sub): support Reality params for fallback inbounds via externalProxy

### DIFF
--- a/sub/subService.go
+++ b/sub/subService.go
@@ -435,34 +435,37 @@ func (s *SubService) genVlessLink(inbound *model.Inbound, email string) string {
 		}
 	}
 
+	// Extract Reality params unconditionally so they're available when
+	// externalProxy overrides security to "reality" via forceTls.
+	realitySetting, _ := stream["realitySettings"].(map[string]any)
+	realitySettings, _ := searchKey(realitySetting, "settings")
+	if realitySetting != nil {
+		if sniValue, ok := searchKey(realitySetting, "serverNames"); ok {
+			sNames, _ := sniValue.([]any)
+			params["sni"] = sNames[random.Num(len(sNames))].(string)
+		}
+		if pbkValue, ok := searchKey(realitySettings, "publicKey"); ok {
+			params["pbk"], _ = pbkValue.(string)
+		}
+		if sidValue, ok := searchKey(realitySetting, "shortIds"); ok {
+			shortIds, _ := sidValue.([]any)
+			params["sid"] = shortIds[random.Num(len(shortIds))].(string)
+		}
+		if fpValue, ok := searchKey(realitySettings, "fingerprint"); ok {
+			if fp, ok := fpValue.(string); ok && len(fp) > 0 {
+				params["fp"] = fp
+			}
+		}
+		if pqvValue, ok := searchKey(realitySettings, "mldsa65Verify"); ok {
+			if pqv, ok := pqvValue.(string); ok && len(pqv) > 0 {
+				params["pqv"] = pqv
+			}
+		}
+		params["spx"] = "/" + random.Seq(15)
+	}
+
 	if security == "reality" {
 		params["security"] = "reality"
-		realitySetting, _ := stream["realitySettings"].(map[string]any)
-		realitySettings, _ := searchKey(realitySetting, "settings")
-		if realitySetting != nil {
-			if sniValue, ok := searchKey(realitySetting, "serverNames"); ok {
-				sNames, _ := sniValue.([]any)
-				params["sni"] = sNames[random.Num(len(sNames))].(string)
-			}
-			if pbkValue, ok := searchKey(realitySettings, "publicKey"); ok {
-				params["pbk"], _ = pbkValue.(string)
-			}
-			if sidValue, ok := searchKey(realitySetting, "shortIds"); ok {
-				shortIds, _ := sidValue.([]any)
-				params["sid"] = shortIds[random.Num(len(shortIds))].(string)
-			}
-			if fpValue, ok := searchKey(realitySettings, "fingerprint"); ok {
-				if fp, ok := fpValue.(string); ok && len(fp) > 0 {
-					params["fp"] = fp
-				}
-			}
-			if pqvValue, ok := searchKey(realitySettings, "mldsa65Verify"); ok {
-				if pqv, ok := pqvValue.(string); ok && len(pqv) > 0 {
-					params["pqv"] = pqv
-				}
-			}
-			params["spx"] = "/" + random.Seq(15)
-		}
 
 		if streamNetwork == "tcp" && len(clients[clientIndex].Flow) > 0 {
 			params["flow"] = clients[clientIndex].Flow
@@ -627,34 +630,37 @@ func (s *SubService) genTrojanLink(inbound *model.Inbound, email string) string 
 		}
 	}
 
+	// Extract Reality params unconditionally so they're available when
+	// externalProxy overrides security to "reality" via forceTls.
+	realitySetting, _ := stream["realitySettings"].(map[string]any)
+	realitySettings, _ := searchKey(realitySetting, "settings")
+	if realitySetting != nil {
+		if sniValue, ok := searchKey(realitySetting, "serverNames"); ok {
+			sNames, _ := sniValue.([]any)
+			params["sni"] = sNames[random.Num(len(sNames))].(string)
+		}
+		if pbkValue, ok := searchKey(realitySettings, "publicKey"); ok {
+			params["pbk"], _ = pbkValue.(string)
+		}
+		if sidValue, ok := searchKey(realitySetting, "shortIds"); ok {
+			shortIds, _ := sidValue.([]any)
+			params["sid"] = shortIds[random.Num(len(shortIds))].(string)
+		}
+		if fpValue, ok := searchKey(realitySettings, "fingerprint"); ok {
+			if fp, ok := fpValue.(string); ok && len(fp) > 0 {
+				params["fp"] = fp
+			}
+		}
+		if pqvValue, ok := searchKey(realitySettings, "mldsa65Verify"); ok {
+			if pqv, ok := pqvValue.(string); ok && len(pqv) > 0 {
+				params["pqv"] = pqv
+			}
+		}
+		params["spx"] = "/" + random.Seq(15)
+	}
+
 	if security == "reality" {
 		params["security"] = "reality"
-		realitySetting, _ := stream["realitySettings"].(map[string]any)
-		realitySettings, _ := searchKey(realitySetting, "settings")
-		if realitySetting != nil {
-			if sniValue, ok := searchKey(realitySetting, "serverNames"); ok {
-				sNames, _ := sniValue.([]any)
-				params["sni"] = sNames[random.Num(len(sNames))].(string)
-			}
-			if pbkValue, ok := searchKey(realitySettings, "publicKey"); ok {
-				params["pbk"], _ = pbkValue.(string)
-			}
-			if sidValue, ok := searchKey(realitySetting, "shortIds"); ok {
-				shortIds, _ := sidValue.([]any)
-				params["sid"] = shortIds[random.Num(len(shortIds))].(string)
-			}
-			if fpValue, ok := searchKey(realitySettings, "fingerprint"); ok {
-				if fp, ok := fpValue.(string); ok && len(fp) > 0 {
-					params["fp"] = fp
-				}
-			}
-			if pqvValue, ok := searchKey(realitySettings, "mldsa65Verify"); ok {
-				if pqv, ok := pqvValue.(string); ok && len(pqv) > 0 {
-					params["pqv"] = pqv
-				}
-			}
-			params["spx"] = "/" + random.Seq(15)
-		}
 
 		if streamNetwork == "tcp" && len(clients[clientIndex].Flow) > 0 {
 			params["flow"] = clients[clientIndex].Flow

--- a/sub/subService.go
+++ b/sub/subService.go
@@ -492,6 +492,14 @@ func (s *SubService) genVlessLink(inbound *model.Inbound, email string) string {
 			} else {
 				params["security"] = security
 			}
+
+			// Allow externalProxy to override SNI (useful when the
+			// inbound has extra serverNames for fallback routing that
+			// should not appear in subscription links).
+			if sni, ok := ep["sni"].(string); ok && len(sni) > 0 {
+				params["sni"] = sni
+			}
+
 			url, _ := url.Parse(link)
 			q := url.Query()
 
@@ -687,6 +695,14 @@ func (s *SubService) genTrojanLink(inbound *model.Inbound, email string) string 
 			} else {
 				params["security"] = security
 			}
+
+			// Allow externalProxy to override SNI (useful when the
+			// inbound has extra serverNames for fallback routing that
+			// should not appear in subscription links).
+			if sni, ok := ep["sni"].(string); ok && len(sni) > 0 {
+				params["sni"] = sni
+			}
+
 			url, _ := url.Parse(link)
 			q := url.Query()
 
@@ -854,6 +870,14 @@ func (s *SubService) genShadowsocksLink(inbound *model.Inbound, email string) st
 			} else {
 				params["security"] = security
 			}
+
+			// Allow externalProxy to override SNI (useful when the
+			// inbound has extra serverNames for fallback routing that
+			// should not appear in subscription links).
+			if sni, ok := ep["sni"].(string); ok && len(sni) > 0 {
+				params["sni"] = sni
+			}
+
 			url, _ := url.Parse(link)
 			q := url.Query()
 

--- a/web/assets/js/model/inbound.js
+++ b/web/assets/js/model/inbound.js
@@ -1738,7 +1738,7 @@ class Inbound extends XrayCommonClass {
             'o': '',
         };
         if (ObjectUtil.isArrEmpty(this.stream.externalProxy)) {
-            let r = orderChars.split('').map(char => orders[char]).filter(x => x.length > 0).join(separationChar);
+            let r = orderChars.split('').map(char => orders[char]).filter(x => x && x.length > 0).join(separationChar);
             result.push({
                 remark: r,
                 link: this.genLink(addr, port, 'same', r, client)
@@ -1746,7 +1746,7 @@ class Inbound extends XrayCommonClass {
         } else {
             this.stream.externalProxy.forEach((ep) => {
                 orders['o'] = ep.remark;
-                let r = orderChars.split('').map(char => orders[char]).filter(x => x.length > 0).join(separationChar);
+                let r = orderChars.split('').map(char => orders[char]).filter(x => x && x.length > 0).join(separationChar);
                 result.push({
                     remark: r,
                     link: this.genLink(ep.dest, ep.port, ep.forceTls, r, client)


### PR DESCRIPTION
## Summary

- Extract Reality settings (pbk, sni, sid, fp, spx) from stream config unconditionally so they are available when `externalProxy` overrides security to `"reality"` via `forceTls`. Previously these params were only read when `security == "reality"`, which meant fallback inbounds with `security: "none"` couldn't generate correct subscription links even with externalProxy.
- Add `sni` field to `externalProxy` entries to override the randomly selected serverName. This is needed when an inbound has extra serverNames for fallback routing (e.g., MTProto via VLESS fallback) that should not appear in client subscription links.
- Fix `genAllLinks` crash (`TypeError: undefined is not an object (evaluating 'x.length')`) when remarkModel contains characters without a corresponding entry in the orders map.

## Use case

When using VLESS Reality fallbacks to multiplex multiple services on port 443 (e.g., XHTTP + MTProto), the fallback target inbound must have `security: "none"` since the outer Reality inbound already handles TLS. Without this fix, subscription links for such inbounds either crash the UI or generate links without Reality params.