### PR TITLE
Improve balancer failover responsiveness

### DIFF
--- a/web/html/xray.html
+++ b/web/html/xray.html
@@ -366,17 +366,17 @@
       defaultObservatory: {
         subjectSelector: [],
         probeURL: "https://www.google.com/generate_204",
-        probeInterval: "10m",
+        probeInterval: "10s",
         enableConcurrency: true
       },
       defaultBurstObservatory: {
         subjectSelector: [],
         pingConfig: {
           destination: "https://www.google.com/generate_204",
-          interval: "30m",
+          interval: "15s",
           connectivity: "http://connectivitycheck.platform.hicloud.com/generate_204",
-          timeout: "10s",
-          sampling: 2
+          timeout: "5s",
+          sampling: 5
         }
       }
     },
@@ -865,7 +865,7 @@
               newTemplateSettings.burstObservatory.subjectSelector = newTemplateSettings.burstObservatory.subjectSelector.filter(s => s != oldTag);
             }
 
-            if (balancer.strategy && balancer.strategy != 'random') {
+            if (balancer.strategy && balancer.strategy != 'leastPing') {
               tmpBalancer.strategy = {
                 'type': balancer.strategy
               };


### PR DESCRIPTION
By reducing observatory probe intervals and adjusting burst observatory settings, the system can detect unavailable outbounds much faster. Additionally, the default balancer strategy is changed to leastPing, allowing Xray to prefer the most responsive outbound instead of randomly selecting one.
Overall, these changes lead to quicker failover and more stable outbound selection without modifying existing architecture or backend logic