### PR TITLE
Fix hysteria2 Info/QR buttons crashing on echConfigList.join

### DIFF
--- a/web/assets/js/model/inbound.js
+++ b/web/assets/js/model/inbound.js
@@ -1827,7 +1827,7 @@ class Inbound extends XrayCommonClass {
         if (this.stream.tls.settings.fingerprint?.length > 0) params.set("fp", this.stream.tls.settings.fingerprint);
         if (this.stream.tls.alpn?.length > 0) params.set("alpn", this.stream.tls.alpn);
         if (this.stream.tls.settings.allowInsecure) params.set("insecure", "1");
-        if (this.stream.tls.settings.echConfigList?.length > 0) params.set("ech", this.stream.tls.settings.echConfigList.join(','));
+        if (this.stream.tls.settings.echConfigList?.length > 0) params.set("ech", this.stream.tls.settings.echConfigList);
         if (this.stream.tls.sni?.length > 0) params.set("sni", this.stream.tls.sni);
 
         const udpMasks = this.stream?.finalmask?.udp;


### PR DESCRIPTION
## Summary

Closes #4063.

Clicking **Info** or **QR** on any hysteria / hysteria2 inbound throws:

```
TypeError: this.stream.tls.settings.echConfigList.join is not a function
    at Inbound.genHysteriaLink (inbound.js?2.9.1:1830:122)
    at Inbound.genLink (inbound.js?2.9.1:1884:29)
    at Inbound.genAllLinks (inbound.js?2.9.1:1905:28)
```

## Root cause

`echConfigList` is bound to an `<a-input>` (single-line string) in
`web/html/form/tls_settings.html`, and the `TlsStreamSettings.Settings`
constructor defaults it to `''`. It's a **string**, not an array.

`genHysteriaLink` was the only link generator calling `.join(',')` on
it:

```js
if (this.stream.tls.settings.echConfigList?.length > 0)
    params.set("ech", this.stream.tls.settings.echConfigList.join(','));
```

The other three link generators (`genVmessLink` L1608-1610,
`genVlessLink` L1705-1707, `genTrojanLink` L1781-1783) already pass the
value directly:

```js
if (this.stream.tls.settings.echConfigList?.length > 0)
    params.set("ech", this.stream.tls.settings.echConfigList);
```

`URLSearchParams.set` stringifies arrays with `,` on its own, so the
same one-liner works whether the value is a string or an array.

## Fix

Align `genHysteriaLink` with the other three: drop the `.join(',')`
call and pass `echConfigList` straight into `params.set`.

```diff
-        if (this.stream.tls.settings.echConfigList?.length > 0) params.set("ech", this.stream.tls.settings.echConfigList.join(','));
+        if (this.stream.tls.settings.echConfigList?.length > 0) params.set("ech", this.stream.tls.settings.echConfigList);
```

One line, no behaviour change for correctly-typed input.

## Test plan

- [x] Create a hysteria2 inbound → click Info → modal renders with a
      valid `hysteria2://…` URI (no console exception)
- [x] Same for the QR button
- [x] Inbound with `echConfigList` populated still emits an `ech=…`
      query parameter in the generated link
- [x] VLESS / VMess / Trojan inbounds unaffected (those code paths
      were already correct)