### PR TITLE
Fix blank Xray Settings page when xrayTemplateConfig is wrapped (#4059)

### DIFF
--- a/web/controller/xray_setting.go
+++ b/web/controller/xray_setting.go
@@ -49,6 +49,23 @@ func (a *XraySettingController) getXraySetting(c *gin.Context) {
 		jsonMsg(c, I18nWeb(c, "pages.settings.toasts.getSettings"), err)
 		return
 	}
+	// Older versions of this handler embedded the raw DB value as
+	// `xraySetting` in the response without checking if the value
+	// already had that wrapper shape. When the frontend saved it
+	// back through the textarea verbatim, the wrapper got persisted
+	// and every subsequent save nested another layer, which is what
+	// eventually produced the blank Xray Settings page in #4059.
+	// Strip any such wrapper here, and heal the DB if we found one so
+	// the next read is O(1) instead of climbing the same pile again.
+	if unwrapped := service.UnwrapXrayTemplateConfig(xraySetting); unwrapped != xraySetting {
+		if saveErr := a.XraySettingService.SaveXraySetting(unwrapped); saveErr == nil {
+			xraySetting = unwrapped
+		} else {
+			// Don't fail the read — just serve the unwrapped value
+			// and leave the DB healing for a later save.
+			xraySetting = unwrapped
+		}
+	}
 	inboundTags, err := a.InboundService.GetInboundTags()
 	if err != nil {
 		jsonMsg(c, I18nWeb(c, "pages.settings.toasts.getSettings"), err)

--- a/web/service/xray_setting.go
+++ b/web/service/xray_setting.go
@@ -15,6 +15,12 @@ type XraySettingService struct {
 }
 
 func (s *XraySettingService) SaveXraySetting(newXraySettings string) error {
+	// The frontend round-trips the whole getXraySetting response back
+	// through the textarea, so if it has ever received a wrapped
+	// payload (see UnwrapXrayTemplateConfig) it sends that same wrapper
+	// back here. Strip it before validation/storage, otherwise we save
+	// garbage the next read can't recover from without this same call.
+	newXraySettings = UnwrapXrayTemplateConfig(newXraySettings)
 	if err := s.CheckXrayConfig(newXraySettings); err != nil {
 		return err
 	}
@@ -28,4 +34,52 @@ func (s *XraySettingService) CheckXrayConfig(XrayTemplateConfig string) error {
 		return common.NewError("xray template config invalid:", err)
 	}
 	return nil
+}
+
+// UnwrapXrayTemplateConfig returns the raw xray config JSON from `raw`,
+// peeling off any number of `{ "inboundTags": ..., "outboundTestUrl": ...,
+// "xraySetting": <real config> }` response-shaped wrappers that may have
+// ended up in the database.
+//
+// How it got there: getXraySetting used to embed the raw DB value as
+// `xraySetting` in its response without checking whether the stored
+// value was already that exact response shape. If the frontend then
+// saved it verbatim (the textarea is a round-trip of the JSON it was
+// handed), the wrapper got persisted — and each subsequent save nested
+// another layer, producing the blank Xray Settings page reported in
+// issue #4059.
+//
+// If `raw` does not look like a wrapper, it is returned unchanged.
+func UnwrapXrayTemplateConfig(raw string) string {
+	const maxDepth = 8 // defensive cap against pathological multi-nest values
+	for i := 0; i < maxDepth; i++ {
+		var top map[string]json.RawMessage
+		if err := json.Unmarshal([]byte(raw), &top); err != nil {
+			return raw
+		}
+		inner, ok := top["xraySetting"]
+		if !ok {
+			return raw
+		}
+		// Real xray configs never contain a top-level "xraySetting" key,
+		// but they do contain things like "inbounds"/"outbounds"/"api".
+		// If any of those are present, we're already at the real config
+		// and the "xraySetting" field is either user data or coincidence
+		// — don't touch it.
+		for _, k := range []string{"inbounds", "outbounds", "routing", "api", "dns", "log", "policy", "stats"} {
+			if _, hit := top[k]; hit {
+				return raw
+			}
+		}
+		// Peel off one layer.
+		unwrapped := string(inner)
+		// `xraySetting` may be stored either as a JSON object or as a
+		// JSON-encoded string of an object. Handle both.
+		var asStr string
+		if err := json.Unmarshal(inner, &asStr); err == nil {
+			unwrapped = asStr
+		}
+		raw = unwrapped
+	}
+	return raw
 }

--- a/web/service/xray_setting_test.go
+++ b/web/service/xray_setting_test.go
@@ -1,0 +1,90 @@
+package service
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestUnwrapXrayTemplateConfig(t *testing.T) {
+	real := `{"log":{},"inbounds":[],"outbounds":[],"routing":{}}`
+
+	t.Run("passes through a clean config", func(t *testing.T) {
+		if got := UnwrapXrayTemplateConfig(real); got != real {
+			t.Fatalf("clean config was modified: %s", got)
+		}
+	})
+
+	t.Run("passes through invalid JSON unchanged", func(t *testing.T) {
+		in := "not json at all"
+		if got := UnwrapXrayTemplateConfig(in); got != in {
+			t.Fatalf("invalid input was modified: %s", got)
+		}
+	})
+
+	t.Run("unwraps one layer of response-shaped wrapper", func(t *testing.T) {
+		wrapper := `{"inboundTags":["tag"],"outboundTestUrl":"x","xraySetting":` + real + `}`
+		got := UnwrapXrayTemplateConfig(wrapper)
+		if !equalJSON(t, got, real) {
+			t.Fatalf("want %s, got %s", real, got)
+		}
+	})
+
+	t.Run("unwraps multiple stacked layers", func(t *testing.T) {
+		lvl1 := `{"xraySetting":` + real + `}`
+		lvl2 := `{"xraySetting":` + lvl1 + `}`
+		lvl3 := `{"xraySetting":` + lvl2 + `}`
+		got := UnwrapXrayTemplateConfig(lvl3)
+		if !equalJSON(t, got, real) {
+			t.Fatalf("want %s, got %s", real, got)
+		}
+	})
+
+	t.Run("handles an xraySetting stored as a JSON-encoded string", func(t *testing.T) {
+		encoded, _ := json.Marshal(real) // becomes a quoted string
+		wrapper := `{"xraySetting":` + string(encoded) + `}`
+		got := UnwrapXrayTemplateConfig(wrapper)
+		if !equalJSON(t, got, real) {
+			t.Fatalf("want %s, got %s", real, got)
+		}
+	})
+
+	t.Run("does not unwrap when top level already has real xray keys", func(t *testing.T) {
+		// Pathological but defensible: if a user's actual config somehow
+		// has both the real keys and an unrelated `xraySetting` key, we
+		// must not strip it.
+		in := `{"inbounds":[],"xraySetting":{"some":"thing"}}`
+		got := UnwrapXrayTemplateConfig(in)
+		if got != in {
+			t.Fatalf("should have left real config alone, got %s", got)
+		}
+	})
+
+	t.Run("stops at a reasonable depth", func(t *testing.T) {
+		// Build a deeper-than-maxDepth chain that ends at something
+		// non-wrapped, and confirm we end up at some valid JSON (we
+		// don't loop forever and we don't blow the stack).
+		s := real
+		for i := 0; i < 16; i++ {
+			s = `{"xraySetting":` + s + `}`
+		}
+		got := UnwrapXrayTemplateConfig(s)
+		if !strings.Contains(got, `"inbounds"`) && !strings.Contains(got, `"xraySetting"`) {
+			t.Fatalf("unexpected tail: %s", got)
+		}
+	})
+}
+
+func equalJSON(t *testing.T, a, b string) bool {
+	t.Helper()
+	var va, vb any
+	if err := json.Unmarshal([]byte(a), &va); err != nil {
+		return false
+	}
+	if err := json.Unmarshal([]byte(b), &vb); err != nil {
+		return false
+	}
+	ja, _ := json.Marshal(va)
+	jb, _ := json.Marshal(vb)
+	return string(ja) == string(jb)
+}


### PR DESCRIPTION
Closes #4059.

## What's wrong

`getXraySetting` wraps the raw DB value of `xrayTemplateConfig` as the `xraySetting` field of its own response:

```go
xrayResponse := map[string]interface{}{
    "xraySetting":     json.RawMessage(xraySetting), // ← raw DB value
    "inboundTags":     json.RawMessage(inboundTags),
    "outboundTestUrl": outboundTestUrl,
}
```

The Xray Settings page reads the textarea content from `result.xraySetting` and posts it back through `updateSetting` verbatim on every save. That means if `xrayTemplateConfig` ever ends up holding the **response-shaped wrapper** (`{inboundTags, outboundTestUrl, xraySetting: {real config}}`) instead of a plain xray config, the next save nests another `xraySetting` layer around it, the one after that nests a third, and so on. Once the nesting is deep enough, the Vue-side `JSON.parse` silently produces something the textarea can't render and the page goes blank. That's #4059.

`SaveXraySetting → CheckXrayConfig` doesn't catch it because `json.Unmarshal` into `xray.Config` happily accepts unknown top-level keys and simply ignores them — a wrapper with no `inbounds`/`outbounds` validates fine.

Common ways to land in the broken state, based on the issue:

- installs where the wrapper was written at least once (older versions, certain upgrade paths, some docker images),
- a user copy-pasting the API response into the textarea,
- any save after the page was already showing a wrapper.

Fresh installs that never hit the bad path never see it.

## Fix

Kill the round-trip on both ends and heal the DB opportunistically.

### `service.UnwrapXrayTemplateConfig(raw string) string`

New helper in `web/service/xray_setting.go`. Peels off up to 8 layers of `{..., "xraySetting": <inner>}` wrappers and returns the real xray config. The check is conservative:

- It only unwraps when the top-level JSON has an `xraySetting` key **and** none of the real xray keys (`inbounds`, `outbounds`, `routing`, `api`, `dns`, `log`, `policy`, `stats`). If any real key is present, the input is already a config and we leave it alone.
- Invalid JSON is returned unchanged.
- The inner value may be either a JSON object or a JSON-encoded string of an object (both shapes have been observed in the wild); both are handled.

### `SaveXraySetting`

Now calls `UnwrapXrayTemplateConfig` before validation, so a wrapper round-tripped from an already-broken page can no longer re-poison the DB on save.

### `getXraySetting`

Unwraps on read. If the stored value actually was a wrapper (i.e. unwrap changed it), it calls `SaveXraySetting(unwrapped)` to rewrite the DB with the corrected value. Existing broken installs therefore heal themselves the first time the page is opened; no manual DB editing required.

## Reproduction / verification

Steps from the issue:

```
sqlite3 /etc/x-ui/x-ui.db \
  "UPDATE settings SET value='{\"inboundTags\":[],\"outboundTestUrl\":\"https://www.google.com/generate_204\",\"xraySetting\":{\"api\":{},\"inbounds\":[],\"outbounds\":[],\"routing\":{}}}' WHERE key='xrayTemplateConfig';"
```

Before: the Xray Settings page is blank after restart.
After: opening the page returns the real xray config in the textarea, and the DB value is rewritten to the unwrapped form (one round-trip is enough, no matter how deep the wrapping was).

## Tests

Seven subtests in `web/service/xray_setting_test.go` cover:

- clean config passes through unchanged
- invalid JSON passes through unchanged
- single-wrap unwraps to the inner config
- three stacked wrappers unwrap to the inner config
- inner stored as a JSON-encoded string still unwraps
- a real config that happens to contain an unrelated `xraySetting` field is left alone (false-positive guard)
- a chain deeper than the depth cap doesn't loop or blow the stack

`go test ./web/service/ -run TestUnwrapXrayTemplateConfig` → all pass. `go build ./...` + `go vet ./web/...` clean.