### PR TITLE
Fix Hysteria External Proxy + include Hysteria in Clash subscription (#4053)

### DIFF
--- a/sub/subClashService.go
+++ b/sub/subClashService.go
@@ -159,6 +159,16 @@ func (s *SubClashService) getProxies(inbound *model.Inbound, client model.Client
 }
 
 func (s *SubClashService) buildProxy(inbound *model.Inbound, client model.Client, stream map[string]any, extraRemark string) map[string]any {
+	// Hysteria (v1 / v2) doesn't ride an xray `streamSettings.network`
+	// transport and the TLS story is handled inside hysteria itself, so
+	// applyTransport / applySecurity below don't model it. Build the
+	// proxy directly. Without this, hysteria inbounds fell into the
+	// `default: return nil` branch and silently vanished from the
+	// generated Clash config.
+	if inbound.Protocol == model.Hysteria {
+		return s.buildHysteriaProxy(inbound, client, extraRemark)
+	}
+
 	proxy := map[string]any{
 		"name":   s.SubService.genRemark(inbound, client.Email, extraRemark),
 		"server": inbound.Listen,
@@ -217,6 +227,82 @@ func (s *SubClashService) buildProxy(inbound *model.Inbound, client model.Client
 	security, _ := stream["security"].(string)
 	if !s.applySecurity(proxy, security, stream) {
 		return nil
+	}
+
+	return proxy
+}
+
+// buildHysteriaProxy produces a mihomo-compatible Clash entry for a
+// Hysteria (v1) or Hysteria2 inbound. It reads `inbound.StreamSettings`
+// directly instead of going through streamData/tlsData, because those
+// helpers prune fields (like `allowInsecure` / the salamander obfs
+// block) that the hysteria proxy wants preserved.
+func (s *SubClashService) buildHysteriaProxy(inbound *model.Inbound, client model.Client, extraRemark string) map[string]any {
+	var inboundSettings map[string]any
+	_ = json.Unmarshal([]byte(inbound.Settings), &inboundSettings)
+
+	proxyType := "hysteria2"
+	authKey := "password"
+	if v, ok := inboundSettings["version"].(float64); ok && int(v) == 1 {
+		proxyType = "hysteria"
+		authKey = "auth-str"
+	}
+
+	proxy := map[string]any{
+		"name":    s.SubService.genRemark(inbound, client.Email, extraRemark),
+		"type":    proxyType,
+		"server":  inbound.Listen,
+		"port":    inbound.Port,
+		"udp":     true,
+		authKey:   client.Auth,
+	}
+
+	var rawStream map[string]any
+	_ = json.Unmarshal([]byte(inbound.StreamSettings), &rawStream)
+
+	// TLS details — hysteria always uses TLS.
+	if tlsSettings, ok := rawStream["tlsSettings"].(map[string]any); ok {
+		if serverName, ok := tlsSettings["serverName"].(string); ok && serverName != "" {
+			proxy["sni"] = serverName
+		}
+		if alpnList, ok := tlsSettings["alpn"].([]any); ok && len(alpnList) > 0 {
+			out := make([]string, 0, len(alpnList))
+			for _, a := range alpnList {
+				if s, ok := a.(string); ok && s != "" {
+					out = append(out, s)
+				}
+			}
+			if len(out) > 0 {
+				proxy["alpn"] = out
+			}
+		}
+		if inner, ok := tlsSettings["settings"].(map[string]any); ok {
+			if insecure, ok := inner["allowInsecure"].(bool); ok && insecure {
+				proxy["skip-cert-verify"] = true
+			}
+			if fp, ok := inner["fingerprint"].(string); ok && fp != "" {
+				proxy["client-fingerprint"] = fp
+			}
+		}
+	}
+
+	// Salamander obfs (Hysteria2). Read the same finalmask.udp[salamander]
+	// block the subscription link generator uses.
+	if finalmask, ok := rawStream["finalmask"].(map[string]any); ok {
+		if udpMasks, ok := finalmask["udp"].([]any); ok {
+			for _, m := range udpMasks {
+				mask, _ := m.(map[string]any)
+				if mask == nil || mask["type"] != "salamander" {
+					continue
+				}
+				settings, _ := mask["settings"].(map[string]any)
+				if pw, ok := settings["password"].(string); ok && pw != "" {
+					proxy["obfs"] = "salamander"
+					proxy["obfs-password"] = pw
+					break
+				}
+			}
+		}
 	}
 
 	return proxy

--- a/sub/subClashService.go
+++ b/sub/subClashService.go
@@ -249,12 +249,12 @@ func (s *SubClashService) buildHysteriaProxy(inbound *model.Inbound, client mode
 	}
 
 	proxy := map[string]any{
-		"name":    s.SubService.genRemark(inbound, client.Email, extraRemark),
-		"type":    proxyType,
-		"server":  inbound.Listen,
-		"port":    inbound.Port,
-		"udp":     true,
-		authKey:   client.Auth,
+		"name":   s.SubService.genRemark(inbound, client.Email, extraRemark),
+		"type":   proxyType,
+		"server": inbound.Listen,
+		"port":   inbound.Port,
+		"udp":    true,
+		authKey:  client.Auth,
 	}
 
 	var rawStream map[string]any

--- a/sub/subService.go
+++ b/sub/subService.go
@@ -888,7 +888,6 @@ func (s *SubService) genShadowsocksLink(inbound *model.Inbound, email string) st
 }
 
 func (s *SubService) genHysteriaLink(inbound *model.Inbound, email string) string {
-	address := s.address
 	if inbound.Protocol != model.Hysteria {
 		return ""
 	}
@@ -903,7 +902,6 @@ func (s *SubService) genHysteriaLink(inbound *model.Inbound, email string) strin
 		}
 	}
 	auth := clients[clientIndex].Auth
-	port := inbound.Port
 	params := make(map[string]string)
 
 	params["security"] = "tls"
@@ -932,6 +930,26 @@ func (s *SubService) genHysteriaLink(inbound *model.Inbound, email string) strin
 		}
 	}
 
+	// salamander obfs (Hysteria2). The panel-side link generator already
+	// emits these; keep the subscription output in sync so a client has
+	// the obfs password to match the server.
+	if finalmask, ok := stream["finalmask"].(map[string]interface{}); ok {
+		if udpMasks, ok := finalmask["udp"].([]interface{}); ok {
+			for _, m := range udpMasks {
+				mask, _ := m.(map[string]interface{})
+				if mask == nil || mask["type"] != "salamander" {
+					continue
+				}
+				settings, _ := mask["settings"].(map[string]interface{})
+				if pw, ok := settings["password"].(string); ok && pw != "" {
+					params["obfs"] = "salamander"
+					params["obfs-password"] = pw
+					break
+				}
+			}
+		}
+	}
+
 	var settings map[string]interface{}
 	json.Unmarshal([]byte(inbound.Settings), &settings)
 	version, _ := settings["version"].(float64)
@@ -940,7 +958,35 @@ func (s *SubService) genHysteriaLink(inbound *model.Inbound, email string) strin
 		protocol = "hysteria"
 	}
 
-	link := fmt.Sprintf("%s://%s@%s:%d", protocol, auth, address, port)
+	// Fan out one link per External Proxy entry if any. Previously this
+	// generator ignored `externalProxy` entirely, so the link kept the
+	// server's own IP/port even when the admin configured an alternate
+	// endpoint (e.g. a CDN hostname + port that forwards to the node).
+	// Matches the behaviour of genVlessLink / genTrojanLink / ….
+	externalProxies, _ := stream["externalProxy"].([]interface{})
+	if len(externalProxies) > 0 {
+		links := make([]string, 0, len(externalProxies))
+		for _, externalProxy := range externalProxies {
+			ep, _ := externalProxy.(map[string]interface{})
+			dest, _ := ep["dest"].(string)
+			epPort := int(ep["port"].(float64))
+			epRemark, _ := ep["remark"].(string)
+
+			link := fmt.Sprintf("%s://%s@%s:%d", protocol, auth, dest, epPort)
+			u, _ := url.Parse(link)
+			q := u.Query()
+			for k, v := range params {
+				q.Add(k, v)
+			}
+			u.RawQuery = q.Encode()
+			u.Fragment = s.genRemark(inbound, email, epRemark)
+			links = append(links, u.String())
+		}
+		return strings.Join(links, "\n")
+	}
+
+	// No external proxy configured — fall back to the request host.
+	link := fmt.Sprintf("%s://%s@%s:%d", protocol, auth, s.address, inbound.Port)
 	url, _ := url.Parse(link)
 	q := url.Query()
 	for k, v := range params {


### PR DESCRIPTION
Closes #4053.

Two related gaps on the Hysteria side of the subscription layer.

## 1. `genHysteriaLink` ignored `externalProxy`

`sub/subService.go → genHysteriaLink` built its link as

```go
link := fmt.Sprintf("%s://%s@%s:%d", protocol, auth, s.address, inbound.Port)
```

with no reference to the inbound's `externalProxy` array. Every other generator (`genVmessLink`, `genVlessLink`, `genTrojanLink`, `genShadowsocksLink`) iterates that array and emits one link per entry, substituting `dest` / `port` / `remark`. Hysteria was the outlier, so admins who pointed a Hysteria inbound at an alternate endpoint (typical scenario: a CDN hostname that forwards UDP to the node) still got a subscription with the original server address. The issue reporter ran into exactly this.

Fix: mirror the pattern. When `externalProxy` is non-empty, fan out — one link per entry — substituting `dest` / `port` and using the entry's remark as a suffix. If the array is absent or empty, keep the previous behaviour (use the request host + `inbound.Port`).

While I was in there, I also propagated the salamander obfs password (`finalmask.udp[salamander].settings.password`) as `obfs=salamander&obfs-password=…`. The panel-side link generator (`web/assets/js/model/inbound.js → genHysteriaLink`) already emits these query params, so the subscription output was just lagging.

## 2. Hysteria missing from Clash subscription

`sub/subClashService.go → buildProxy` had a protocol switch with cases for VMESS / VLESS / Trojan / Shadowsocks and a `default: return nil`. Hysteria inbounds fell into the default branch and silently vanished from the YAML — the user saw every other protocol in their Clash config except the Hysteria ones.

Fix: route Hysteria through a dedicated `buildHysteriaProxy` helper *before* the existing `applyTransport` / `applySecurity` helpers run. Those helpers model xray `streamSettings.network` / `streamSettings.security`, which Hysteria doesn't use — Hysteria carries its own UDP transport and TLS handshake. The helper reads `inbound.StreamSettings` directly instead of going through `streamData` / `tlsData`, because those prune fields (`allowInsecure`, the salamander `finalmask.udp` block) that the mihomo Hysteria proxy needs preserved.

Output shape matches mihomo's docs:

```yaml
- name: <remark>
  type: hysteria2              # or "hysteria" for v1 inbounds
  server: <ext-proxy-host or inbound.Listen>
  port: <ext-proxy-port or inbound.Port>
  password: <client.Auth>      # "auth-str" for v1
  udp: true
  sni: <tlsSettings.serverName>
  alpn: [h3]                   # whatever tlsSettings.alpn has
  skip-cert-verify: true       # iff tlsSettings.settings.allowInsecure
  client-fingerprint: chrome   # iff tlsSettings.settings.fingerprint set
  obfs: salamander
  obfs-password: <finalmask.udp[salamander].settings.password>
```

The existing `getProxies` fanout over `externalProxy` is untouched and plugs in automatically, so once Hysteria is recognised by `buildProxy` it also picks up External Proxy entries in the Clash output.

## Diff size

`sub/subService.go`: `genHysteriaLink` rewritten (+49 −3)
`sub/subClashService.go`: +86 (early Hysteria dispatch + `buildHysteriaProxy`)

## Test plan

- [x] `go build ./...` + `go vet ./sub/...` clean
- [x] Hysteria inbound **without** External Proxy → subscription link uses request host + `inbound.Port` (unchanged from before)
- [x] Hysteria inbound **with** External Proxy entries → one `hysteria2://…` link per entry, each pointing at its own `dest:port` with the configured remark suffix
- [x] Salamander obfs password on the inbound ends up as `obfs=salamander&obfs-password=…` in every emitted link
- [x] Clash subscription now contains `type: hysteria2` (or `hysteria` for v1) proxies for every Hysteria inbound, with `password` / `auth-str` / `sni` / `alpn` / `skip-cert-verify` / `obfs` / `obfs-password` populated from the inbound
- [x] External Proxy on a Hysteria inbound produces one Clash proxy per entry (via the existing `getProxies` fanout, now that `buildProxy` stops dropping Hysteria)
- [x] Non-Hysteria inbounds unchanged (vmess/vless/trojan/ss paths never touched)