### PR TITLE
fix(panel): set ALPN to h3 when switching to Hysteria protocol

### DIFF
--- a/web/assets/js/model/inbound.js
+++ b/web/assets/js/model/inbound.js
@@ -1396,6 +1396,8 @@ class Inbound extends XrayCommonClass {
         if (protocol === Protocols.HYSTERIA) {
             this.stream.network = 'hysteria';
             this.stream.security = 'tls';
+            // Hysteria runs over QUIC and must not inherit TCP TLS ALPN defaults.
+            this.stream.tls.alpn = [ALPN_OPTION.H3];
         }
     }
 


### PR DESCRIPTION
- Automatically explicitly set ALPN to ['h3'] for Hysteria to prevent QUIC handshake mismatch.

## What is the pull request?

<!-- Briefly describe the changes introduced by this pull request -->

This PR fixes a bug in the inbound configuration form where incompatible ALPN default values (`h2`, `http/1.1`) are preserved when switching from TCP-based protocols (like VLESS/VMESS) to QUIC-based protocols (`hysteria`).

### The Issue
Currently, when a user selects `hysteria`, the ALPN field incorrectly retains the default values `['h2', 'http/1.1']`. Since Hysteria is built on QUIC (UDP), passing TCP-based ALPNs causes an immediate ALPN mismatch during the TLS handshake. 

As a result, the Xray-core immediately rejects the client's connection request (sending back a 37-byte Connection Close frame), which leads to a frustrating `Timeout` error on clients like Clash Meta and v2rayN.

## Which part of the application is affected by the change?

- [x] Frontend
- [ ] Backend

## Type of Changes

- [x] Bug fix
- [ ] New feature
- [ ] Refactoring
- [ ] Other

## Screenshots

<!-- Add screenshots to illustrate the changes -->
<!-- Remove this section if it is not applicable. -->