### PR TITLE
x-ui.sh: bundle nftables when installing fail2ban

### DIFF
--- a/x-ui.sh
+++ b/x-ui.sh
@@ -1802,7 +1802,14 @@ install_iplimit() {
     if ! command -v fail2ban-client &>/dev/null; then
         echo -e "${green}Fail2ban is not installed. Installing now...!${plain}\n"
 
-        # Check the OS and install necessary packages
+        # Install fail2ban together with nftables. Recent fail2ban packages
+        # default to `banaction = nftables-multiport` in /etc/fail2ban/jail.conf,
+        # but the `nftables` package isn't pulled in as a dependency on most
+        # minimal server images (Debian 12+, Ubuntu 24+, fresh RHEL-family).
+        # Without `nft` in PATH the default sshd jail fails to ban with
+        #   stderr: '/bin/sh: 1: nft: not found'
+        # even though our own 3x-ipl jail uses iptables. Bundling the binary
+        # at install time prevents that confusing log spam for new installs.
         case "${release}" in
         ubuntu)
             apt-get update
@@ -1810,34 +1817,34 @@ install_iplimit() {
                 apt-get install python3-pip -y
                 python3 -m pip install pyasynchat --break-system-packages
             fi
-            apt-get install fail2ban -y
+            apt-get install fail2ban nftables -y
             ;;
         debian)
             apt-get update
             if [ "$os_version" -ge 12 ]; then
                 apt-get install -y python3-systemd
             fi
-            apt-get install -y fail2ban
+            apt-get install -y fail2ban nftables
             ;;
         armbian)
-            apt-get update && apt-get install fail2ban -y
+            apt-get update && apt-get install fail2ban nftables -y
             ;;
         fedora | amzn | virtuozzo | rhel | almalinux | rocky | ol)
-            dnf -y update && dnf -y install fail2ban
+            dnf -y update && dnf -y install fail2ban nftables
             ;;
         centos)
             if [[ "${VERSION_ID}" =~ ^7 ]]; then
                 yum update -y && yum install epel-release -y
-                yum -y install fail2ban
+                yum -y install fail2ban nftables
             else
-                dnf -y update && dnf -y install fail2ban
+                dnf -y update && dnf -y install fail2ban nftables
             fi
             ;;
         arch | manjaro | parch)
-            pacman -Syu --noconfirm fail2ban
+            pacman -Syu --noconfirm fail2ban nftables
             ;;
         alpine)
-            apk add fail2ban
+            apk add fail2ban nftables
             ;;
         *)
             echo -e "${red}Unsupported operating system. Please check the script and install the necessary packages manually.${plain}\n"


### PR DESCRIPTION
Fresh Debian 12+, Ubuntu 24+ and recent RHEL-family minimal server images ship `fail2ban` with `banaction = nftables-multiport` as the default in `/etc/fail2ban/jail.conf`, but do not pull in the `nftables` package. The first SSH brute-force attempt reaches the default `sshd` jail and fail2ban logs:

```
stderr: /bin/sh: 1: nft: not found
returned 127 -- HINT on 127: "Command not found"
```

over and over until the attacker gives up. Noisy, looks like a 3x-ui regression on first install — see the discussion on #4083 where a user updated, checked `Service Status` / `Ban Logs` from the x-ui menu, and assumed the update caused it.

The `3x-ipl` jail itself is fine because `create_iplimit_jails` writes an iptables-based action (`action.d/3x-ipl.conf` inherits from `iptables-allports.conf`). But the default sshd jail is inherited from the distro fail2ban config and the noise is real.

Add `nftables` to the package list in every branch of `install_iplimit` so fresh installs end up with a working default sshd jail. Installs that already have `nftables` present are a no-op.

No effect on existing deployments — `install_iplimit` only runs when the admin explicitly picks "Install IP Limit" from the x-ui menu, and only when `fail2ban-client` is not already on the system. 

### Test plan

- [x] bash syntax check on x-ui.sh (no errors)
- [x] diff review — only the package arg changed per distro, nothing else
- [x] behaviourally equivalent on systems where `nftables` is already installed (apt / dnf / pacman / apk all no-op an already-installed package)