### PR TITLE
chore: fix shadowrocketUrl client

### DIFF
--- a/web/assets/js/subscription.js
+++ b/web/assets/js/subscription.js
@@ -135,8 +135,9 @@
         return enabledOk && expiryOk && trafficOk;
       },
       shadowrocketUrl() {
-        const rawUrl = this.app.subUrl + '?flag=shadowrocket';
-        const base64Url = btoa(rawUrl);
+        const separator = this.app.subUrl.includes('?') ? '&' : '?';
+        const rawUrl = this.app.subUrl + separator + 'flag=shadowrocket';
+        const base64Url = encodeURIComponent(btoa(rawUrl));
         const remark = encodeURIComponent(this.app.sId || 'Subscription');
         return `shadowrocket://add/sub/${base64Url}?remark=${remark}`;
       },


### PR DESCRIPTION
## What is the pull request?
Fix Shadowrocket subscription URL failing when remark or 
subscription URL contains Unicode characters (e.g. Vietnamese, 
Chinese, Arabic). `btoa()` throws an error on non-Latin characters,
causing the Shadowrocket link to break silently.

## Which part of the application is affected by the change?
- [x] Frontend

## Type of Changes
- [x] Bug fix

## Screenshots
Before: `btoa()` throws `InvalidCharacterError` on Unicode input  
After: Unicode characters are safely encoded before base64 conversion