### PR TITLE
feat(wireguard): add configurable DNS to exported client configs

### DIFF
--- a/web/assets/js/model/inbound.js
+++ b/web/assets/js/model/inbound.js
@@ -2250,10 +2250,11 @@ class Inbound extends XrayCommonClass {
     }
 
     getWireguardTxt(address, port, remark, peerId) {
+        const DNS = this.settings.DNS || '1.1.1.1, 1.0.0.1';
         let txt = `[Interface]\n`
         txt += `PrivateKey = ${this.settings.peers[peerId].privateKey}\n`
         txt += `Address = ${this.settings.peers[peerId].allowedIPs[0]}\n`
-        txt += `DNS = 1.1.1.1, 1.0.0.1\n`
+        txt += `DNS = ${DNS}\n`
         if (this.settings.mtu) {
             txt += `MTU = ${this.settings.mtu}\n`
         }
@@ -2275,6 +2276,8 @@ class Inbound extends XrayCommonClass {
         const peer = this.settings?.peers?.[peerId];
         if (!peer) return '';
 
+        const DNS = this.settings.DNS || '1.1.1.1, 1.0.0.1';
+
         const link = `wireguard://${address}:${port}`;
         const url = new URL(link);
         url.username = peer.privateKey || '';
@@ -2287,6 +2290,9 @@ class Inbound extends XrayCommonClass {
         }
         if (this.settings?.mtu) {
             url.searchParams.set("mtu", this.settings.mtu);
+        }
+        if (DNS) {
+            url.searchParams.set("dns", DNS);
         }
 
         url.hash = encodeURIComponent(remark);
@@ -3095,7 +3101,8 @@ Inbound.WireguardSettings = class extends XrayCommonClass {
         mtu = 1420,
         secretKey = Wireguard.generateKeypair().privateKey,
         peers = [new Inbound.WireguardSettings.Peer()],
-        noKernelTun = false
+        noKernelTun = false,
+        DNS = '1.1.1.1, 1.0.0.1'
     ) {
         super(protocol);
         this.mtu = mtu;
@@ -3103,6 +3110,7 @@ Inbound.WireguardSettings = class extends XrayCommonClass {
         this.pubKey = secretKey.length > 0 ? Wireguard.generateKeypair(secretKey).publicKey : '';
         this.peers = peers;
         this.noKernelTun = noKernelTun;
+        this.DNS = DNS || '1.1.1.1, 1.0.0.1';
     }
 
     addPeer() {
@@ -3118,8 +3126,9 @@ Inbound.WireguardSettings = class extends XrayCommonClass {
             Protocols.WIREGUARD,
             json.mtu,
             json.secretKey,
-            json.peers.map(peer => Inbound.WireguardSettings.Peer.fromJson(peer)),
+            (json.peers || []).map(peer => Inbound.WireguardSettings.Peer.fromJson(peer)),
             json.noKernelTun,
+            json.DNS
         );
     }
 
@@ -3129,6 +3138,7 @@ Inbound.WireguardSettings = class extends XrayCommonClass {
             secretKey: this.secretKey,
             peers: Inbound.WireguardSettings.Peer.toJsonArray(this.peers),
             noKernelTun: this.noKernelTun,
+            DNS: this.DNS || undefined,
         };
     }
 };

--- a/web/html/form/protocol/wireguard.html
+++ b/web/html/form/protocol/wireguard.html
@@ -19,6 +19,10 @@
   <a-form-item label='MTU'>
     <a-input-number v-model.number="inbound.settings.mtu"></a-input-number>
   </a-form-item>
+  <a-form-item label='DNS'>
+    <a-input v-model.trim="inbound.settings.DNS" placeholder="1.1.1.1, 1.0.0.1">
+    </a-input>
+  </a-form-item>
   <a-form-item label='No Kernel Tun'>
     <a-switch v-model="inbound.settings.noKernelTun"></a-switch>
   </a-form-item>


### PR DESCRIPTION
This change adds configurable DNS support for exported WireGuard client configurations.

Previously, generated WireGuard client configs always used hardcoded Cloudflare DNS values: `1.1.1.1, 1.0.0.1`. With this change, the administrator can set a custom DNS server in the WireGuard inbound settings, and that value is saved as part of the inbound configuration.

The configured DNS is exported into generated `.conf` files under the `[Interface]` section as `DNS = ...`, and is also included in generated `wireguard://` links as a `dns` query parameter for QR/link-based export. DNS is stored as a shared inbound-level setting.

This allows sharing ready-to-use WireGuard client configs via file, QR code, or link without requiring users to manually edit DNS settings on their devices. It is especially useful when the default Cloudflare DNS resolvers are blocked or unreliable, because the administrator can provide an alternative DNS resolver directly in the exported client configuration.

Existing WireGuard settings without a `DNS` field remain compatible and fall back to `1.1.1.1, 1.0.0.1`.

## Which part of the application is affected by the change?

- [x] Frontend
- [x] Backend

## Type of Changes

- [ ] Bug fix
- [x] New feature
- [ ] Refactoring
- [ ] Other