### PR TITLE
fix(xray): clear outbound test state on delete to prevent result bleed

### DIFF
--- a/frontend/src/pages/xray/OutboundsTab.vue
+++ b/frontend/src/pages/xray/OutboundsTab.vue
@@ -48,7 +48,7 @@ const inboundTagOptions = computed(() => {
   return [...out];
 });
 
-const emit = defineEmits(['reset-traffic', 'test', 'show-warp', 'show-nord']);
+const emit = defineEmits(['reset-traffic', 'test', 'show-warp', 'show-nord', 'delete']);
 
 // === Modal state ====================================================
 const modalOpen = ref(false);
@@ -86,7 +86,7 @@ function confirmDelete(idx) {
     okText: t('delete'),
     okType: 'danger',
     cancelText: t('cancel'),
-    onOk: () => { props.templateSettings.outbounds.splice(idx, 1); },
+    onOk: () => { emit('delete', idx); },
   });
 }
 function setFirst(idx) {

--- a/frontend/src/pages/xray/XrayPage.vue
+++ b/frontend/src/pages/xray/XrayPage.vue
@@ -57,6 +57,15 @@ async function onTestOutbound(idx) {
   if (outbound) await testOutbound(idx, outbound);
 }
 
+function onDeleteOutbound(idx) {
+  templateSettings.value.outbounds.splice(idx, 1);
+  outboundTestStates.value = Object.fromEntries(
+    Object.entries(outboundTestStates.value)
+      .filter(([k]) => Number(k) !== idx)
+      .map(([k, v]) => [Number(k) > idx ? Number(k) - 1 : Number(k), v]),
+  );
+}
+
 // === Advanced tab — radio-driven view ==============================
 // Mirrors the legacy advanced page: a 4-way radio toggles which slice
 // of the xray config the textarea edits — the full config, just the
@@ -298,6 +307,7 @@ function confirmRestart() {
                         :is-mobile="isMobile"
                         @reset-traffic="resetOutboundsTraffic"
                         @test="onTestOutbound"
+                        @delete="onDeleteOutbound"
                         @show-warp="showWarp"
                         @show-nord="showNord"
                       />


### PR DESCRIPTION
## What is the pull request?

Ping results were stored by array index, so deleting an outbound left a stale result that immediately appeared on the next one. Fix moves delete handling to XrayPage so outboundTestStates is shifted alongside the array.

## Which part of the application is affected by the change?

- [X] Frontend
- [ ] Backend

## Type of Changes

- [X] Bug fix
- [ ] New feature
- [ ] Refactoring
- [ ] Other