### PR TITLE
Fix silently ignored errors in password migration seeder

### DIFF
--- a/database/db.go
+++ b/database/db.go
@@ -89,11 +89,17 @@ func runSeeders(isUsersEmpty bool) error {
 		return db.Create(hashSeeder).Error
 	} else {
 		var seedersHistory []string
-		db.Model(&model.HistoryOfSeeders{}).Pluck("seeder_name", &seedersHistory)
+		if err := db.Model(&model.HistoryOfSeeders{}).Pluck("seeder_name", &seedersHistory).Error; err != nil {
+			log.Printf("Error fetching seeder history: %v", err)
+			return err
+		}
 
 		if !slices.Contains(seedersHistory, "UserPasswordHash") && !isUsersEmpty {
 			var users []model.User
-			db.Find(&users)
+			if err := db.Find(&users).Error; err != nil {
+				log.Printf("Error fetching users for password migration: %v", err)
+				return err
+			}
 
 			for _, user := range users {
 				hashedPassword, err := crypto.HashPasswordAsBcrypt(user.Password)
@@ -101,7 +107,10 @@ func runSeeders(isUsersEmpty bool) error {
 					log.Printf("Error hashing password for user '%s': %v", user.Username, err)
 					return err
 				}
-				db.Model(&user).Update("password", hashedPassword)
+				if err := db.Model(&user).Update("password", hashedPassword).Error; err != nil {
+					log.Printf("Error updating password for user '%s': %v", user.Username, err)
+					return err
+				}
 			}
 
 			hashSeeder := &model.HistoryOfSeeders{


### PR DESCRIPTION
## Summary

- Fix three silently ignored database errors in `database/db.go` `runSeeders()` function
- The password migration seeder (which migrates user passwords to bcrypt) had three GORM operations whose errors were not checked

## Issues Fixed

1. **`Pluck("seeder_name", &seedersHistory)`** — If this fails, `seedersHistory` is empty, causing the seeder to re-run and potentially **double-hash already bcrypt'd passwords**, corrupting them and locking users out.

2. **`Find(&users)`** — If this fails, the `users` slice is empty, so no passwords get migrated, but the seeder still marks itself as complete. Users remain with old-format passwords indefinitely.

3. **`Update("password", hashedPassword)`** — If this fails for any user, their password silently remains in the old format while other users are migrated, creating an inconsistent state.

All three now properly check errors and return early with descriptive log messages.

## Test plan

- [ ] Verify the application starts normally with an existing database
- [ ] Verify fresh installation still creates default admin user
- [ ] Verify password migration from old format to bcrypt works correctly
- [ ] Verify that a database error during migration is properly logged and does not mark the seeder as complete

🤖 Generated with [Claude Code](https://claude.com/claude-code)