### PR TITLE
Fix overly permissive file permissions (os.ModePerm / 0777)

### DIFF
--- a/database/db.go
+++ b/database/db.go
@@ -6,7 +6,6 @@ import (
 	"bytes"
 	"errors"
 	"io"
-	"io/fs"
 	"log"
 	"os"
 	"path"
@@ -124,7 +123,7 @@ func isTableEmpty(tableName string) (bool, error) {
 // InitDB sets up the database connection, migrates models, and runs seeders.
 func InitDB(dbPath string) error {
 	dir := path.Dir(dbPath)
-	err := os.MkdirAll(dir, fs.ModePerm)
+	err := os.MkdirAll(dir, 0755)
 	if err != nil {
 		return err
 	}

--- a/web/service/server.go
+++ b/web/service/server.go
@@ -7,7 +7,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/fs"
 	"mime/multipart"
 	"net/http"
 	"os"
@@ -660,7 +659,7 @@ func (s *ServerService) UpdateXray(version string) error {
 		defer zipFile.Close()
 		os.MkdirAll(filepath.Dir(fileName), 0755)
 		os.Remove(fileName)
-		file, err := os.OpenFile(fileName, os.O_CREATE|os.O_RDWR|os.O_TRUNC, fs.ModePerm)
+		file, err := os.OpenFile(fileName, os.O_CREATE|os.O_RDWR|os.O_TRUNC, 0755)
 		if err != nil {
 			return err
 		}

--- a/xray/process.go
+++ b/xray/process.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/fs"
 	"os"
 	"os/exec"
 	"runtime"
@@ -321,7 +320,7 @@ func (p *process) Start() (err error) {
 	if p.configPath != "" {
 		configPath = p.configPath
 	}
-	err = os.WriteFile(configPath, data, fs.ModePerm)
+	err = os.WriteFile(configPath, data, 0644)
 	if err != nil {
 		return common.NewErrorf("Failed to write configuration file: %v", err)
 	}
@@ -381,5 +380,5 @@ func (p *process) Stop() error {
 // writeCrashReport writes a crash report to the binary folder with a timestamped filename.
 func writeCrashReport(m []byte) error {
 	crashReportPath := config.GetBinFolderPath() + "/core_crash_" + time.Now().Format("20060102_150405") + ".log"
-	return os.WriteFile(crashReportPath, m, os.ModePerm)
+	return os.WriteFile(crashReportPath, m, 0644)
 }


### PR DESCRIPTION
## Summary

- Replace `os.ModePerm` / `fs.ModePerm` (0777) with appropriate restrictive permissions across four file operations
- Remove unused `"io/fs"` imports from the affected files

## Changes

| File | Operation | Before | After |
|------|-----------|--------|-------|
| `database/db.go` | DB directory creation | 0777 | 0755 |
| `xray/process.go` | Xray config write | 0777 | 0644 |
| `xray/process.go` | Crash report write | 0777 | 0644 |
| `web/service/server.go` | Binary extraction | 0777 | 0755 |

## Why

`os.ModePerm` (0777) makes files and directories **world-writable**, violating the principle of least privilege. An attacker with local access could modify the Xray configuration file or crash reports, or inject malicious binaries.

- **0755** for directories: owner read/write/execute, group/others read/execute
- **0644** for regular files: owner read/write, group/others read-only
- **0755** for executable binaries: owner read/write/execute, group/others read/execute

## Test plan

- [ ] Verify the application starts normally
- [ ] Verify Xray config file is created with 0644 permissions
- [ ] Verify crash reports are created with 0644 permissions
- [ ] Verify binary extraction produces files with 0755 permissions

🤖 Generated with [Claude Code](https://claude.com/claude-code)