### PR TITLE
Fix silently ignored error when saving outbound test URL

### DIFF
--- a/web/controller/xray_setting.go
+++ b/web/controller/xray_setting.go
@@ -104,7 +104,10 @@ func (a *XraySettingController) updateSetting(c *gin.Context) {
 	if outboundTestUrl == "" {
 		outboundTestUrl = "https://www.google.com/generate_204"
 	}
-	_ = a.SettingService.SetXrayOutboundTestUrl(outboundTestUrl)
+	if err := a.SettingService.SetXrayOutboundTestUrl(outboundTestUrl); err != nil {
+		jsonMsg(c, I18nWeb(c, "pages.settings.toasts.modifySettings"), err)
+		return
+	}
 	jsonMsg(c, I18nWeb(c, "pages.settings.toasts.modifySettings"), nil)
 }
 


### PR DESCRIPTION
## Summary

- Fix an ignored error in `web/controller/xray_setting.go` `updateSetting()` handler
- The `SetXrayOutboundTestUrl()` error was silently discarded, causing users to see a "Settings updated successfully" toast even when the outbound test URL failed to save to the database

## Before

```go
_ = a.SettingService.SetXrayOutboundTestUrl(outboundTestUrl)
jsonMsg(c, I18nWeb(c, "pages.settings.toasts.modifySettings"), nil)
```

The user always got a success response regardless of whether the setting was actually persisted.

## After

```go
if err := a.SettingService.SetXrayOutboundTestUrl(outboundTestUrl); err != nil {
    jsonMsg(c, I18nWeb(c, "pages.settings.toasts.modifySettings"), err)
    return
}
jsonMsg(c, I18nWeb(c, "pages.settings.toasts.modifySettings"), nil)
```

Now consistent with how the preceding `SaveXraySetting()` call handles errors.

## Test plan

- [ ] Save Xray settings with a custom outbound test URL → should show success
- [ ] Verify the outbound test URL is actually persisted (refresh settings page)
- [ ] Simulate a database error and verify the user gets an error toast

🤖 Generated with [Claude Code](https://claude.com/claude-code)