### PR TITLE
fix(graphs): increase y-axis padding to prevent clipped labels

### DIFF
--- a/frontend/src/components/Sparkline.vue
+++ b/frontend/src/components/Sparkline.vue
@@ -17,7 +17,7 @@ const props = defineProps({
   showAxes: { type: Boolean, default: false },
   yTickStep: { type: Number, default: 25 },
   tickCountX: { type: Number, default: 4 },
-  paddingLeft: { type: Number, default: 32 },
+  paddingLeft: { type: Number, default: 56 },
   paddingRight: { type: Number, default: 6 },
   paddingTop: { type: Number, default: 6 },
   paddingBottom: { type: Number, default: 20 },


### PR DESCRIPTION
In Sparkline.vue, y-axis labels (e.g. "0.00 MB/s", "500.00 KB/s") 
were clipped on the left edge because paddingLeft was only 32px.
At font-size 10, labels longer than ~4 characters extend past x=0 
and get cut off by the SVG viewBox.

Increased the default paddingLeft from 32 to 56, giving ample room 
for labels up to ~10 characters (e.g. "10.00 MB/s").

Fixes #4305