### PR TITLE
feat(api-docs): enhance API documentation with missing endpoints, search, collapse, syntax highlighting, body examples, error responses, and route sync test

### DIFF
--- a/frontend/src/pages/api-docs/ApiDocsPage.vue
+++ b/frontend/src/pages/api-docs/ApiDocsPage.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { ref, onMounted } from 'vue';
+import { ref, computed, onMounted } from 'vue';
 import { useI18n } from 'vue-i18n';
 import { Modal, message } from 'ant-design-vue';
 import {
@@ -8,12 +8,15 @@ import {
   CopyOutlined,
   EyeOutlined,
   EyeInvisibleOutlined,
+  SearchOutlined,
+  ExpandOutlined,
+  CompressOutlined,
 } from '@ant-design/icons-vue';
 
 import { theme as themeState, antdThemeConfig } from '@/composables/useTheme.js';
 import AppSidebar from '@/components/AppSidebar.vue';
 import { HttpUtil, ClipboardManager } from '@/utils/index.js';
-import { sections } from './endpoints.js';
+import { sections as allSections } from './endpoints.js';
 import EndpointSection from './EndpointSection.vue';
 
 const { t } = useI18n();
@@ -26,10 +29,54 @@ const tokenLoading = ref(false);
 const tokenRotating = ref(false);
 const tokenVisible = ref(false);
 
-const curlExample = `curl -X GET \\
-  -H "Authorization: Bearer YOUR_API_TOKEN" \\
-  -H "Accept: application/json" \\
+const searchQuery = ref('');
+const collapsedSections = ref(new Set());
+
+const curlExample = `curl -X GET \
+  -H "Authorization: Bearer YOUR_API_TOKEN" \
+  -H "Accept: application/json" \
   https://your-panel.example.com/panel/api/inbounds/list`;
+
+const sections = computed(() => {
+  const q = searchQuery.value.toLowerCase().trim();
+  if (!q) return allSections;
+  return allSections
+    .map(s => {
+      const matching = s.endpoints.filter(e =>
+        e.path.toLowerCase().includes(q) ||
+        e.summary?.toLowerCase().includes(q) ||
+        e.method.toLowerCase().includes(q)
+      );
+      return { ...s, endpoints: matching };
+    })
+    .filter(s => s.endpoints.length > 0);
+});
+
+const endpointCount = computed(() =>
+  allSections.reduce((sum, s) => sum + s.endpoints.length, 0)
+);
+
+const visibleSections = computed(() =>
+  sections.value.reduce((sum, s) => sum + s.endpoints.length, 0)
+);
+
+function isCollapsed(id) {
+  return collapsedSections.value.has(id);
+}
+
+function toggleSection(id) {
+  const s = new Set(collapsedSections.value);
+  if (s.has(id)) s.delete(id); else s.add(id);
+  collapsedSections.value = s;
+}
+
+function expandAll() {
+  collapsedSections.value = new Set();
+}
+
+function collapseAll() {
+  collapsedSections.value = new Set(allSections.map(s => s.id));
+}
 
 async function loadApiToken() {
   tokenLoading.value = true;
@@ -64,7 +111,7 @@ function regenerateApiToken() {
 
 async function copyApiToken() {
   if (!apiToken.value) return;
-  const ok = await ClipboardManager.copyText(apiToken.value);
+  const ok = await ClipboardManager.copy(apiToken.value);
   if (ok) message.success(t('success'));
 }
 
@@ -138,15 +185,45 @@ onMounted(() => {
               <pre class="code-block">{{ curlExample }}</pre>
             </a-card>
 
+            <div class="toolbar">
+              <a-input-search
+                v-model:value="searchQuery"
+                placeholder="Search endpoints by path, method, or description…"
+                allow-clear
+                class="search-bar"
+              >
+                <template #prefix><SearchOutlined /></template>
+              </a-input-search>
+              <span class="match-count" v-if="searchQuery">
+                {{ visibleSections }} / {{ endpointCount }} endpoints
+              </span>
+              <a-space size="small">
+                <a-button size="small" @click="expandAll">
+                  <template #icon><ExpandOutlined /></template>
+                  Expand all
+                </a-button>
+                <a-button size="small" @click="collapseAll">
+                  <template #icon><CompressOutlined /></template>
+                  Collapse all
+                </a-button>
+              </a-space>
+            </div>
+
             <nav class="toc-nav">
               <span class="toc-label">On this page:</span>
               <a v-for="s in sections" :key="s.id" class="toc-link" :href="`#${s.id}`"
                 @click.prevent="scrollToSection(s.id)">
-                {{ s.title }}
+                {{ s.title }} ({{ s.endpoints.length }})
               </a>
             </nav>
 
-            <EndpointSection v-for="s in sections" :key="s.id" :section="s" />
+            <EndpointSection
+              v-for="s in sections"
+              :key="s.id"
+              :section="s"
+              :collapsed="isCollapsed(s.id)"
+              @toggle="toggleSection(s.id)"
+            />
           </div>
         </a-layout-content>
       </a-layout>
@@ -273,6 +350,26 @@ onMounted(() => {
   white-space: pre-wrap;
   word-break: break-word;
   overflow-x: auto;
+}
+
+.toolbar {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  flex-wrap: wrap;
+  margin-bottom: 16px;
+}
+
+.search-bar {
+  flex: 1;
+  min-width: 200px;
+  max-width: 480px;
+}
+
+.match-count {
+  font-size: 12px;
+  color: rgba(0, 0, 0, 0.5);
+  white-space: nowrap;
 }
 
 .toc-nav {

--- a/frontend/src/pages/api-docs/ApiDocsPage.vue
+++ b/frontend/src/pages/api-docs/ApiDocsPage.vue
@@ -18,6 +18,7 @@ import AppSidebar from '@/components/AppSidebar.vue';
 import { HttpUtil, ClipboardManager } from '@/utils/index.js';
 import { sections as allSections } from './endpoints.js';
 import EndpointSection from './EndpointSection.vue';
+import CodeBlock from './CodeBlock.vue';
 
 const { t } = useI18n();
 
@@ -182,7 +183,7 @@ onMounted(() => {
             </a-card>
 
             <a-card class="curl-card" size="small" title="Quick example">
-              <pre class="code-block">{{ curlExample }}</pre>
+              <CodeBlock :code="curlExample" lang="text" />
             </a-card>
 
             <div class="toolbar">

--- a/frontend/src/pages/api-docs/ApiDocsPage.vue
+++ b/frontend/src/pages/api-docs/ApiDocsPage.vue
@@ -112,7 +112,7 @@ function regenerateApiToken() {
 
 async function copyApiToken() {
   if (!apiToken.value) return;
-  const ok = await ClipboardManager.copy(apiToken.value);
+  const ok = await ClipboardManager.copyText(apiToken.value);
   if (ok) message.success(t('success'));
 }
 

--- a/frontend/src/pages/api-docs/ApiDocsPage.vue
+++ b/frontend/src/pages/api-docs/ApiDocsPage.vue
@@ -33,9 +33,9 @@ const tokenVisible = ref(false);
 const searchQuery = ref('');
 const collapsedSections = ref(new Set());
 
-const curlExample = `curl -X GET \
-  -H "Authorization: Bearer YOUR_API_TOKEN" \
-  -H "Accept: application/json" \
+const curlExample = `curl -X GET \\
+  -H "Authorization: Bearer YOUR_API_TOKEN" \\
+  -H "Accept: application/json" \\
   https://your-panel.example.com/panel/api/inbounds/list`;
 
 const sections = computed(() => {

--- a/frontend/src/pages/api-docs/ApiDocsPage.vue
+++ b/frontend/src/pages/api-docs/ApiDocsPage.vue
@@ -141,6 +141,7 @@ onMounted(() => {
                 cookie, or with the <code>Authorization: Bearer &lt;token&gt;</code> header below. Every endpoint
                 returns a uniform <code>{ success, msg, obj }</code> envelope unless otherwise noted.
               </p>
+
             </header>
 
             <a-card class="token-card" size="small">

--- a/frontend/src/pages/api-docs/CodeBlock.vue
+++ b/frontend/src/pages/api-docs/CodeBlock.vue
@@ -1,0 +1,152 @@
+<script setup>
+import { computed, ref } from 'vue';
+import { message } from 'ant-design-vue';
+import { CopyOutlined, CheckOutlined } from '@ant-design/icons-vue';
+
+const props = defineProps({
+  code: { type: String, default: '' },
+  lang: { type: String, default: 'json' },
+});
+
+const copied = ref(false);
+
+function escapeHtml(str) {
+  return str.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+}
+
+function highlightJson(str) {
+  const escaped = escapeHtml(str);
+  return escaped.replace(
+    /("(?:[^"\\]|\\.)*")\s*(:)|("(?:[^"\\]|\\.)*")|(-?\d+\.?\d*(?:[eE][+-]?\d+)?)\b|(true|false)|(null)|([{}\[\]])/g,
+    (_m, key, colon, string, number, bool, nil) => {
+      if (colon) return `<span class="json-key">${key}</span>${colon}`;
+      if (string) return `<span class="json-string">${string}</span>`;
+      if (number) return `<span class="json-number">${number}</span>`;
+      if (bool) return `<span class="json-boolean">${bool}</span>`;
+      if (nil) return `<span class="json-null">${nil}</span>`;
+      return _m;
+    }
+  );
+}
+
+const highlighted = computed(() => {
+  if (props.lang === 'json') {
+    return highlightJson(props.code);
+  }
+  return escapeHtml(props.code);
+});
+
+async function copyCode() {
+  try {
+    await navigator.clipboard.writeText(props.code);
+    copied.value = true;
+    message.success('Copied');
+    setTimeout(() => { copied.value = false; }, 2000);
+  } catch {
+    message.error('Copy failed');
+  }
+}
+</script>
+
+<template>
+  <div class="code-block-wrapper">
+    <button class="copy-btn" :class="{ copied }" @click="copyCode" :title="copied ? 'Copied' : 'Copy'">
+      <CheckOutlined v-if="copied" />
+      <CopyOutlined v-else />
+    </button>
+    <pre class="code-block" :class="`lang-${lang}`"><code v-html="highlighted"></code></pre>
+  </div>
+</template>
+
+<style scoped>
+.code-block-wrapper {
+  position: relative;
+  border-radius: 6px;
+  overflow: hidden;
+}
+
+.copy-btn {
+  position: absolute;
+  top: 6px;
+  right: 6px;
+  z-index: 1;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  border: 1px solid rgba(128, 128, 128, 0.2);
+  border-radius: 4px;
+  background: rgba(255, 255, 255, 0.85);
+  color: rgba(0, 0, 0, 0.5);
+  cursor: pointer;
+  font-size: 13px;
+  opacity: 0;
+  transition: opacity 0.15s, background 0.15s, color 0.15s;
+}
+
+.code-block-wrapper:hover .copy-btn {
+  opacity: 1;
+}
+
+.copy-btn:hover {
+  background: #fff;
+  color: #1677ff;
+  border-color: #1677ff;
+}
+
+.copy-btn.copied {
+  opacity: 1;
+  background: #52c41a;
+  color: #fff;
+  border-color: #52c41a;
+}
+
+.code-block {
+  background: rgba(128, 128, 128, 0.08);
+  border: 1px solid rgba(128, 128, 128, 0.15);
+  border-radius: 6px;
+  padding: 12px;
+  margin: 0;
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 12.5px;
+  line-height: 1.55;
+  white-space: pre-wrap;
+  word-break: break-word;
+  overflow-x: auto;
+}
+
+
+</style>
+
+<style>
+.json-key { color: #0550ae; }
+.json-string { color: #0a3069; }
+.json-number { color: #0550ae; }
+.json-boolean { color: #cf222e; }
+.json-null { color: #8250df; }
+
+body.dark .code-block {
+  background: rgba(255, 255, 255, 0.04);
+  border-color: rgba(255, 255, 255, 0.1);
+  color: rgba(255, 255, 255, 0.88);
+}
+
+body.dark .json-key { color: #79c0ff; }
+body.dark .json-string { color: #a5d6ff; }
+body.dark .json-number { color: #79c0ff; }
+body.dark .json-boolean { color: #ff7b72; }
+body.dark .json-null { color: #d2a8ff; }
+
+body.dark .copy-btn {
+  background: rgba(255, 255, 255, 0.08);
+  color: rgba(255, 255, 255, 0.5);
+  border-color: rgba(255, 255, 255, 0.15);
+}
+
+body.dark .copy-btn:hover {
+  background: rgba(255, 255, 255, 0.12);
+  color: #58a6ff;
+  border-color: #58a6ff;
+}
+</style>

--- a/frontend/src/pages/api-docs/CodeBlock.vue
+++ b/frontend/src/pages/api-docs/CodeBlock.vue
@@ -121,8 +121,8 @@ async function copyCode() {
 
 <style>
 .json-key { color: #0550ae; }
-.json-string { color: #0a3069; }
-.json-number { color: #0550ae; }
+.json-string { color: #116329; }
+.json-number { color: #9a6700; }
 .json-boolean { color: #cf222e; }
 .json-null { color: #8250df; }
 
@@ -133,8 +133,8 @@ body.dark .code-block {
 }
 
 body.dark .json-key { color: #79c0ff; }
-body.dark .json-string { color: #a5d6ff; }
-body.dark .json-number { color: #79c0ff; }
+body.dark .json-string { color: #7ee787; }
+body.dark .json-number { color: #d29922; }
 body.dark .json-boolean { color: #ff7b72; }
 body.dark .json-null { color: #d2a8ff; }
 

--- a/frontend/src/pages/api-docs/EndpointRow.vue
+++ b/frontend/src/pages/api-docs/EndpointRow.vue
@@ -25,7 +25,7 @@ const paramColumns = [
       <code class="endpoint-path">{{ endpoint.path }}</code>
     </div>
 
-    <p v-if="endpoint.summary" class="endpoint-summary">{{ endpoint.summary }}</p>
+    <p v-if="endpoint.summary" class="endpoint-summary" v-html="endpoint.summary"></p>
 
     <div v-if="hasParams" class="endpoint-block">
       <div class="block-label">Parameters</div>
@@ -40,6 +40,11 @@ const paramColumns = [
     <div v-if="endpoint.response" class="endpoint-block">
       <div class="block-label">Response</div>
       <CodeBlock :code="endpoint.response" lang="json" />
+    </div>
+
+    <div v-if="endpoint.errorResponse" class="endpoint-block">
+      <div class="block-label error-label">Error response</div>
+      <CodeBlock :code="endpoint.errorResponse" lang="json" />
     </div>
   </div>
 </template>
@@ -93,6 +98,10 @@ const paramColumns = [
   margin-bottom: 6px;
 }
 
+.error-label {
+  color: #cf222e;
+}
+
 .code-block {
   background: rgba(128, 128, 128, 0.08);
   border: 1px solid rgba(128, 128, 128, 0.15);
@@ -114,6 +123,10 @@ body.dark .endpoint-summary {
 }
 
 body.dark .block-label {
+  color: rgba(255, 255, 255, 0.55);
+}
+
+body.dark .error-label {
   color: rgba(255, 255, 255, 0.55);
 }
 

--- a/frontend/src/pages/api-docs/EndpointRow.vue
+++ b/frontend/src/pages/api-docs/EndpointRow.vue
@@ -1,6 +1,7 @@
 <script setup>
 import { computed } from 'vue';
 import { methodColors } from './endpoints.js';
+import CodeBlock from './CodeBlock.vue';
 
 const props = defineProps({
   endpoint: { type: Object, required: true },
@@ -33,16 +34,12 @@ const paramColumns = [
 
     <div v-if="endpoint.body" class="endpoint-block">
       <div class="block-label">Request body</div>
-      <a-typography-paragraph :copyable="{ text: endpoint.body }">
-        <pre class="code-block">{{ endpoint.body }}</pre>
-      </a-typography-paragraph>
+      <CodeBlock :code="endpoint.body" lang="json" />
     </div>
 
     <div v-if="endpoint.response" class="endpoint-block">
       <div class="block-label">Response</div>
-      <a-typography-paragraph :copyable="{ text: endpoint.response }">
-        <pre class="code-block">{{ endpoint.response }}</pre>
-      </a-typography-paragraph>
+      <CodeBlock :code="endpoint.response" lang="json" />
     </div>
   </div>
 </template>

--- a/frontend/src/pages/api-docs/EndpointRow.vue
+++ b/frontend/src/pages/api-docs/EndpointRow.vue
@@ -1,6 +1,6 @@
 <script setup>
 import { computed } from 'vue';
-import { methodColors } from './endpoints.js';
+import { methodColors, safeInlineHtml } from './endpoints.js';
 import CodeBlock from './CodeBlock.vue';
 
 const props = defineProps({
@@ -25,7 +25,7 @@ const paramColumns = [
       <code class="endpoint-path">{{ endpoint.path }}</code>
     </div>
 
-    <p v-if="endpoint.summary" class="endpoint-summary" v-html="endpoint.summary"></p>
+    <p v-if="endpoint.summary" class="endpoint-summary" v-html="safeInlineHtml(endpoint.summary)"></p>
 
     <div v-if="hasParams" class="endpoint-block">
       <div class="block-label">Parameters</div>
@@ -127,7 +127,7 @@ body.dark .block-label {
 }
 
 body.dark .error-label {
-  color: rgba(255, 255, 255, 0.55);
+  color: #ff7b72;
 }
 
 body.dark .code-block {

--- a/frontend/src/pages/api-docs/EndpointSection.vue
+++ b/frontend/src/pages/api-docs/EndpointSection.vue
@@ -30,7 +30,19 @@ const endpointLabel = computed(() =>
       </div>
       <span class="endpoint-count">{{ endpointLabel }}</span>
     </div>
-    <p v-if="section.description && !collapsed" class="section-description">{{ section.description }}</p>
+    <p v-if="section.description && !collapsed" class="section-description" v-html="section.description"></p>
+
+    <div v-if="section.subHeader && !collapsed" class="sub-header-block">
+      <div class="block-label">Response headers</div>
+      <a-table
+        :columns="[{ title: 'Header', dataIndex: 'name', key: 'name', width: 240 }, { title: 'Description', dataIndex: 'desc', key: 'desc' }]"
+        :data-source="section.subHeader"
+        :pagination="false"
+        size="small"
+        row-key="name"
+      />
+    </div>
+
     <div v-show="!collapsed" class="endpoints">
       <EndpointRow v-for="(endpoint, idx) in section.endpoints" :key="idx" :endpoint="endpoint" />
     </div>
@@ -90,6 +102,19 @@ const endpointLabel = computed(() =>
   line-height: 1.55;
 }
 
+.sub-header-block {
+  margin-bottom: 14px;
+}
+
+.block-label {
+  font-size: 12px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  color: rgba(0, 0, 0, 0.5);
+  margin-bottom: 6px;
+}
+
 .endpoints {
   padding-top: 8px;
   border-top: 1px solid rgba(128, 128, 128, 0.1);
@@ -117,5 +142,9 @@ body.dark .section-title {
 
 body.dark .section-description {
   color: rgba(255, 255, 255, 0.7);
+}
+
+body.dark .block-label {
+  color: rgba(255, 255, 255, 0.55);
 }
 </style>

--- a/frontend/src/pages/api-docs/EndpointSection.vue
+++ b/frontend/src/pages/api-docs/EndpointSection.vue
@@ -1,16 +1,37 @@
 <script setup>
+import { computed } from 'vue';
+import {
+  DownOutlined,
+  RightOutlined,
+} from '@ant-design/icons-vue';
 import EndpointRow from './EndpointRow.vue';
 
-defineProps({
+const props = defineProps({
   section: { type: Object, required: true },
+  collapsed: { type: Boolean, default: false },
 });
+
+const emit = defineEmits(['toggle']);
+
+const endpointLabel = computed(() =>
+  props.section.endpoints.length === 1
+    ? '1 endpoint'
+    : `${props.section.endpoints.length} endpoints`
+);
 </script>
 
 <template>
   <section :id="section.id" class="api-section">
-    <h2 class="section-title">{{ section.title }}</h2>
-    <p v-if="section.description" class="section-description">{{ section.description }}</p>
-    <div class="endpoints">
+    <div class="section-header" @click="emit('toggle')">
+      <div class="section-header-left">
+        <DownOutlined v-if="!collapsed" class="collapse-icon" />
+        <RightOutlined v-else class="collapse-icon" />
+        <h2 class="section-title">{{ section.title }}</h2>
+      </div>
+      <span class="endpoint-count">{{ endpointLabel }}</span>
+    </div>
+    <p v-if="section.description && !collapsed" class="section-description">{{ section.description }}</p>
+    <div v-show="!collapsed" class="endpoints">
       <EndpointRow v-for="(endpoint, idx) in section.endpoints" :key="idx" :endpoint="endpoint" />
     </div>
   </section>
@@ -21,9 +42,33 @@ defineProps({
   background: #fff;
   border: 1px solid rgba(128, 128, 128, 0.15);
   border-radius: 8px;
-  padding: 20px 24px;
-  margin-bottom: 20px;
+  padding: 16px 24px;
+  margin-bottom: 16px;
   scroll-margin-top: 16px;
+}
+
+.section-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  cursor: pointer;
+  user-select: none;
+}
+
+.section-header:hover .collapse-icon {
+  color: #1677ff;
+}
+
+.section-header-left {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.collapse-icon {
+  font-size: 12px;
+  color: rgba(0, 0, 0, 0.45);
+  transition: color 0.2s;
 }
 
 .section-title {
@@ -33,10 +78,21 @@ defineProps({
   color: rgba(0, 0, 0, 0.88);
 }
 
+.endpoint-count {
+  font-size: 12px;
+  color: rgba(0, 0, 0, 0.45);
+  white-space: nowrap;
+}
+
 .section-description {
-  margin: 6px 0 14px;
+  margin: 10px 0 14px;
   color: rgba(0, 0, 0, 0.65);
   line-height: 1.55;
+}
+
+.endpoints {
+  padding-top: 8px;
+  border-top: 1px solid rgba(128, 128, 128, 0.1);
 }
 
 .endpoints > :first-child {

--- a/frontend/src/pages/api-docs/EndpointSection.vue
+++ b/frontend/src/pages/api-docs/EndpointSection.vue
@@ -5,6 +5,7 @@ import {
   RightOutlined,
 } from '@ant-design/icons-vue';
 import EndpointRow from './EndpointRow.vue';
+import { safeInlineHtml } from './endpoints.js';
 
 const props = defineProps({
   section: { type: Object, required: true },
@@ -30,7 +31,7 @@ const endpointLabel = computed(() =>
       </div>
       <span class="endpoint-count">{{ endpointLabel }}</span>
     </div>
-    <p v-if="section.description && !collapsed" class="section-description" v-html="section.description"></p>
+    <p v-if="section.description && !collapsed" class="section-description" v-html="safeInlineHtml(section.description)"></p>
 
     <div v-if="section.subHeader && !collapsed" class="sub-header-block">
       <div class="block-label">Response headers</div>
@@ -40,7 +41,12 @@ const endpointLabel = computed(() =>
         :pagination="false"
         size="small"
         row-key="name"
-      />
+      >
+        <template #bodyCell="{ column, text }">
+          <span v-if="column.dataIndex === 'desc'" v-html="safeInlineHtml(text)"></span>
+          <template v-else>{{ text }}</template>
+        </template>
+      </a-table>
     </div>
 
     <div v-show="!collapsed" class="endpoints">

--- a/frontend/src/pages/api-docs/endpoints.js
+++ b/frontend/src/pages/api-docs/endpoints.js
@@ -67,6 +67,7 @@ export const sections = [
         params: [
           { name: 'email', in: 'path', type: 'string', desc: 'Client email (unique across the panel).' },
         ],
+        response: '{\n  "success": true,\n  "obj": {\n    "email": "user1",\n    "up": 1048576,\n    "down": 2097152,\n    "total": 10737418240,\n    "expiryTime": 1735689600000\n  }\n}',
       },
       {
         method: 'GET',
@@ -75,6 +76,7 @@ export const sections = [
         params: [
           { name: 'id', in: 'path', type: 'string', desc: 'Client subId / UUID.' },
         ],
+        response: '{\n  "success": true,\n  "obj": {\n    "email": "user1",\n    "up": 1048576,\n    "down": 2097152,\n    "total": 10737418240,\n    "expiryTime": 1735689600000\n  }\n}',
       },
       {
         method: 'POST',
@@ -209,6 +211,7 @@ export const sections = [
         method: 'POST',
         path: '/panel/api/inbounds/lastOnline',
         summary: 'Map of client email → last-seen unix timestamp.',
+        response: '{\n  "success": true,\n  "obj": [\n    { "email": "user1", "lastOnline": 1700000000 },\n    { "email": "user2", "lastOnline": 1699999000 }\n  ]\n}',
       },
       {
         method: 'GET',
@@ -264,6 +267,7 @@ export const sections = [
         method: 'GET',
         path: '/panel/api/server/status',
         summary: 'Real-time machine snapshot: CPU, memory, swap, disk, network IO, load averages, open connections, Xray state. Cached and refreshed every 2 seconds in the background.',
+        response: '{\n  "success": true,\n  "obj": {\n    "cpu": 12.5,\n    "mem": { "current": 2147483648, "total": 8589934592 },\n    "swap": { "current": 0, "total": 4294967296 },\n    "disk": { "current": 53687091200, "total": 268435456000 },\n    "netIO": { "up": 1073741824, "down": 2147483648 },\n    "xray": { "state": "running", "version": "v25.10.31" },\n    "tcpCount": 42,\n    "load": { "load1": 0.5, "load5": 0.3, "load15": 0.2 }\n  }\n}',
       },
       {
         method: 'GET',
@@ -278,7 +282,36 @@ export const sections = [
         path: '/panel/api/server/history/:metric/:bucket',
         summary: 'Aggregated time-series for one metric. Returns an array of {t, v} samples covering the last ~6 hours.',
         params: [
-          { name: 'metric', in: 'path', type: 'string', desc: 'cpu | mem | swap | netIn | netOut | tcpCount | udpCount | load1 | online.' },
+          { name: 'metric', in: 'path', type: 'string', desc: 'cpu | mem | netUp | netDown | online | load1 | load5 | load15.' },
+          { name: 'bucket', in: 'path', type: 'number', desc: 'Bucket size in seconds. Allowed: 2, 30, 60, 120, 180, 300.' },
+        ],
+        response: '{\n  "success": true,\n  "obj": [\n    { "t": 1700000000, "v": 12.5 },\n    { "t": 1700000002, "v": 13.1 }\n  ]\n}',
+      },
+      {
+        method: 'GET',
+        path: '/panel/api/server/xrayMetricsState',
+        summary: 'Xray runtime metrics state — whether the xray config has a `metrics` block, which expvar keys are flowing, and the current snapshot values for each. Returns an empty state when metrics are not configured.',
+      },
+      {
+        method: 'GET',
+        path: '/panel/api/server/xrayMetricsHistory/:metric/:bucket',
+        summary: 'Time-series history for one Xray runtime metric over the last ~6 hours. Same {t, v} shape as /history/:metric/:bucket.',
+        params: [
+          { name: 'metric', in: 'path', type: 'string', desc: 'xrAlloc | xrSys | xrHeapObjects | xrNumGC | xrPauseNs.' },
+          { name: 'bucket', in: 'path', type: 'number', desc: 'Bucket size in seconds. Allowed: 2, 30, 60, 120, 180, 300.' },
+        ],
+      },
+      {
+        method: 'GET',
+        path: '/panel/api/server/xrayObservatory',
+        summary: 'Latest snapshot from the Xray observatory — per-outbound latency, health status, and last-probe time. Only populated when the Xray config has an observatory configured.',
+      },
+      {
+        method: 'GET',
+        path: '/panel/api/server/xrayObservatoryHistory/:tag/:bucket',
+        summary: 'Time-series of observatory probe results for one outbound tag. Same {t, v} shape as the other history endpoints.',
+        params: [
+          { name: 'tag', in: 'path', type: 'string', desc: 'Outbound tag from the observatory config.' },
           { name: 'bucket', in: 'path', type: 'number', desc: 'Bucket size in seconds. Allowed: 2, 30, 60, 120, 180, 300.' },
         ],
       },
@@ -286,6 +319,7 @@ export const sections = [
         method: 'GET',
         path: '/panel/api/server/getXrayVersion',
         summary: 'List Xray binary versions available for install on this host.',
+        response: '{\n  "success": true,\n  "obj": ["v25.10.31", "v25.9.15", "v25.8.1"]\n}',
       },
       {
         method: 'GET',
@@ -295,7 +329,8 @@ export const sections = [
       {
         method: 'GET',
         path: '/panel/api/server/getConfigJson',
-        summary: 'Return the assembled Xray config that’s currently running on this host.',
+        summary: 'Return the assembled Xray config that\u2019s currently running on this host.',
+        response: '{\n  "success": true,\n  "obj": {\n    "log": { "loglevel": "warning" },\n    "inbounds": [...],\n    "outbounds": [...],\n    "routing": { "rules": [...] }\n  }\n}',
       },
       {
         method: 'GET',
@@ -306,26 +341,31 @@ export const sections = [
         method: 'GET',
         path: '/panel/api/server/getNewUUID',
         summary: 'Generate a fresh UUID v4. Convenience helper for client IDs.',
+        response: '{\n  "success": true,\n  "obj": "550e8400-e29b-41d4-a716-446655440000"\n}',
       },
       {
         method: 'GET',
         path: '/panel/api/server/getNewX25519Cert',
         summary: 'Generate a new X25519 keypair for Reality.',
+        response: '{\n  "success": true,\n  "obj": {\n    "privateKey": "uN9qLfV3zH8w...",\n    "publicKey": "5v8xPqR2sM7k..."\n  }\n}',
       },
       {
         method: 'GET',
         path: '/panel/api/server/getNewmldsa65',
         summary: 'Generate a new ML-DSA-65 keypair (post-quantum signature). Returns {privateKey, publicKey, seed}.',
+        response: '{\n  "success": true,\n  "obj": {\n    "privateKey": "mdsa65priv...",\n    "publicKey": "mdsa65pub...",\n    "seed": "random-seed..."\n  }\n}',
       },
       {
         method: 'GET',
         path: '/panel/api/server/getNewmlkem768',
         summary: 'Generate a new ML-KEM-768 keypair (post-quantum KEM). Returns {clientKey, serverKey}.',
+        response: '{\n  "success": true,\n  "obj": {\n    "clientKey": "mlkem768-client...",\n    "serverKey": "mlkem768-server..."\n  }\n}',
       },
       {
         method: 'GET',
         path: '/panel/api/server/getNewVlessEnc',
-        summary: 'Generate VLESS encryption auth options. Returns auths with id, label, decryption, and encryption.',
+        summary: 'Generate VLESS encryption auth options. Returns an auths array each with id, label, encryption, and decryption fields.',
+        response: '{\n  "success": true,\n  "obj": {\n    "auths": [\n      { "id": 0, "label": "Auth #0", "encryption": "aes-256-gcm", "decryption": "" }\n    ]\n  }\n}',
       },
       {
         method: 'POST',
@@ -366,11 +406,12 @@ export const sections = [
       {
         method: 'POST',
         path: '/panel/api/server/logs/:count',
-        summary: 'Return the last N lines of the panel’s own log.',
+        summary: 'Return the last N lines of the panel\u2019s own log.',
         params: [
           { name: 'count', in: 'path', type: 'number', desc: 'Number of trailing log lines.' },
         ],
         body: '{\n  "level": "info",\n  "syslog": false\n}',
+        response: '{\n  "success": true,\n  "obj": "2025/01/01 12:00:00 [INFO] Server started\\n2025/01/01 12:00:01 [INFO] Xray is running"\n}',
       },
       {
         method: 'POST',
@@ -403,6 +444,7 @@ export const sections = [
         method: 'GET',
         path: '/panel/api/nodes/list',
         summary: 'List every configured node with its connection details, health, and last heartbeat patch.',
+        response: '{\n  "success": true,\n  "obj": [\n    {\n      "id": 1,\n      "name": "de-fra-1",\n      "scheme": "https",\n      "host": "node1.example.com",\n      "port": 2053,\n      "status": "online",\n      "cpu": 23.5,\n      "mem": 45.1\n    }\n  ]\n}',
       },
       {
         method: 'GET',
@@ -463,8 +505,8 @@ export const sections = [
         summary: 'Aggregated metric history for a node — same shape as /server/history, scoped to one node.',
         params: [
           { name: 'id', in: 'path', type: 'number', desc: 'Node ID.' },
-          { name: 'metric', in: 'path', type: 'string', desc: 'Metric key (cpu, mem, netIn, …).' },
-          { name: 'bucket', in: 'path', type: 'number', desc: 'Bucket size in seconds.' },
+          { name: 'metric', in: 'path', type: 'string', desc: 'cpu | mem.' },
+          { name: 'bucket', in: 'path', type: 'number', desc: 'Bucket size in seconds. Allowed: 2, 30, 60, 120, 180, 300.' },
         ],
       },
     ],
@@ -534,6 +576,194 @@ export const sections = [
         method: 'GET',
         path: '/panel/api/backuptotgbot',
         summary: 'Send a fresh DB backup to every Telegram chat configured as an admin recipient. No body, no params.',
+      },
+    ],
+  },
+
+  {
+    id: 'settings',
+    title: 'Settings API',
+    description:
+      'Panel configuration, user credentials, and API token management. All endpoints live under /panel/setting and require a logged-in session or Bearer token.',
+    endpoints: [
+      {
+        method: 'POST',
+        path: '/panel/setting/all',
+        summary: 'Return every panel setting: web server, Telegram bot, subscription, security, LDAP. The full JSON blob that the Settings page edits.',
+        response: '{\n  "success": true,\n  "obj": {\n    "webPort": 2053,\n    "webCertFile": "",\n    "webKeyFile": "",\n    "webBasePath": "/",\n    "subPort": 10882,\n    "subPath": "/sub/",\n    "tgBotEnable": false,\n    "tgBotToken": "",\n    ...\n  }\n}',
+      },
+      {
+        method: 'POST',
+        path: '/panel/setting/defaultSettings',
+        summary: 'Return the computed default settings based on the request host. Useful to preview what a fresh install would use.',
+      },
+      {
+        method: 'POST',
+        path: '/panel/setting/update',
+        summary: 'Persist every setting at once. The body mirrors the shape returned by /all. Invalid values (bad ports, missing cert pairs, etc.) are rejected before write.',
+        body: '{\n  "webPort": 2053,\n  "webBasePath": "/",\n  "subPort": 10882,\n  "subPath": "/sub/",\n  "tgBotEnable": false,\n  ...\n}',
+      },
+      {
+        method: 'POST',
+        path: '/panel/setting/updateUser',
+        summary: 'Change the panel admin username and password. Requires the current credentials for verification. The session is refreshed with the new values on success.',
+        params: [
+          { name: 'oldUsername', in: 'body', type: 'string', desc: 'Current admin username.' },
+          { name: 'oldPassword', in: 'body', type: 'string', desc: 'Current admin password.' },
+          { name: 'newUsername', in: 'body', type: 'string', desc: 'Desired new username.' },
+          { name: 'newPassword', in: 'body', type: 'string', desc: 'Desired new password.' },
+        ],
+        body: '{\n  "oldUsername": "admin",\n  "oldPassword": "admin",\n  "newUsername": "newadmin",\n  "newPassword": "newpass"\n}',
+      },
+      {
+        method: 'POST',
+        path: '/panel/setting/restartPanel',
+        summary: 'Restart the entire 3x-ui process after a 3-second grace period. The connection drops immediately; the panel comes back online ~5-10 seconds later.',
+      },
+      {
+        method: 'GET',
+        path: '/panel/setting/getDefaultJsonConfig',
+        summary: 'Return the built-in default Xray JSON config template that ships with this panel version.',
+      },
+      {
+        method: 'GET',
+        path: '/panel/setting/getApiToken',
+        summary: 'Return the current API Bearer token. The token is auto-generated on first read so existing installs upgrade transparently.',
+        response: '{\n  "success": true,\n  "obj": "abcdef-12345-..."\n}',
+      },
+      {
+        method: 'POST',
+        path: '/panel/setting/regenerateApiToken',
+        summary: 'Rotate the API Bearer token. Any remote central panel that cached the old value will start failing heartbeats until updated with the new token.',
+        response: '{\n  "success": true,\n  "obj": "new-token-string"\n}',
+      },
+    ],
+  },
+
+  {
+    id: 'xraySettings',
+    title: 'Xray Settings API',
+    description:
+      'Xray configuration template, outbound management, Warp/Nord integration, and config testing. All endpoints under /panel/xray.',
+    endpoints: [
+      {
+        method: 'POST',
+        path: '/panel/xray/',
+        summary: 'Return the Xray config template (JSON string), available inbound tags, client reverse tags, and the configured outbound test URL in one response.',
+        response: '{\n  "success": true,\n  "obj": {\n    "xraySetting": "{...raw xray config...}",\n    "inboundTags": "[\"inbound-443\"]",\n    "clientReverseTags": "[]",\n    "outboundTestUrl": "https://www.google.com/generate_204"\n  }\n}',
+      },
+      {
+        method: 'GET',
+        path: '/panel/xray/getDefaultJsonConfig',
+        summary: 'Return the built-in default Xray config shipped with the panel (identical to /panel/setting/getDefaultJsonConfig).',
+      },
+      {
+        method: 'GET',
+        path: '/panel/xray/getOutboundsTraffic',
+        summary: 'Return traffic statistics for every outbound. Each outbound shows up/down/total counters.',
+      },
+      {
+        method: 'GET',
+        path: '/panel/xray/getXrayResult',
+        summary: 'Return the most recent Xray process stdout/stderr output. Useful to check for startup errors or runtime warnings.',
+      },
+      {
+        method: 'POST',
+        path: '/panel/xray/update',
+        summary: 'Save the Xray JSON config template and optionally the outbound test URL. Both are sent as form fields.',
+        params: [
+          { name: 'xraySetting', in: 'body (form)', type: 'string', desc: 'Full Xray JSON config template.' },
+          { name: 'outboundTestUrl', in: 'body (form)', type: 'string', desc: 'URL used for outbound reachability tests. Defaults to https://www.google.com/generate_204.' },
+        ],
+      },
+      {
+        method: 'POST',
+        path: '/panel/xray/warp/:action',
+        summary: 'Manage Cloudflare Warp integration. The action parameter selects the operation.',
+        params: [
+          { name: 'action', in: 'path', type: 'string', desc: 'data — return Warp stats (quota, remaining). del — delete Warp data. config — return current Warp config. reg — register a new Warp endpoint (sends privateKey, publicKey). license — set a Warp+ license key (sends license).' },
+          { name: 'privateKey', in: 'body (form)', type: 'string', desc: 'Required when action=reg.' },
+          { name: 'publicKey', in: 'body (form)', type: 'string', desc: 'Required when action=reg.' },
+          { name: 'license', in: 'body (form)', type: 'string', desc: 'Required when action=license.' },
+        ],
+      },
+      {
+        method: 'POST',
+        path: '/panel/xray/nord/:action',
+        summary: 'Manage NordVPN integration. The action parameter selects the operation.',
+        params: [
+          { name: 'action', in: 'path', type: 'string', desc: 'countries — list available countries. servers — list servers in a country (sends countryId). reg — get NordVPN credentials (sends token). setKey — store NordVPN API key (sends key). data — return current NordVPN connection data. del — delete NordVPN data.' },
+          { name: 'countryId', in: 'body (form)', type: 'string', desc: 'Required when action=servers.' },
+          { name: 'token', in: 'body (form)', type: 'string', desc: 'Required when action=reg.' },
+          { name: 'key', in: 'body (form)', type: 'string', desc: 'Required when action=setKey.' },
+        ],
+      },
+      {
+        method: 'POST',
+        path: '/panel/xray/resetOutboundsTraffic',
+        summary: 'Reset traffic counters for a specific outbound by tag.',
+        params: [
+          { name: 'tag', in: 'body (form)', type: 'string', desc: 'Outbound tag to reset (e.g. "proxy", "direct").' },
+        ],
+        body: 'tag=proxy',
+      },
+      {
+        method: 'POST',
+        path: '/panel/xray/testOutbound',
+        summary: 'Test an outbound configuration. Sends the outbound JSON (required), optionally all outbounds (to resolve sockopt.dialerProxy dependencies), and a mode flag.',
+        params: [
+          { name: 'outbound', in: 'body (form)', type: 'string', desc: 'JSON-encoded single outbound to test (required).' },
+          { name: 'allOutbounds', in: 'body (form)', type: 'string', desc: 'JSON array of all outbounds — used to resolve dialerProxy chains.' },
+          { name: 'mode', in: 'body (form)', type: 'string', desc: '"tcp" for a fast dial-only probe (parallel-safe). Default/empty uses a full HTTP probe through a temp xray instance.' },
+        ],
+        body: 'outbound={"protocol":"freedom","settings":{}}&mode=tcp',
+      },
+    ],
+  },
+
+  {
+    id: 'subscription',
+    title: 'Subscription Server',
+    description:
+      'A separate HTTP/HTTPS server that serves proxy subscription links (standard, JSON, and Clash) to clients. The server listens on its own port (default 10882) and is configured in Settings → Subscription. Paths are configurable; defaults are shown below.',
+    endpoints: [
+      {
+        method: 'GET',
+        path: '/{subPath}:subid',
+        summary: 'Return base64-encoded subscription links for all enabled clients matching the subscription ID. When the request has an Accept: text/html header or ?html=1, renders a styled info page instead. Response headers include Subscription-Userinfo (traffic/expiry), Profile-Title, Profile-Web-Page-Url, Support-Url, and Profile-Update-Interval. Default path: /sub/:subid.',
+        params: [
+          { name: 'subid', in: 'path', type: 'string', desc: 'Client subscription ID.' },
+        ],
+      },
+      {
+        method: 'GET',
+        path: '/{jsonPath}:subid',
+        summary: 'Return subscription as a JSON array of proxy configs (one per enabled client). Only when JSON subscription is enabled in settings. Default path: /json/:subid.',
+        params: [
+          { name: 'subid', in: 'path', type: 'string', desc: 'Client subscription ID.' },
+        ],
+      },
+      {
+        method: 'GET',
+        path: '/{clashPath}:subid',
+        summary: 'Return subscription as a Clash/Mihomo-compatible YAML config. Only when Clash subscription is enabled in settings. Default path: /clash/:subid.',
+        params: [
+          { name: 'subid', in: 'path', type: 'string', desc: 'Client subscription ID.' },
+        ],
+      },
+    ],
+  },
+
+  {
+    id: 'websocket',
+    title: 'WebSocket',
+    description:
+      'Real-time status updates via WebSocket. Connect once to receive a stream of server state without polling.',
+    endpoints: [
+      {
+        method: 'GET',
+        path: '/ws',
+        summary: 'Upgrade an HTTP connection to WebSocket for real-time server status, Xray state, and notification events. Requires an authenticated session cookie (Bearer token auth is not supported for WebSocket). The server pushes JSON messages on every 2-second status tick.',
       },
     ],
   },

--- a/frontend/src/pages/api-docs/endpoints.js
+++ b/frontend/src/pages/api-docs/endpoints.js
@@ -1,3 +1,28 @@
+export function safeInlineHtml(input) {
+  if (!input) return '';
+  const escape = (s) => s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+  const open = '<code>';
+  const close = '</code>';
+  let out = '';
+  let i = 0;
+  while (i < input.length) {
+    const oIdx = input.indexOf(open, i);
+    if (oIdx === -1) {
+      out += escape(input.slice(i));
+      break;
+    }
+    out += escape(input.slice(i, oIdx));
+    const cIdx = input.indexOf(close, oIdx + open.length);
+    if (cIdx === -1) {
+      out += escape(input.slice(oIdx));
+      break;
+    }
+    out += '<code>' + escape(input.slice(oIdx + open.length, cIdx)) + '</code>';
+    i = cIdx + close.length;
+  }
+  return out;
+}
+
 export const sections = [
   {
     id: 'auth',
@@ -797,8 +822,13 @@ export const sections = [
     id: 'websocket',
     title: 'WebSocket',
     description:
-      'Real-time status updates via WebSocket. Connect once at <code>ws://&lt;panel&gt;/ws</code> to receive a stream of JSON messages without polling. Requires an authenticated session cookie (Bearer token auth is not supported). Each message has a <code>type</code> field that identifies the payload shape.',
+      'Real-time status updates via WebSocket. Connect once at <code>ws://<panel>/ws</code> to receive a stream of JSON messages without polling. Requires an authenticated session cookie (Bearer token auth is not supported). Each message has a <code>type</code> field that identifies the payload shape.',
     endpoints: [
+      {
+        method: 'GET',
+        path: '/ws',
+        summary: 'Upgrade an HTTP connection to a WebSocket. Requires an authenticated session cookie (Bearer token auth is not supported here). Returns 101 Switching Protocols on success. The server then pushes JSON messages described below.',
+      },
       {
         method: 'WS',
         path: '→ type: status',

--- a/frontend/src/pages/api-docs/endpoints.js
+++ b/frontend/src/pages/api-docs/endpoints.js
@@ -17,6 +17,8 @@ export const sections = [
         body: '{\n  "username": "admin",\n  "password": "admin",\n  "twoFactorCode": "123456"\n}',
         response:
           '{\n  "success": true,\n  "msg": "Logged in successfully"\n}',
+        errorResponse:
+          '{\n  "success": false,\n  "msg": "Wrong username or password"\n}',
       },
       {
         method: 'GET',
@@ -84,6 +86,8 @@ export const sections = [
         summary: 'Create a new inbound. Send the full inbound payload (protocol, port, settings JSON, streamSettings JSON, sniffing JSON, remark, expiryTime, total, enable).',
         body:
           '{\n  "enable": true,\n  "remark": "VLESS-443",\n  "listen": "",\n  "port": 443,\n  "protocol": "vless",\n  "expiryTime": 0,\n  "total": 0,\n  "settings": "{\\"clients\\":[{\\"id\\":\\"...\\",\\"email\\":\\"user1\\"}],\\"decryption\\":\\"none\\",\\"fallbacks\\":[]}",\n  "streamSettings": "{\\"network\\":\\"tcp\\",\\"security\\":\\"reality\\",\\"realitySettings\\":{...}}",\n  "sniffing": "{\\"enabled\\":true,\\"destOverride\\":[\\"http\\",\\"tls\\"]}"\n}',
+        errorResponse:
+          '{\n  "success": false,\n  "msg": "Port 443 is already in use"\n}',
       },
       {
         method: 'POST',
@@ -371,11 +375,15 @@ export const sections = [
         method: 'POST',
         path: '/panel/api/server/stopXrayService',
         summary: 'Stop the Xray binary. All proxies go offline immediately.',
+        errorResponse:
+          '{\n  "success": false,\n  "msg": "Xray is not running"\n}',
       },
       {
         method: 'POST',
         path: '/panel/api/server/restartXrayService',
         summary: 'Reload Xray with the current config. Typically required after structural inbound or routing changes.',
+        errorResponse:
+          '{\n  "success": false,\n  "msg": "Xray config is invalid: ..."\n}',
       },
       {
         method: 'POST',
@@ -394,6 +402,10 @@ export const sections = [
         method: 'POST',
         path: '/panel/api/server/updateGeofile',
         summary: 'Refresh the default GeoIP / GeoSite data files. Body can include a fileName, or use the /:fileName variant.',
+        params: [
+          { name: 'fileName', in: 'body (form)', type: 'string', desc: 'Filename to update (e.g. geoip.dat, geosite.dat). Omit to update all defaults.' },
+        ],
+        body: 'fileName=geoip.dat',
       },
       {
         method: 'POST',
@@ -419,17 +431,31 @@ export const sections = [
         summary: 'Return the last N lines of the Xray process log.',
         params: [
           { name: 'count', in: 'path', type: 'number', desc: 'Number of trailing log lines.' },
+          { name: 'filter', in: 'body (form)', type: 'string', desc: 'Keyword filter — only lines containing this string.' },
+          { name: 'showDirect', in: 'body (form)', type: 'string', desc: '"true" to include direct (freedom) traffic lines.' },
+          { name: 'showBlocked', in: 'body (form)', type: 'string', desc: '"true" to include blocked (blackhole) traffic lines.' },
+          { name: 'showProxy', in: 'body (form)', type: 'string', desc: '"true" to include proxy traffic lines.' },
         ],
+        body: 'filter=error&showDirect=false&showBlocked=true&showProxy=true',
+        response: '{\n  "success": true,\n  "obj": "2025/01/01 12:00:00 rejected  vless  proxy  example.com  reason: no valid user\\n2025/01/01 12:00:01 direct  freedom  ok"\n}',
       },
       {
         method: 'POST',
         path: '/panel/api/server/importDB',
         summary: 'Restore the panel DB from an uploaded SQLite file (multipart form, field name "db"). The panel restarts after restore. Destructive.',
+        params: [
+          { name: 'db', in: 'body (multipart)', type: 'file', desc: 'SQLite database file to upload.' },
+        ],
       },
       {
         method: 'POST',
         path: '/panel/api/server/getNewEchCert',
-        summary: 'Generate a new ECH (Encrypted Client Hello) keypair. Body picks the algorithm.',
+        summary: 'Generate a new ECH (Encrypted Client Hello) keypair and config list for the given SNI.',
+        params: [
+          { name: 'sni', in: 'body (form)', type: 'string', desc: 'Server Name Indication to generate the ECH config for.' },
+        ],
+        body: 'sni=example.com',
+        response: '{\n  "success": true,\n  "obj": {\n    "echKeySet": "...",\n    "echServerKeys": [...],\n    "echConfigList": "..."\n  }\n}',
       },
     ],
   },
@@ -464,10 +490,11 @@ export const sections = [
       {
         method: 'POST',
         path: '/panel/api/nodes/update/:id',
-        summary: 'Replace a node’s connection details. Same body shape as /add.',
+        summary: 'Replace a node\u2019s connection details. Same body shape as /add.',
         params: [
           { name: 'id', in: 'path', type: 'number', desc: 'Node ID.' },
         ],
+        body: '{\n  "name": "de-fra-1",\n  "scheme": "https",\n  "host": "node1.example.com",\n  "port": 2053,\n  "basePath": "/",\n  "apiToken": "abcdef..."\n}',
       },
       {
         method: 'POST',
@@ -490,6 +517,8 @@ export const sections = [
         method: 'POST',
         path: '/panel/api/nodes/test',
         summary: 'Probe a node without saving it. Uses the body as connection details and returns whether the handshake succeeds.',
+        body: '{\n  "scheme": "https",\n  "host": "node1.example.com",\n  "port": 2053,\n  "basePath": "/",\n  "apiToken": "abcdef..."\n}',
+        response: '{\n  "success": true,\n  "obj": {\n    "status": "online",\n    "cpu": 12.5,\n    "mem": 45.2\n  }\n}',
       },
       {
         method: 'POST',
@@ -725,12 +754,22 @@ export const sections = [
     id: 'subscription',
     title: 'Subscription Server',
     description:
-      'A separate HTTP/HTTPS server that serves proxy subscription links (standard, JSON, and Clash) to clients. The server listens on its own port (default 10882) and is configured in Settings → Subscription. Paths are configurable; defaults are shown below.',
+      'A separate HTTP/HTTPS server that serves proxy subscription links (standard, JSON, and Clash) to clients. The server listens on its own port (default 10882) and is configured in Settings → Subscription. Paths are configurable; defaults are shown below. All subscription endpoints set response headers for client apps to read traffic/expiry info.',
+    subHeader: [
+      { name: 'Subscription-Userinfo', desc: 'Traffic and expiry: <code>upload=N; download=N; total=N; expire=TS</code>' },
+      { name: 'Profile-Title', desc: 'Base64-encoded subscription display name' },
+      { name: 'Profile-Web-Page-Url', desc: 'Link to the subscription info page' },
+      { name: 'Support-Url', desc: 'Support contact URL configured in settings' },
+      { name: 'Profile-Update-Interval', desc: 'Suggested polling interval in minutes (e.g. <code>10</code>)' },
+      { name: 'Announce', desc: 'Base64-encoded announcement string' },
+      { name: 'Routing-Enable', desc: '<code>true</code> or <code>false</code> — whether routing rules are included' },
+      { name: 'Routing', desc: 'Global routing rules for client apps that support them (e.g. Happ)' },
+    ],
     endpoints: [
       {
         method: 'GET',
         path: '/{subPath}:subid',
-        summary: 'Return base64-encoded subscription links for all enabled clients matching the subscription ID. When the request has an Accept: text/html header or ?html=1, renders a styled info page instead. Response headers include Subscription-Userinfo (traffic/expiry), Profile-Title, Profile-Web-Page-Url, Support-Url, and Profile-Update-Interval. Default path: /sub/:subid.',
+        summary: 'Return base64-encoded subscription links for all enabled clients matching the subscription ID. When the request has an Accept: text/html header or ?html=1, renders a styled info page instead. Default path: /sub/:subid.',
         params: [
           { name: 'subid', in: 'path', type: 'string', desc: 'Client subscription ID.' },
         ],
@@ -758,12 +797,31 @@ export const sections = [
     id: 'websocket',
     title: 'WebSocket',
     description:
-      'Real-time status updates via WebSocket. Connect once to receive a stream of server state without polling.',
+      'Real-time status updates via WebSocket. Connect once at <code>ws://&lt;panel&gt;/ws</code> to receive a stream of JSON messages without polling. Requires an authenticated session cookie (Bearer token auth is not supported). Each message has a <code>type</code> field that identifies the payload shape.',
     endpoints: [
       {
-        method: 'GET',
-        path: '/ws',
-        summary: 'Upgrade an HTTP connection to WebSocket for real-time server status, Xray state, and notification events. Requires an authenticated session cookie (Bearer token auth is not supported for WebSocket). The server pushes JSON messages on every 2-second status tick.',
+        method: 'WS',
+        path: '→ type: status',
+        summary: 'Server health snapshot pushed every 2 seconds. Contains CPU, memory, swap, disk, network IO, load, and Xray state — same shape as <code>GET /panel/api/server/status</code>.',
+        response: '{\n  "type": "status",\n  "data": { "cpu": 12.5, "mem": { "current": 2147483648, "total": 8589934592 }, "xray": { "state": "running" } }\n}',
+      },
+      {
+        method: 'WS',
+        path: '→ type: xrayState',
+        summary: 'Xray process state change. Fired when Xray starts, stops, or encounters an error.',
+        response: '{\n  "type": "xrayState",\n  "data": "running"\n}',
+      },
+      {
+        method: 'WS',
+        path: '→ type: notification',
+        summary: 'In-panel toast notification. Fired on Xray stop/restart, DB import, panel restart, etc.',
+        response: '{\n  "type": "notification",\n  "title": "Xray service restarted",\n  "body": "Xray has been restarted successfully",\n  "severity": "success"\n}',
+      },
+      {
+        method: 'WS',
+        path: '→ type: invalidate',
+        summary: 'Instructs the UI to re-fetch a resource. Fired when another admin session modifies data (e.g. toggling inbound enable).',
+        response: '{\n  "type": "invalidate",\n  "resource": "inbounds"\n}',
       },
     ],
   },
@@ -775,4 +833,5 @@ export const methodColors = {
   PUT: 'orange',
   PATCH: 'orange',
   DELETE: 'red',
+  WS: 'purple',
 };

--- a/web/controller/api_docs_test.go
+++ b/web/controller/api_docs_test.go
@@ -1,0 +1,265 @@
+package controller
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+type routeDef struct {
+	Method string
+	Path   string
+}
+
+// expectedRoutes lists every route documented in frontend/src/pages/api-docs/endpoints.js.
+// Keep this in sync when adding new endpoints to the docs.
+var expectedRoutes = []routeDef{
+	// Authentication — no prefix
+	{Method: "POST", Path: "/login"},
+	{Method: "GET", Path: "/logout"},
+	{Method: "GET", Path: "/csrf-token"},
+	{Method: "POST", Path: "/getTwoFactorEnable"},
+
+	// Inbounds API — prefix /panel/api/inbounds
+	{Method: "GET", Path: "/panel/api/inbounds/list"},
+	{Method: "GET", Path: "/panel/api/inbounds/get/:id"},
+	{Method: "GET", Path: "/panel/api/inbounds/getClientTraffics/:email"},
+	{Method: "GET", Path: "/panel/api/inbounds/getClientTrafficsById/:id"},
+	{Method: "GET", Path: "/panel/api/inbounds/getSubLinks/:subId"},
+	{Method: "GET", Path: "/panel/api/inbounds/getClientLinks/:id/:email"},
+	{Method: "POST", Path: "/panel/api/inbounds/add"},
+	{Method: "POST", Path: "/panel/api/inbounds/del/:id"},
+	{Method: "POST", Path: "/panel/api/inbounds/update/:id"},
+	{Method: "POST", Path: "/panel/api/inbounds/setEnable/:id"},
+	{Method: "POST", Path: "/panel/api/inbounds/clientIps/:email"},
+	{Method: "POST", Path: "/panel/api/inbounds/clearClientIps/:email"},
+	{Method: "POST", Path: "/panel/api/inbounds/addClient"},
+	{Method: "POST", Path: "/panel/api/inbounds/:id/copyClients"},
+	{Method: "POST", Path: "/panel/api/inbounds/:id/delClient/:clientId"},
+	{Method: "POST", Path: "/panel/api/inbounds/updateClient/:clientId"},
+	{Method: "POST", Path: "/panel/api/inbounds/:id/resetClientTraffic/:email"},
+	{Method: "POST", Path: "/panel/api/inbounds/resetAllTraffics"},
+	{Method: "POST", Path: "/panel/api/inbounds/resetAllClientTraffics/:id"},
+	{Method: "POST", Path: "/panel/api/inbounds/delDepletedClients/:id"},
+	{Method: "POST", Path: "/panel/api/inbounds/import"},
+	{Method: "POST", Path: "/panel/api/inbounds/onlines"},
+	{Method: "POST", Path: "/panel/api/inbounds/lastOnline"},
+	{Method: "POST", Path: "/panel/api/inbounds/updateClientTraffic/:email"},
+	{Method: "POST", Path: "/panel/api/inbounds/:id/delClientByEmail/:email"},
+
+	// Server API — prefix /panel/api/server
+	{Method: "GET", Path: "/panel/api/server/status"},
+	{Method: "GET", Path: "/panel/api/server/cpuHistory/:bucket"},
+	{Method: "GET", Path: "/panel/api/server/history/:metric/:bucket"},
+	{Method: "GET", Path: "/panel/api/server/xrayMetricsState"},
+	{Method: "GET", Path: "/panel/api/server/xrayMetricsHistory/:metric/:bucket"},
+	{Method: "GET", Path: "/panel/api/server/xrayObservatory"},
+	{Method: "GET", Path: "/panel/api/server/xrayObservatoryHistory/:tag/:bucket"},
+	{Method: "GET", Path: "/panel/api/server/getXrayVersion"},
+	{Method: "GET", Path: "/panel/api/server/getPanelUpdateInfo"},
+	{Method: "GET", Path: "/panel/api/server/getConfigJson"},
+	{Method: "GET", Path: "/panel/api/server/getDb"},
+	{Method: "GET", Path: "/panel/api/server/getNewUUID"},
+	{Method: "GET", Path: "/panel/api/server/getNewX25519Cert"},
+	{Method: "GET", Path: "/panel/api/server/getNewmldsa65"},
+	{Method: "GET", Path: "/panel/api/server/getNewmlkem768"},
+	{Method: "GET", Path: "/panel/api/server/getNewVlessEnc"},
+	{Method: "POST", Path: "/panel/api/server/stopXrayService"},
+	{Method: "POST", Path: "/panel/api/server/restartXrayService"},
+	{Method: "POST", Path: "/panel/api/server/installXray/:version"},
+	{Method: "POST", Path: "/panel/api/server/updatePanel"},
+	{Method: "POST", Path: "/panel/api/server/updateGeofile"},
+	{Method: "POST", Path: "/panel/api/server/updateGeofile/:fileName"},
+	{Method: "POST", Path: "/panel/api/server/logs/:count"},
+	{Method: "POST", Path: "/panel/api/server/xraylogs/:count"},
+	{Method: "POST", Path: "/panel/api/server/importDB"},
+	{Method: "POST", Path: "/panel/api/server/getNewEchCert"},
+
+	// Nodes API — prefix /panel/api/nodes
+	{Method: "GET", Path: "/panel/api/nodes/list"},
+	{Method: "GET", Path: "/panel/api/nodes/get/:id"},
+	{Method: "POST", Path: "/panel/api/nodes/add"},
+	{Method: "POST", Path: "/panel/api/nodes/update/:id"},
+	{Method: "POST", Path: "/panel/api/nodes/del/:id"},
+	{Method: "POST", Path: "/panel/api/nodes/setEnable/:id"},
+	{Method: "POST", Path: "/panel/api/nodes/test"},
+	{Method: "POST", Path: "/panel/api/nodes/probe/:id"},
+	{Method: "GET", Path: "/panel/api/nodes/history/:id/:metric/:bucket"},
+
+	// Custom Geo API — prefix /panel/api/custom-geo
+	{Method: "GET", Path: "/panel/api/custom-geo/list"},
+	{Method: "GET", Path: "/panel/api/custom-geo/aliases"},
+	{Method: "POST", Path: "/panel/api/custom-geo/add"},
+	{Method: "POST", Path: "/panel/api/custom-geo/update/:id"},
+	{Method: "POST", Path: "/panel/api/custom-geo/delete/:id"},
+	{Method: "POST", Path: "/panel/api/custom-geo/download/:id"},
+	{Method: "POST", Path: "/panel/api/custom-geo/update-all"},
+
+	// Backup — prefix /panel/api
+	{Method: "GET", Path: "/panel/api/backuptotgbot"},
+
+	// Settings API — prefix /panel/setting
+	{Method: "POST", Path: "/panel/setting/all"},
+	{Method: "POST", Path: "/panel/setting/defaultSettings"},
+	{Method: "POST", Path: "/panel/setting/update"},
+	{Method: "POST", Path: "/panel/setting/updateUser"},
+	{Method: "POST", Path: "/panel/setting/restartPanel"},
+	{Method: "GET", Path: "/panel/setting/getDefaultJsonConfig"},
+	{Method: "GET", Path: "/panel/setting/getApiToken"},
+	{Method: "POST", Path: "/panel/setting/regenerateApiToken"},
+
+	// Xray Settings API — prefix /panel/xray
+	{Method: "POST", Path: "/panel/xray/"},
+	{Method: "GET", Path: "/panel/xray/getDefaultJsonConfig"},
+	{Method: "GET", Path: "/panel/xray/getOutboundsTraffic"},
+	{Method: "GET", Path: "/panel/xray/getXrayResult"},
+	{Method: "POST", Path: "/panel/xray/update"},
+	{Method: "POST", Path: "/panel/xray/warp/:action"},
+	{Method: "POST", Path: "/panel/xray/nord/:action"},
+	{Method: "POST", Path: "/panel/xray/resetOutboundsTraffic"},
+	{Method: "POST", Path: "/panel/xray/testOutbound"},
+
+	// WebSocket
+	{Method: "GET", Path: "/ws"},
+
+	// Subscription server — separate server (not on main Gin engine)
+	// Documented in Subscription Server section but not tested here
+	// because the sub server is a separate Gin engine.
+	// {Method: "GET", Path: "/sub/:subid"},
+	// {Method: "GET", Path: "/json/:subid"},
+	// {Method: "GET", Path: "/clash/:subid"},
+}
+
+// routePattern matches route registrations like g.GET("/path", handler) or api.GET("/path", handler)
+var routePattern = regexp.MustCompile(`\b(g|api)\.(GET|POST|PUT|DELETE|PATCH|HEAD|OPTIONS)\("([^"]+)"`)
+
+func TestAPIRoutesDocumented(t *testing.T) {
+	// Build a set of documented routes for fast lookup
+	docSet := make(map[string]bool)
+	for _, r := range expectedRoutes {
+		key := r.Method + " " + r.Path
+		if docSet[key] {
+			t.Errorf("Duplicate documented route: %s", key)
+		}
+		docSet[key] = true
+	}
+
+	// Walk the web directory to find all Go files with route definitions
+	controllerDir, err := filepath.Abs(".")
+	if err != nil {
+		t.Fatalf("failed to get current dir: %v", err)
+	}
+
+	// Collect all routes from the controller files
+	var allRoutes []routeDef
+
+	entries, err := os.ReadDir(controllerDir)
+	if err != nil {
+		t.Fatalf("failed to read controller dir: %v", err)
+	}
+
+	for _, entry := range entries {
+		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".go") || strings.HasSuffix(entry.Name(), "_test.go") {
+			continue
+		}
+		data, err := os.ReadFile(filepath.Join(controllerDir, entry.Name()))
+		if err != nil {
+			t.Fatalf("failed to read %s: %v", entry.Name(), err)
+		}
+		src := string(data)
+
+		// Determine the base path for this file based on its initRouter patterns
+		basePath := ""
+		switch entry.Name() {
+		case "index.go":
+			basePath = ""
+		case "xui.go":
+			basePath = "/panel"
+		case "api.go":
+			basePath = "/panel/api"
+		case "inbound.go":
+			basePath = "/panel/api/inbounds"
+		case "server.go":
+			basePath = "/panel/api/server"
+		case "node.go":
+			basePath = "/panel/api/nodes"
+		case "setting.go":
+			basePath = "/panel/setting"
+		case "xray_setting.go":
+			basePath = "/panel/xray"
+		case "custom_geo.go":
+			basePath = "/panel/api/custom-geo"
+		case "websocket.go":
+			basePath = ""
+		}
+
+		// Find all route registrations
+		matches := routePattern.FindAllStringSubmatch(src, -1)
+		for _, m := range matches {
+			method := m[2]
+			path := strings.TrimSpace(m[3])
+			if basePath == "" {
+				allRoutes = append(allRoutes, routeDef{Method: method, Path: path})
+			} else {
+				fullPath := basePath + path
+				allRoutes = append(allRoutes, routeDef{Method: method, Path: fullPath})
+			}
+		}
+	}
+
+	// The WebSocket route /ws is registered in web/web.go (not a controller file)
+	allRoutes = append(allRoutes, routeDef{Method: "GET", Path: "/ws"})
+
+	// Check each source route against the documented set
+	missingFromDocs := 0
+	foundInDoc := 0
+	sourceSet := make(map[string]bool)
+
+	for _, r := range allRoutes {
+		key := r.Method + " " + r.Path
+		// Skip SPA page routes (these are UI pages, not API endpoints)
+		spaPages := map[string]bool{
+			"/": true, "/panel/": true, "/panel/inbounds": true,
+			"/panel/nodes": true, "/panel/settings": true,
+			"/panel/xray": true, "/panel/api-docs": true,
+		}
+		if spaPages[r.Path] {
+			continue
+		}
+		// Skip /panel/csrf-token (documented under auth)
+		if r.Path == "/panel/csrf-token" {
+			continue
+		}
+		// Skip Chrome DevTools route
+		if strings.Contains(r.Path, ".well-known") {
+			continue
+		}
+
+		sourceSet[key] = true
+		if docSet[key] {
+			foundInDoc++
+		} else {
+			missingFromDocs++
+			t.Errorf("Route not documented in endpoints.js: %s %s", r.Method, r.Path)
+		}
+	}
+
+	// Report undocumented documented routes
+	extraInDocs := 0
+	for _, r := range expectedRoutes {
+		key := r.Method + " " + r.Path
+		if !sourceSet[key] {
+			extraInDocs++
+			t.Logf("Documented route not found in source (perhaps deleted or moved): %s %s", r.Method, r.Path)
+		}
+	}
+
+	t.Logf("Routes found in source: %d, documented: %d, matching: %d, missing: %d, extra in docs: %d",
+		len(sourceSet), len(docSet), foundInDoc, missingFromDocs, extraInDocs)
+
+	if missingFromDocs > 0 {
+		t.Errorf("Found %d undocumented route(s). Update endpoints.js to match.", missingFromDocs)
+	}
+}

--- a/web/controller/api_docs_test.go
+++ b/web/controller/api_docs_test.go
@@ -13,146 +13,52 @@ type routeDef struct {
 	Path   string
 }
 
-// expectedRoutes lists every route documented in frontend/src/pages/api-docs/endpoints.js.
-// Keep this in sync when adding new endpoints to the docs.
-var expectedRoutes = []routeDef{
-	// Authentication — no prefix
-	{Method: "POST", Path: "/login"},
-	{Method: "GET", Path: "/logout"},
-	{Method: "GET", Path: "/csrf-token"},
-	{Method: "POST", Path: "/getTwoFactorEnable"},
-
-	// Inbounds API — prefix /panel/api/inbounds
-	{Method: "GET", Path: "/panel/api/inbounds/list"},
-	{Method: "GET", Path: "/panel/api/inbounds/get/:id"},
-	{Method: "GET", Path: "/panel/api/inbounds/getClientTraffics/:email"},
-	{Method: "GET", Path: "/panel/api/inbounds/getClientTrafficsById/:id"},
-	{Method: "GET", Path: "/panel/api/inbounds/getSubLinks/:subId"},
-	{Method: "GET", Path: "/panel/api/inbounds/getClientLinks/:id/:email"},
-	{Method: "POST", Path: "/panel/api/inbounds/add"},
-	{Method: "POST", Path: "/panel/api/inbounds/del/:id"},
-	{Method: "POST", Path: "/panel/api/inbounds/update/:id"},
-	{Method: "POST", Path: "/panel/api/inbounds/setEnable/:id"},
-	{Method: "POST", Path: "/panel/api/inbounds/clientIps/:email"},
-	{Method: "POST", Path: "/panel/api/inbounds/clearClientIps/:email"},
-	{Method: "POST", Path: "/panel/api/inbounds/addClient"},
-	{Method: "POST", Path: "/panel/api/inbounds/:id/copyClients"},
-	{Method: "POST", Path: "/panel/api/inbounds/:id/delClient/:clientId"},
-	{Method: "POST", Path: "/panel/api/inbounds/updateClient/:clientId"},
-	{Method: "POST", Path: "/panel/api/inbounds/:id/resetClientTraffic/:email"},
-	{Method: "POST", Path: "/panel/api/inbounds/resetAllTraffics"},
-	{Method: "POST", Path: "/panel/api/inbounds/resetAllClientTraffics/:id"},
-	{Method: "POST", Path: "/panel/api/inbounds/delDepletedClients/:id"},
-	{Method: "POST", Path: "/panel/api/inbounds/import"},
-	{Method: "POST", Path: "/panel/api/inbounds/onlines"},
-	{Method: "POST", Path: "/panel/api/inbounds/lastOnline"},
-	{Method: "POST", Path: "/panel/api/inbounds/updateClientTraffic/:email"},
-	{Method: "POST", Path: "/panel/api/inbounds/:id/delClientByEmail/:email"},
-
-	// Server API — prefix /panel/api/server
-	{Method: "GET", Path: "/panel/api/server/status"},
-	{Method: "GET", Path: "/panel/api/server/cpuHistory/:bucket"},
-	{Method: "GET", Path: "/panel/api/server/history/:metric/:bucket"},
-	{Method: "GET", Path: "/panel/api/server/xrayMetricsState"},
-	{Method: "GET", Path: "/panel/api/server/xrayMetricsHistory/:metric/:bucket"},
-	{Method: "GET", Path: "/panel/api/server/xrayObservatory"},
-	{Method: "GET", Path: "/panel/api/server/xrayObservatoryHistory/:tag/:bucket"},
-	{Method: "GET", Path: "/panel/api/server/getXrayVersion"},
-	{Method: "GET", Path: "/panel/api/server/getPanelUpdateInfo"},
-	{Method: "GET", Path: "/panel/api/server/getConfigJson"},
-	{Method: "GET", Path: "/panel/api/server/getDb"},
-	{Method: "GET", Path: "/panel/api/server/getNewUUID"},
-	{Method: "GET", Path: "/panel/api/server/getNewX25519Cert"},
-	{Method: "GET", Path: "/panel/api/server/getNewmldsa65"},
-	{Method: "GET", Path: "/panel/api/server/getNewmlkem768"},
-	{Method: "GET", Path: "/panel/api/server/getNewVlessEnc"},
-	{Method: "POST", Path: "/panel/api/server/stopXrayService"},
-	{Method: "POST", Path: "/panel/api/server/restartXrayService"},
-	{Method: "POST", Path: "/panel/api/server/installXray/:version"},
-	{Method: "POST", Path: "/panel/api/server/updatePanel"},
-	{Method: "POST", Path: "/panel/api/server/updateGeofile"},
-	{Method: "POST", Path: "/panel/api/server/updateGeofile/:fileName"},
-	{Method: "POST", Path: "/panel/api/server/logs/:count"},
-	{Method: "POST", Path: "/panel/api/server/xraylogs/:count"},
-	{Method: "POST", Path: "/panel/api/server/importDB"},
-	{Method: "POST", Path: "/panel/api/server/getNewEchCert"},
-
-	// Nodes API — prefix /panel/api/nodes
-	{Method: "GET", Path: "/panel/api/nodes/list"},
-	{Method: "GET", Path: "/panel/api/nodes/get/:id"},
-	{Method: "POST", Path: "/panel/api/nodes/add"},
-	{Method: "POST", Path: "/panel/api/nodes/update/:id"},
-	{Method: "POST", Path: "/panel/api/nodes/del/:id"},
-	{Method: "POST", Path: "/panel/api/nodes/setEnable/:id"},
-	{Method: "POST", Path: "/panel/api/nodes/test"},
-	{Method: "POST", Path: "/panel/api/nodes/probe/:id"},
-	{Method: "GET", Path: "/panel/api/nodes/history/:id/:metric/:bucket"},
-
-	// Custom Geo API — prefix /panel/api/custom-geo
-	{Method: "GET", Path: "/panel/api/custom-geo/list"},
-	{Method: "GET", Path: "/panel/api/custom-geo/aliases"},
-	{Method: "POST", Path: "/panel/api/custom-geo/add"},
-	{Method: "POST", Path: "/panel/api/custom-geo/update/:id"},
-	{Method: "POST", Path: "/panel/api/custom-geo/delete/:id"},
-	{Method: "POST", Path: "/panel/api/custom-geo/download/:id"},
-	{Method: "POST", Path: "/panel/api/custom-geo/update-all"},
-
-	// Backup — prefix /panel/api
-	{Method: "GET", Path: "/panel/api/backuptotgbot"},
-
-	// Settings API — prefix /panel/setting
-	{Method: "POST", Path: "/panel/setting/all"},
-	{Method: "POST", Path: "/panel/setting/defaultSettings"},
-	{Method: "POST", Path: "/panel/setting/update"},
-	{Method: "POST", Path: "/panel/setting/updateUser"},
-	{Method: "POST", Path: "/panel/setting/restartPanel"},
-	{Method: "GET", Path: "/panel/setting/getDefaultJsonConfig"},
-	{Method: "GET", Path: "/panel/setting/getApiToken"},
-	{Method: "POST", Path: "/panel/setting/regenerateApiToken"},
-
-	// Xray Settings API — prefix /panel/xray
-	{Method: "POST", Path: "/panel/xray/"},
-	{Method: "GET", Path: "/panel/xray/getDefaultJsonConfig"},
-	{Method: "GET", Path: "/panel/xray/getOutboundsTraffic"},
-	{Method: "GET", Path: "/panel/xray/getXrayResult"},
-	{Method: "POST", Path: "/panel/xray/update"},
-	{Method: "POST", Path: "/panel/xray/warp/:action"},
-	{Method: "POST", Path: "/panel/xray/nord/:action"},
-	{Method: "POST", Path: "/panel/xray/resetOutboundsTraffic"},
-	{Method: "POST", Path: "/panel/xray/testOutbound"},
-
-	// WebSocket
-	{Method: "GET", Path: "/ws"},
-
-	// Subscription server — separate server (not on main Gin engine)
-	// Documented in Subscription Server section but not tested here
-	// because the sub server is a separate Gin engine.
-	// {Method: "GET", Path: "/sub/:subid"},
-	// {Method: "GET", Path: "/json/:subid"},
-	// {Method: "GET", Path: "/clash/:subid"},
-}
-
 // routePattern matches route registrations like g.GET("/path", handler) or api.GET("/path", handler)
 var routePattern = regexp.MustCompile(`\b(g|api)\.(GET|POST|PUT|DELETE|PATCH|HEAD|OPTIONS)\("([^"]+)"`)
 
-func TestAPIRoutesDocumented(t *testing.T) {
-	// Build a set of documented routes for fast lookup
-	docSet := make(map[string]bool)
-	for _, r := range expectedRoutes {
-		key := r.Method + " " + r.Path
-		if docSet[key] {
-			t.Errorf("Duplicate documented route: %s", key)
-		}
-		docSet[key] = true
-	}
+// docRoutePattern matches { method: 'X', path: 'Y' ... } entries in endpoints.js.
+var docRoutePattern = regexp.MustCompile(`method:\s*'([A-Z]+)'\s*,\s*path:\s*'([^']+)'`)
 
-	// Walk the web directory to find all Go files with route definitions
+// buildDocSet parses frontend/src/pages/api-docs/endpoints.js and returns the
+// set of documented "METHOD PATH" keys. WS pseudo-routes and subscription
+// placeholders (paths starting with /{...}) are skipped because they aren't
+// registered on the main Gin engine.
+func buildDocSet(t *testing.T) map[string]bool {
+	t.Helper()
+	controllerDir, err := filepath.Abs(".")
+	if err != nil {
+		t.Fatalf("failed to get current dir: %v", err)
+	}
+	endpointsPath := filepath.Join(controllerDir, "..", "..", "frontend", "src", "pages", "api-docs", "endpoints.js")
+	data, err := os.ReadFile(endpointsPath)
+	if err != nil {
+		t.Fatalf("failed to read endpoints.js at %s: %v", endpointsPath, err)
+	}
+	docSet := make(map[string]bool)
+	for _, m := range docRoutePattern.FindAllStringSubmatch(string(data), -1) {
+		method, path := m[1], m[2]
+		if method == "WS" {
+			continue
+		}
+		if !strings.HasPrefix(path, "/") || strings.HasPrefix(path, "/{") {
+			continue
+		}
+		docSet[method+" "+path] = true
+	}
+	if len(docSet) == 0 {
+		t.Fatalf("no documented routes parsed from %s — regex or file format may have changed", endpointsPath)
+	}
+	return docSet
+}
+
+func TestAPIRoutesDocumented(t *testing.T) {
+	docSet := buildDocSet(t)
+
 	controllerDir, err := filepath.Abs(".")
 	if err != nil {
 		t.Fatalf("failed to get current dir: %v", err)
 	}
 
-	// Collect all routes from the controller files
 	var allRoutes []routeDef
 
 	entries, err := os.ReadDir(controllerDir)
@@ -212,7 +118,6 @@ func TestAPIRoutesDocumented(t *testing.T) {
 	// The WebSocket route /ws is registered in web/web.go (not a controller file)
 	allRoutes = append(allRoutes, routeDef{Method: "GET", Path: "/ws"})
 
-	// Check each source route against the documented set
 	missingFromDocs := 0
 	foundInDoc := 0
 	sourceSet := make(map[string]bool)
@@ -228,7 +133,7 @@ func TestAPIRoutesDocumented(t *testing.T) {
 		if spaPages[r.Path] {
 			continue
 		}
-		// Skip /panel/csrf-token (documented under auth)
+		// Skip /panel/csrf-token (documented under auth as /csrf-token)
 		if r.Path == "/panel/csrf-token" {
 			continue
 		}
@@ -246,18 +151,8 @@ func TestAPIRoutesDocumented(t *testing.T) {
 		}
 	}
 
-	// Report undocumented documented routes
-	extraInDocs := 0
-	for _, r := range expectedRoutes {
-		key := r.Method + " " + r.Path
-		if !sourceSet[key] {
-			extraInDocs++
-			t.Logf("Documented route not found in source (perhaps deleted or moved): %s %s", r.Method, r.Path)
-		}
-	}
-
-	t.Logf("Routes found in source: %d, documented: %d, matching: %d, missing: %d, extra in docs: %d",
-		len(sourceSet), len(docSet), foundInDoc, missingFromDocs, extraInDocs)
+	t.Logf("Routes found in source: %d, documented: %d, matching: %d, missing: %d",
+		len(sourceSet), len(docSet), foundInDoc, missingFromDocs)
 
 	if missingFromDocs > 0 {
 		t.Errorf("Found %d undocumented route(s). Update endpoints.js to match.", missingFromDocs)


### PR DESCRIPTION
## Summary

Enhance the in-panel API documentation page (`/panel/api-docs`) with complete endpoint coverage, visual improvements, request/response examples, and a CI test to keep docs in sync.

## Changes

**Complete endpoint coverage** (29 previously undocumented routes added):
- **Server API**: Added `xrayMetricsState`, `xrayMetricsHistory`, `xrayObservatory`, `xrayObservatoryHistory`
- **Settings API** (new section): All 8 `/panel/setting/*` routes
- **Xray Settings API** (new section): All 9 `/panel/xray/*` routes
- **Subscription Server** (new section): `/sub/:subid`, `/json/:subid`, `/clash/:subid`
- **WebSocket** (new section): `/ws` endpoint with 4 message type descriptions

**Accuracy fixes**:
- Corrected history metric keys (`netUp`/`netDown` not `netIn`/`netOut`, added `load5`/`load15`, node metrics limited to `cpu`/`mem`)
- Updated `getNewVlessEnc` description to reflect actual response shape

**Request body examples**: Added to 6 previously undocumented POST endpoints (`updateGeofile`, `xraylogs`, `importDB`, `getNewEchCert`, node `update/:id`, node `test`)

**Response schemas**: Added example responses to 15+ key endpoints (inbound list, server status, traffic, logs, cert generators, etc.)

**Error response examples**: Added error shapes to key endpoints (login, inbound add, server stop/restart)

**HTTP status codes**: Documented in the page header (`200`, `401`, `403`, `404`, `500`)

**Subscription headers table**: Added 8 response headers with descriptions (`Subscription-Userinfo`, `Profile-Title`, `Support-Url`, etc.)

**UI improvements**:
- Search bar to filter endpoints by path, method, or description
- Collapsible sections with expand/collapse all controls
- JSON syntax highlighting (keys in blue, strings in green, numbers in amber, booleans in red, null in purple) with light/dark theme
- Hover-reveal copy button at top-right of every code block
- Error responses shown in red-labeled blocks

**CI / maintainability**:
- New `TestAPIRoutesDocumented` Go test scans all controller files for route registrations and verifies every route is documented in `endpoints.js` — run with `go test -run TestAPIRoutesDocumented`