### PR TITLE
fix: delete button missing after searching for a user

### DIFF
--- a/frontend/src/pages/inbounds/ClientRowTable.vue
+++ b/frontend/src/pages/inbounds/ClientRowTable.vue
@@ -32,6 +32,7 @@ const props = defineProps({
   lastOnlineMap: { type: Object, default: () => ({}) },
   isDarkTheme: { type: Boolean, default: false },
   pageSize: { type: Number, default: 0 },
+  totalClientCount: { type: Number, default: 0 },
 });
 
 const emit = defineEmits([
@@ -138,7 +139,7 @@ function statsExpColor(email) {
   return PURPLE;
 }
 
-const isRemovable = computed(() => clients.value.length > 1);
+const isRemovable = computed(() => (props.totalClientCount || clients.value.length) > 1);
 
 function totalGbDisplay(client) {
   if (!client.totalGB || client.totalGB <= 0) return '';

--- a/frontend/src/pages/inbounds/InboundList.vue
+++ b/frontend/src/pages/inbounds/InboundList.vue
@@ -457,7 +457,7 @@ function showQrCodeMenu(dbInbound) {
           <div v-if="record.isMultiUser() && isExpanded(record.id)" class="card-clients">
             <ClientRowTable :db-inbound="record" :is-mobile="true" :traffic-diff="trafficDiff" :expire-diff="expireDiff"
               :online-clients="onlineClients" :last-online-map="lastOnlineMap" :is-dark-theme="isDarkTheme"
-              :page-size="pageSize"
+              :page-size="pageSize" :total-client-count="clientCount[record.id]?.clients || 0"
               @edit-client="(p) => emit('edit-client', p)" @qrcode-client="(p) => emit('qrcode-client', p)"
               @info-client="(p) => emit('info-client', p)"
               @reset-traffic-client="(p) => emit('reset-traffic-client', p)"
@@ -479,6 +479,7 @@ function showQrCodeMenu(dbInbound) {
           <ClientRowTable v-if="record.isMultiUser()" :db-inbound="record" :is-mobile="isMobile"
             :traffic-diff="trafficDiff" :expire-diff="expireDiff" :online-clients="onlineClients"
             :last-online-map="lastOnlineMap" :is-dark-theme="isDarkTheme" :page-size="pageSize"
+            :total-client-count="clientCount[record.id]?.clients || 0"
             @edit-client="(p) => emit('edit-client', p)"
             @qrcode-client="(p) => emit('qrcode-client', p)" @info-client="(p) => emit('info-client', p)"
             @reset-traffic-client="(p) => emit('reset-traffic-client', p)"


### PR DESCRIPTION
## Summary

When searching for a user, the "Delete" button disappears from search results, making it impossible to delete a user directly from search.

## Root Cause

`ClientRowTable.vue` computes `isRemovable` as `clients.value.length > 1`. When a search is active, `InboundList.vue` projects the inbound via `projectInbound()`, creating a clone with **only the matching clients**. If exactly 1 client matches the search, `clients.value.length` becomes `1`, so `isRemovable` evaluates to `false` — hiding the Delete button (and bulk-delete bar) even though the original inbound may have many clients.

## Fix

1. Added a `totalClientCount` prop to `ClientRowTable.vue`
2. Changed `isRemovable` to use the original total client count (from the parent's `clientCount` prop), falling back to the projected count for backward compatibility
3. Pass `:total-client-count` from `InboundList.vue` in both mobile card and desktop table templates

Closes #4313
