### PR TITLE
fix: auto-renew does not re-enable client (settings JSON c["enable"] not reset)

### DIFF
--- a/web/service/inbound.go
+++ b/web/service/inbound.go
@@ -2036,6 +2036,7 @@ func (s *InboundService) autoRenewClients(tx *gorm.DB) (bool, int64, error) {
 					traffics[traffic_index].Up = 0
 					if !traffic.Enable {
 						traffics[traffic_index].Enable = true
+						c["enable"] = true
 						clientsToAdd = append(clientsToAdd,
 							struct {
 								protocol string


### PR DESCRIPTION
Since v2.9.4 (commit `6099a07f`), `disableInvalidClients` writes `c["enable"] = false` into the inbound settings JSON when a client hits its traffic/expiry limit and gets disabled. This JSON field is consumed by the Xray config generator (`web/service/xray.go:148`) as a "manual disabled flag."

`autoRenewClients` only reset the `client_traffics.enable` column back to `true` — it never flipped the corresponding `c["enable"]` field in the settings JSON. So after auto-renew:

- `client_traffics.enable` = `true` (correct)
- `inbounds.settings.clients[].enable` = `false` (stale from earlier disable)

The Xray config generator checks both sources, and since the JSON still says `false`, the client is excluded from the runtime config — it stays permanently disabled even after renewal.

**Fix:** Added `c["enable"] = true` in `autoRenewClients` right after `traffics[traffic_index].Enable = true`, so the inbound settings JSON is updated in sync with the database row when a client is re-enabled.

**Fixes:** #4310