### PR TITLE
fix(fail2ban): escape percent signs in 3x-ipl datepattern

### DIFF
--- a/DockerEntrypoint.sh
+++ b/DockerEntrypoint.sh
@@ -22,7 +22,7 @@ EOF
 
     cat > /etc/fail2ban/filter.d/3x-ipl.conf << 'EOF'
 [Definition]
-datepattern = ^%Y/%m/%d %H:%M:%S
+datepattern = ^%%Y/%%m/%%d %%H:%%M:%%S
 failregex   = \[LIMIT_IP\]\s*Email\s*=\s*<F-USER>.+</F-USER>\s*\|\|\s*Disconnecting OLD IP\s*=\s*<ADDR>\s*\|\|\s*Timestamp\s*=\s*\d+
 ignoreregex =
 EOF

--- a/x-ui.sh
+++ b/x-ui.sh
@@ -2092,7 +2092,7 @@ EOF
 
     cat << EOF > /etc/fail2ban/filter.d/3x-ipl.conf
 [Definition]
-datepattern = ^%Y/%m/%d %H:%M:%S
+datepattern = ^%%Y/%%m/%%d %%H:%%M:%%S
 failregex   = \[LIMIT_IP\]\s*Email\s*=\s*<F-USER>.+</F-USER>\s*\|\|\s*Disconnecting OLD IP\s*=\s*<ADDR>\s*\|\|\s*Timestamp\s*=\s*\d+
 ignoreregex =
 EOF


### PR DESCRIPTION
## What is the pull request?

This PR escapes percent signs in the generated `3x-ipl` fail2ban filter `datepattern`.

A previous fix escaped `%` in the `actionban` / `actionunban` date commands, but the generated `filter.d/3x-ipl.conf` still contains:

```ini
datepattern = ^%Y/%m/%d %H:%M:%S
```

When `XUI_ENABLE_FAIL2BAN=true` is used in Docker, fail2ban can fail during startup with:

```text
Failed during configuration: '%' must be followed by '%' or '(', found: '%Y/%m/%d %H:%M:%S'
```

This PR changes the generated datepattern to:

```ini
datepattern = ^%%Y/%%m/%%d %%H:%%M:%%S
```

in both `DockerEntrypoint.sh` and `x-ui.sh`.

## Which part of the application is affected by the change?

- [ ] Frontend
- [x] Backend

## Type of Changes

- [x] Bug fix
- [ ] New feature
- [ ] Refactoring
- [ ] Other