### PR TITLE
fix: single inbound traffic reset resets all inbounds (#4334)

### DIFF
--- a/frontend/src/pages/inbounds/InboundsPage.vue
+++ b/frontend/src/pages/inbounds/InboundsPage.vue
@@ -396,7 +396,7 @@ function confirmResetTraffic(dbInbound) {
     okText: 'Reset',
     cancelText: 'Cancel',
     onOk: async () => {
-      const msg = await HttpUtil.post(`/panel/api/inbounds/resetAllTraffics`);
+      const msg = await HttpUtil.post(`/panel/api/inbounds/${dbInbound.id}/resetTraffic`);
       if (msg?.success) await refresh();
     },
   });

--- a/web/controller/inbound.go
+++ b/web/controller/inbound.go
@@ -77,6 +77,7 @@ func (a *InboundController) initRouter(g *gin.RouterGroup) {
 	g.POST("/:id/copyClients", a.copyInboundClients)
 	g.POST("/:id/delClient/:clientId", a.delInboundClient)
 	g.POST("/updateClient/:clientId", a.updateInboundClient)
+	g.POST("/:id/resetTraffic", a.resetInboundTraffic)
 	g.POST("/:id/resetClientTraffic/:email", a.resetClientTraffic)
 	g.POST("/resetAllTraffics", a.resetAllTraffics)
 	g.POST("/resetAllClientTraffics/:id", a.resetAllClientTraffics)
@@ -439,6 +440,24 @@ func (a *InboundController) resetClientTraffic(c *gin.Context) {
 	if needRestart {
 		a.xrayService.SetToNeedRestart()
 	}
+}
+
+// resetInboundTraffic resets traffic counters for a specific inbound.
+func (a *InboundController) resetInboundTraffic(c *gin.Context) {
+	id, err := strconv.Atoi(c.Param("id"))
+	if err != nil {
+		jsonMsg(c, I18nWeb(c, "pages.inbounds.toasts.inboundUpdateSuccess"), err)
+		return
+	}
+
+	err = a.inboundService.ResetInboundTraffic(id)
+	if err != nil {
+		jsonMsg(c, I18nWeb(c, "somethingWentWrong"), err)
+		return
+	} else {
+		a.xrayService.SetToNeedRestart()
+	}
+	jsonMsg(c, I18nWeb(c, "pages.inbounds.toasts.resetInboundTrafficSuccess"), nil)
 }
 
 // resetAllTraffics resets all traffic counters across all inbounds.

--- a/web/translation/ar-EG.json
+++ b/web/translation/ar-EG.json
@@ -341,6 +341,7 @@
         "resetAllClientTrafficSuccess": "تم إعادة تعيين كل حركة المرور من العميل",
         "resetAllTrafficSuccess": "تم إعادة تعيين كل حركة المرور",
         "resetInboundClientTrafficSuccess": "تم إعادة تعيين حركة المرور",
+        "resetInboundTrafficSuccess": "تم إعادة تعيين حركة مرور الداخل",
         "trafficGetError": "خطأ في الحصول على حركات المرور",
         "getNewX25519CertError": "حدث خطأ أثناء الحصول على شهادة X25519.",
         "getNewmldsa65Error": "حدث خطاء في الحصول على mldsa65.",

--- a/web/translation/en-US.json
+++ b/web/translation/en-US.json
@@ -341,6 +341,7 @@
         "resetAllClientTrafficSuccess": "All traffic from the client has been reset.",
         "resetAllTrafficSuccess": "All traffic has been reset.",
         "resetInboundClientTrafficSuccess": "Traffic has been reset.",
+        "resetInboundTrafficSuccess": "Inbound traffic has been reset.",
         "trafficGetError": "Error getting traffics.",
         "getNewX25519CertError": "Error while obtaining the X25519 certificate.",
         "getNewmldsa65Error": "Error while obtaining mldsa65.",

--- a/web/translation/es-ES.json
+++ b/web/translation/es-ES.json
@@ -341,6 +341,7 @@
         "resetAllClientTrafficSuccess": "Todo el tráfico del cliente ha sido reiniciado",
         "resetAllTrafficSuccess": "Todo el tráfico ha sido reiniciado",
         "resetInboundClientTrafficSuccess": "El tráfico ha sido reiniciado",
+        "resetInboundTrafficSuccess": "El tráfico de entrada ha sido reiniciado",
         "trafficGetError": "Error al obtener los tráficos",
         "getNewX25519CertError": "Error al obtener el certificado X25519.",
         "getNewmldsa65Error": "Error al obtener el certificado mldsa65.",

--- a/web/translation/fa-IR.json
+++ b/web/translation/fa-IR.json
@@ -341,6 +341,7 @@
         "resetAllClientTrafficSuccess": "تمام ترافیک کلاینت بازنشانی شد",
         "resetAllTrafficSuccess": "تمام ترافیک‌ها بازنشانی شدند",
         "resetInboundClientTrafficSuccess": "ترافیک بازنشانی شد",
+        "resetInboundTrafficSuccess": "ترافیک ورودی بازنشانی شد",
         "trafficGetError": "خطا در دریافت ترافیک‌ها",
         "getNewX25519CertError": "خطا در دریافت گواهی X25519.",
         "getNewmldsa65Error": "خطا در دریافت گواهی mldsa65.",

--- a/web/translation/id-ID.json
+++ b/web/translation/id-ID.json
@@ -341,6 +341,7 @@
         "resetAllClientTrafficSuccess": "Semua lalu lintas klien telah direset",
         "resetAllTrafficSuccess": "Semua lalu lintas telah direset",
         "resetInboundClientTrafficSuccess": "Lalu lintas telah direset",
+        "resetInboundTrafficSuccess": "Lalu lintas masuk telah direset",
         "trafficGetError": "Gagal mendapatkan data lalu lintas",
         "getNewX25519CertError": "Terjadi kesalahan saat mendapatkan sertifikat X25519.",
         "getNewmldsa65Error": "Terjadi kesalahan saat mendapatkan sertifikat mldsa65.",

--- a/web/translation/ja-JP.json
+++ b/web/translation/ja-JP.json
@@ -341,6 +341,7 @@
         "resetAllClientTrafficSuccess": "クライアントのすべてのトラフィックがリセットされました",
         "resetAllTrafficSuccess": "すべてのトラフィックがリセットされました",
         "resetInboundClientTrafficSuccess": "トラフィックがリセットされました",
+        "resetInboundTrafficSuccess": "受信トラフィックがリセットされました",
         "trafficGetError": "トラフィックの取得中にエラーが発生しました",
         "getNewX25519CertError": "X25519証明書の取得中にエラーが発生しました。",
         "getNewmldsa65Error": "mldsa65証明書の取得中にエラーが発生しました。",

--- a/web/translation/pt-BR.json
+++ b/web/translation/pt-BR.json
@@ -341,6 +341,7 @@
         "resetAllClientTrafficSuccess": "Todo o tráfego do cliente foi reiniciado",
         "resetAllTrafficSuccess": "Todo o tráfego foi reiniciado",
         "resetInboundClientTrafficSuccess": "O tráfego foi reiniciado",
+        "resetInboundTrafficSuccess": "O tráfego de entrada foi reiniciado",
         "trafficGetError": "Erro ao obter tráfegos",
         "getNewX25519CertError": "Erro ao obter o certificado X25519.",
         "getNewmldsa65Error": "Erro ao obter o certificado mldsa65.",

--- a/web/translation/ru-RU.json
+++ b/web/translation/ru-RU.json
@@ -341,6 +341,7 @@
         "resetAllClientTrafficSuccess": "Весь трафик клиента сброшен",
         "resetAllTrafficSuccess": "Весь трафик сброшен",
         "resetInboundClientTrafficSuccess": "Трафик сброшен",
+        "resetInboundTrafficSuccess": "Входящий трафик сброшен",
         "trafficGetError": "Ошибка получения данных о трафике",
         "getNewX25519CertError": "Ошибка при получении сертификата X25519.",
         "getNewmldsa65Error": "Ошибка при получении сертификата mldsa65.",

--- a/web/translation/tr-TR.json
+++ b/web/translation/tr-TR.json
@@ -341,6 +341,7 @@
         "resetAllClientTrafficSuccess": "İstemcinin tüm trafiği sıfırlandı",
         "resetAllTrafficSuccess": "Tüm trafik sıfırlandı",
         "resetInboundClientTrafficSuccess": "Trafik sıfırlandı",
+        "resetInboundTrafficSuccess": "Gelen trafik sıfırlandı",
         "trafficGetError": "Trafik bilgisi alınırken hata oluştu",
         "getNewX25519CertError": "X25519 sertifikası alınırken hata oluştu.",
         "getNewmldsa65Error": "mldsa65 sertifikası alınırken hata oluştu.",

--- a/web/translation/uk-UA.json
+++ b/web/translation/uk-UA.json
@@ -341,6 +341,7 @@
         "resetAllClientTrafficSuccess": "Весь трафік клієнта скинуто",
         "resetAllTrafficSuccess": "Весь трафік скинуто",
         "resetInboundClientTrafficSuccess": "Трафік скинуто",
+        "resetInboundTrafficSuccess": "Трафік вхідного потоку скинуто",
         "trafficGetError": "Помилка отримання даних про трафік",
         "getNewX25519CertError": "Помилка при отриманні сертифіката X25519.",
         "getNewmldsa65Error": "Помилка при отриманні сертифіката mldsa65.",

--- a/web/translation/vi-VN.json
+++ b/web/translation/vi-VN.json
@@ -341,6 +341,7 @@
         "resetAllClientTrafficSuccess": "Đã đặt lại toàn bộ lưu lượng client",
         "resetAllTrafficSuccess": "Đã đặt lại toàn bộ lưu lượng",
         "resetInboundClientTrafficSuccess": "Đã đặt lại lưu lượng",
+        "resetInboundTrafficSuccess": "Đã đặt lại lưu lượng Inbound",
         "trafficGetError": "Lỗi khi lấy thông tin lưu lượng",
         "getNewX25519CertError": "Lỗi khi lấy chứng chỉ X25519.",
         "getNewmldsa65Error": "Lỗi khi lấy chứng chỉ mldsa65.",

--- a/web/translation/zh-CN.json
+++ b/web/translation/zh-CN.json
@@ -341,6 +341,7 @@
         "resetAllClientTrafficSuccess": "客户端所有流量已重置",
         "resetAllTrafficSuccess": "所有流量已重置",
         "resetInboundClientTrafficSuccess": "流量已重置",
+        "resetInboundTrafficSuccess": "入站流量已重置",
         "trafficGetError": "获取流量数据时出错",
         "getNewX25519CertError": "获取X25519证书时出错。",
         "getNewmldsa65Error": "获取mldsa65证书时出错。",

--- a/web/translation/zh-TW.json
+++ b/web/translation/zh-TW.json
@@ -341,6 +341,7 @@
         "resetAllClientTrafficSuccess": "客戶端所有流量已重置",
         "resetAllTrafficSuccess": "所有流量已重置",
         "resetInboundClientTrafficSuccess": "流量已重置",
+        "resetInboundTrafficSuccess": "入站流量已重置",
         "trafficGetError": "取得流量資料時發生錯誤",
         "getNewX25519CertError": "取得X25519憑證時發生錯誤。",
         "getNewmldsa65Error": "取得mldsa65憑證時發生錯誤。",


### PR DESCRIPTION
## Description

Clicking "Reset traffic" on a single inbound (via the 3-dot menu on the Inbounds page) resets traffic counters for **all** inbounds — not just the selected one. It also propagates the reset to remote nodes, resetting client traffic on those nodes.

## How to reproduce

1. Go to the Inbounds page
2. Click the 3-dot menu on any inbound row
3. Click "Reset traffic"
4. All inbound up/down counters are reset to 0

## Root cause

`confirmResetTraffic(dbInbound)` in `InboundsPage.vue` receives the selected inbound as a parameter and displays its remark in the confirmation dialog, but the API call was hardcoded to `POST /panel/api/inbounds/resetAllTraffics` — ignoring the inbound ID entirely.

Additionally, the backend had a correctly-scoped service method `ResetInboundTraffic(id)` (`web/service/inbound.go:3032`) but it was never exposed via an API route.

## Fix

- **Frontend**: Changed the API call to `POST /panel/api/inbounds/${dbInbound.id}/resetTraffic`
- **Backend**: Added `POST /:id/resetTraffic` route wired to a new `resetInboundTraffic` handler that calls the existing `ResetInboundTraffic(id)` service method (which correctly uses `WHERE id = ?`)
- **i18n**: Added `resetInboundTrafficSuccess` key to all 13 translation files

Closes #4334
