### PR TITLE
fix(sub): include xhttp mode in extra JSON for karing compatibility

### DIFF
--- a/frontend/src/models/inbound.js
+++ b/frontend/src/models/inbound.js
@@ -1595,6 +1595,10 @@ export class Inbound extends XrayCommonClass {
             });
         }
 
+        if (typeof xhttp.mode === 'string' && xhttp.mode.length > 0) {
+            extra.mode = xhttp.mode;
+        }
+
         const stringFields = [
             "sessionPlacement", "sessionKey",
             "seqPlacement", "seqKey",

--- a/sub/subJsonService.go
+++ b/sub/subJsonService.go
@@ -265,6 +265,14 @@ func (s *SubJsonService) streamData(stream string) map[string]any {
 		streamSettings["wsSettings"] = s.removeAcceptProxy(streamSettings["wsSettings"])
 	case "httpupgrade":
 		streamSettings["httpupgradeSettings"] = s.removeAcceptProxy(streamSettings["httpupgradeSettings"])
+	case "xhttp":
+		streamSettings["xhttpSettings"] = s.removeAcceptProxy(streamSettings["xhttpSettings"])
+		if xhttp, ok := streamSettings["xhttpSettings"].(map[string]any); ok {
+			delete(xhttp, "noSSEHeader")
+			delete(xhttp, "scMaxBufferedPosts")
+			delete(xhttp, "scStreamUpServerSecs")
+			delete(xhttp, "serverMaxHeaderBytes")
+		}
 	}
 	return streamSettings
 }

--- a/sub/subService.go
+++ b/sub/subService.go
@@ -1025,6 +1025,10 @@ func buildXhttpExtra(xhttp map[string]any) map[string]any {
 		}
 	}
 
+	if mode, ok := xhttp["mode"].(string); ok && len(mode) > 0 {
+		extra["mode"] = mode
+	}
+
 	stringFields := []string{
 		"sessionPlacement", "sessionKey",
 		"seqPlacement", "seqKey",


### PR DESCRIPTION
## Summary
- Fix karing (and other clients) losing xhttp `mode` when `xPaddingBytes` or `scMaxEachPostBytes` is configured
- Fix JSON subscription leaking server-only xhttp fields to clients

Closes #4364

## Problem
When an xhttp inbound has `xPaddingBytes` or `scMaxEachPostBytes` set, the share URL
includes an ` + "`extra=<json>`" + @` query param containing bidirectional SplitHTTP fields.
karing reads exclusively from ` + "`extra`" + @` for transport settings, but ` + "`mode`" + @` was only
emitted as a flat URL param (` + "`mode=packet-up`" + @`), never inside ` + "`extra`" + @`. This silently
dropped the mode, breaking the connection entirely.

```json
// Before (broken karing import):
"transport": {
    "type": "xhttp",
    "host": "...",
    "path": "...",
    "x_padding_bytes": "100-1000",    // flat param ✓
    "sc_max_each_post_bytes": "1000000" // from extra ✓
    // mode MISSING — defaults to wrong behavior
}

// After (fixed):
"transport": {
    "type": "xhttp",
    "host": "...",
    "path": "...",
    "mode": "packet-up",               // now in extra ✓
    "x_padding_bytes": "100-1000",     // flat param ✓
    "sc_max_each_post_bytes": "1000000" // from extra ✓
}
```

## Changes
- **`sub/subService.go`**: Include `mode` in `buildXhttpExtra()` so it is available in the ` + "`extra`" + @` JSON blob alongside other bidirectional SplitHTTP fields
- **`frontend/src/models/inbound.js`**: Same fix in the panel share-link generator for parity
- **`sub/subJsonService.go`**: Add `xhttp` case to `streamData()` to strip `acceptProxyProtocol` and server-only fields (`noSSEHeader`, `scMaxBufferedPosts`, `scStreamUpServerSecs`, `serverMaxHeaderBytes`) from JSON subscription configs, matching how tcp/ws/httpupgrade are already sanitized