### PR TITLE
fix: protocol filter placeholder not showing on initial load

### DIFF
--- a/frontend/src/pages/inbounds/InboundList.vue
+++ b/frontend/src/pages/inbounds/InboundList.vue
@@ -80,7 +80,7 @@ const savedFilterState = (() => {
 const enableFilter = ref(!!savedFilterState.enableFilter);
 const searchKey = ref(savedFilterState.searchKey || '');
 const filterBy = ref(savedFilterState.filterBy || '');
-const protocolFilter = ref(savedFilterState.protocolFilter || '');
+const protocolFilter = ref(savedFilterState.protocolFilter || undefined);
 const nodeFilter = ref(savedFilterState.nodeFilter || '');
 
 watch([enableFilter, searchKey, filterBy, protocolFilter, nodeFilter], () => {


### PR DESCRIPTION
## Summary
- Fix the protocol filter dropdown in the inbounds page not displaying its placeholder text until a protocol is selected and then cleared
- Root cause: `protocolFilter` was initialized to `''` (empty string), which Ant Design's `a-select` treats as a selected value, suppressing the placeholder
- Changed initialization to `undefined` so the placeholder renders immediately on page load