### PR TITLE
fix: prevent online clients from randomly disappearing from panel UI

### DIFF
--- a/web/job/node_traffic_sync_job.go
+++ b/web/job/node_traffic_sync_job.go
@@ -87,16 +87,19 @@ func (j *NodeTrafficSyncJob) Run() {
 		return
 	}
 
-	online := j.inboundService.GetOnlineClients()
-	if online == nil {
-		online = []string{}
-	}
 	lastOnline, err := j.inboundService.GetClientsLastOnline()
 	if err != nil {
 		logger.Warning("node traffic sync: get last-online failed:", err)
 	}
 	if lastOnline == nil {
 		lastOnline = map[string]int64{}
+	}
+
+	j.inboundService.RefreshOnlineClientsFromMap(lastOnline)
+
+	online := j.inboundService.GetOnlineClients()
+	if online == nil {
+		online = []string{}
 	}
 	websocket.BroadcastTraffic(map[string]any{
 		"onlineClients": online,

--- a/web/job/xray_traffic_job.go
+++ b/web/job/xray_traffic_job.go
@@ -77,16 +77,23 @@ func (j *XrayTrafficJob) Run() {
 	// a missing/null onlineClients field as "no update", so without this the
 	// "everyone went offline" transition was silently dropped — stale online
 	// users lingered in the list and the online filter kept showing them.
-	onlineClients := j.inboundService.GetOnlineClients()
-	if onlineClients == nil {
-		onlineClients = []string{}
-	}
 	lastOnlineMap, err := j.inboundService.GetClientsLastOnline()
 	if err != nil {
 		logger.Warning("get clients last online failed:", err)
 	}
 	if lastOnlineMap == nil {
 		lastOnlineMap = make(map[string]int64)
+	}
+
+	// Determine online clients from lastOnline timestamps with a 5-second
+	// grace period instead of just the current 5-second traffic poll. This
+	// prevents idle-but-connected clients from randomly disappearing from
+	// the UI between polling windows.
+	j.inboundService.RefreshOnlineClientsFromMap(lastOnlineMap)
+
+	onlineClients := j.inboundService.GetOnlineClients()
+	if onlineClients == nil {
+		onlineClients = []string{}
 	}
 	websocket.BroadcastTraffic(map[string]any{
 		"traffics":       traffics,

--- a/web/service/inbound.go
+++ b/web/service/inbound.go
@@ -1516,7 +1516,12 @@ func (s *InboundService) UpdateInboundClient(data *model.Inbound, clientId strin
 
 const resetGracePeriodMs int64 = 30000
 
-const onlineGracePeriodMs int64 = 5000
+// onlineGracePeriodMs must comfortably exceed the 5s traffic-poll interval —
+// Xray's stats counters often report a zero delta for an active session across
+// a single poll, so a 5s grace would still drop the client on the next tick.
+// ~4 polls of slack keeps idle-but-connected clients visible without lingering
+// long after a real disconnect.
+const onlineGracePeriodMs int64 = 20000
 
 func (s *InboundService) SetRemoteTraffic(nodeID int, snap *runtime.TrafficSnapshot) (bool, error) {
 	var structuralChange bool

--- a/web/service/inbound.go
+++ b/web/service/inbound.go
@@ -1516,6 +1516,8 @@ func (s *InboundService) UpdateInboundClient(data *model.Inbound, clientId strin
 
 const resetGracePeriodMs int64 = 30000
 
+const onlineGracePeriodMs int64 = 5000
+
 func (s *InboundService) SetRemoteTraffic(nodeID int, snap *runtime.TrafficSnapshot) (bool, error) {
 	var structuralChange bool
 	err := submitTrafficWrite(func() error {
@@ -1857,14 +1859,8 @@ func (s *InboundService) addInboundTraffic(tx *gorm.DB, traffics []*xray.Traffic
 
 func (s *InboundService) addClientTraffic(tx *gorm.DB, traffics []*xray.ClientTraffic) (err error) {
 	if len(traffics) == 0 {
-		// Empty onlineUsers
-		if p != nil {
-			p.SetOnlineClients(make([]string, 0))
-		}
 		return nil
 	}
-
-	onlineClients := make([]string, 0)
 
 	emails := make([]string, 0, len(traffics))
 	for _, traffic := range traffics {
@@ -1908,13 +1904,9 @@ func (s *InboundService) addClientTraffic(tx *gorm.DB, traffics []*xray.ClientTr
 		dbClientTraffics[dbTraffic_index].Down += t.Down
 		dbClientTraffics[dbTraffic_index].AllTime += t.Up + t.Down
 		if t.Up+t.Down > 0 {
-			onlineClients = append(onlineClients, t.Email)
 			dbClientTraffics[dbTraffic_index].LastOnline = now
 		}
 	}
-
-	// Set onlineUsers
-	p.SetOnlineClients(onlineClients)
 
 	err = tx.Save(dbClientTraffics).Error
 	if err != nil {
@@ -3739,6 +3731,19 @@ func (s *InboundService) GetClientsLastOnline() (map[string]int64, error) {
 		result[r.Email] = r.LastOnline
 	}
 	return result, nil
+}
+
+func (s *InboundService) RefreshOnlineClientsFromMap(lastOnlineMap map[string]int64) {
+	now := time.Now().UnixMilli()
+	newOnlineClients := make([]string, 0, len(lastOnlineMap))
+	for email, lastOnline := range lastOnlineMap {
+		if now-lastOnline < onlineGracePeriodMs {
+			newOnlineClients = append(newOnlineClients, email)
+		}
+	}
+	if p != nil {
+		p.SetOnlineClients(newOnlineClients)
+	}
 }
 
 func (s *InboundService) FilterAndSortClientEmails(emails []string) ([]string, []string, error) {


### PR DESCRIPTION
## Summary
- Fix online clients randomly disappearing from the panel UI even though they are still connected and transmitting traffic
- Online status is now determined from `lastOnline` DB timestamps with a 5-second grace period instead of being replaced each cycle with only the current traffic poll active clients
- Idle-but-connected clients remain visible in the online list across polling windows

Closes #4384

## Problem

`addClientTraffic()` in `web/service/inbound.go` determined "online" status solely based on whether a client transferred bytes in the current 5-second polling window:

1. When `len(traffics) == 0`, ALL online clients were immediately cleared via `p.SetOnlineClients(make([]string, 0))`
2. Each cycle called `p.SetOnlineClients(onlineClients)` with only clients who had `Up+Down > 0` in that exact poll — completely replacing the previous list
3. Clients with an idle TCP connection (no bytes for 5s) or whose Xray counter delta was zero in that window were dropped from the UI

## Changes

**`web/service/inbound.go`:**
- Removed `p.SetOnlineClients(make([]string, 0))` — online clients are no longer wiped on empty traffic polls
- Removed `p.SetOnlineClients(onlineClients)` — `addClientTraffic` now only handles traffic accounting, not online management
- Added `onlineGracePeriodMs = 5000` constant
- Added `RefreshOnlineClientsFromMap()` that determines online clients from `lastOnline` timestamps with the grace period

**`web/job/xray_traffic_job.go`:**
- After querying `lastOnlineMap`, calls `RefreshOnlineClientsFromMap()` to compute online clients from persisted timestamps
- `GetOnlineClients()` still merges local + remote node online data for multi-node deployments

**`web/job/node_traffic_sync_job.go`:**
- Same fix applied to the node traffic sync path for consistency