### PR TITLE
fix: correct Hysteria2 "Obfs password" label to "Auth password"

### DIFF
--- a/frontend/src/pages/inbounds/InboundFormModal.vue
+++ b/frontend/src/pages/inbounds/InboundFormModal.vue
@@ -1836,8 +1836,8 @@ watch(
             </a-form-item>
             <a-form-item>
               <template #label>
-                <a-tooltip title="Obfuscation password. Must match between server and client.">
-                  Obfs password
+                <a-tooltip title="Hysteria server authentication password. Overridden by per-client auth when clients are configured. Obfuscation (salamander) is configured via UDP Masks below.">
+                  Auth password
                 </a-tooltip>
               </template>
               <a-input v-model:value="inbound.stream.hysteria.auth" />


### PR DESCRIPTION
## Summary
Fixes the mislabeled "Obfs password" field in the Hysteria2 inbound stream settings. The field was incorrectly bound to `hysteriaSettings.auth` (Hysteria server authentication password) but labeled as obfuscation, misleading users into thinking they were configuring salamander obfuscation.

Closes #4382

## Problem
Per [Xray-core FinalMask docs](https://xtls.github.io/config/transports/finalmask.html), Hysteria2 salamander obfuscation is configured through `finalmask.udp[].salamander.password` — NOT through `hysteriaSettings.auth`. The UI had a field labeled "Obfs password" bound to `hysteriaSettings.auth`, causing:

1. Xray-core receiving no salamander obfuscation config → **stateless reset (46 bytes)** on connection
2. Users trying to work around it via the Advanced JSON editor, but `HysteriaStreamSettings.fromJson()` only reads known fields (`protocol`, `version`, `auth`, `udpIdleTimeout`, `masquerade`), silently dropping any manually-injected `obfuscation` or `obfsPassword` fields

## Fix (1 file, +2/-2 lines)
- Changed label from "Obfs password" → "Auth password"
- Updated tooltip to explain it is the server auth password (overridden by per-client auth) and to direct users to configure salamander obfuscation via the UDP Masks section

| Before | After |
|--------|-------|
| Obfs password | Auth password |
| "Obfuscation password. Must match..." | "Hysteria server authentication password. Overridden by per-client auth..." |

## Verification
- The FinalMaskForm (UDP Masks) is already visible for Hysteria protocol and defaults to `salamander` type — correctly generating `finalmask.udp[].salamander.password` in the Xray config
- `genHysteriaLink()` in `inbound.js` correctly reads the obfuscation password from `finalmask.udp[].salamander.password` and emits `obfs=salamander&obfs-password=xxx` in share links
- The outbound form already uses the correct "Auth password" label for the same field at `OutboundFormModal.vue:833`