### PR TITLE
fix: preserve VLESS encryption/decryption when searching/filtering inbounds

### DIFF
--- a/frontend/src/pages/inbounds/InboundList.vue
+++ b/frontend/src/pages/inbounds/InboundList.vue
@@ -143,7 +143,7 @@ function projectInbound(dbInbound, predicate) {
   }
   if (!Array.isArray(settings.clients)) return next;
   const filtered = settings.clients.filter(predicate);
-  next.settings = Inbound.Settings.fromJson(dbInbound.protocol, { clients: filtered });
+  next.settings = Inbound.Settings.fromJson(dbInbound.protocol, { ...settings, clients: filtered });
   next.invalidateCache();
   return next;
 }


### PR DESCRIPTION
## Summary
- When using the search or filter in the Inbounds page, `projectInbound()` was constructing a new settings object with only the filtered `clients` array, dropping all protocol-specific fields like `encryption` and `decryption` for VLESS (x25519 / ML-KEM-768).
- This caused copied client configs to show `encryption=none` instead of the actual encryption key.

## Fix
`frontend/src/pages/inbounds/InboundList.vue:146` — Spread the original parsed settings and override only `clients` with the filtered list:

```js
// Before
next.settings = Inbound.Settings.fromJson(dbInbound.protocol, { clients: filtered });
// After
next.settings = Inbound.Settings.fromJson(dbInbound.protocol, { ...settings, clients: filtered });
```

This also benefits other protocols (e.g., Trojan `fallbacks`, Shadowsocks `method`/`password`/`ivCheck`) that could have been silently dropped.

Closes #4405