### PR TITLE
fix: Allow bypassing private IP validation

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"strings"
+	"sync"
 )
 
 //go:embed version
@@ -55,6 +56,13 @@ func GetLogLevel() LogLevel {
 // IsDebug returns true if debug mode is enabled via the XUI_DEBUG environment variable.
 func IsDebug() bool {
 	return os.Getenv("XUI_DEBUG") == "true"
+}
+
+// AllowPrivateIPs returns true if user bypasses security checks via the ALLOW_PRIVATES environment variable.
+var AllowPrivateIPs = sync.OnceValue(allowPrivateIPs)
+
+func allowPrivateIPs() bool {
+	return os.Getenv("ALLOW_PRIVATE_IPS") == "true"
 }
 
 // GetBinFolderPath returns the path to the binary folder, defaulting to "bin" if not set via XUI_BIN_FOLDER.

--- a/web/controller/xray_setting.go
+++ b/web/controller/xray_setting.go
@@ -3,6 +3,7 @@ package controller
 import (
 	"encoding/json"
 
+	"github.com/mhsanaei/3x-ui/v3/config"
 	"github.com/mhsanaei/3x-ui/v3/util/common"
 	"github.com/mhsanaei/3x-ui/v3/web/service"
 
@@ -213,7 +214,7 @@ func (a *XraySettingController) testOutbound(c *gin.Context) {
 
 	// Load the test URL from server settings to prevent SSRF via user-controlled URLs
 	testURL, _ := a.SettingService.GetXrayOutboundTestUrl()
-	testURL, err := service.SanitizePublicHTTPURL(testURL, false)
+	testURL, err := service.SanitizePublicHTTPURL(testURL, config.AllowPrivateIPs())
 	if err != nil {
 		jsonMsg(c, I18nWeb(c, "somethingWentWrong"), err)
 		return

--- a/web/job/xray_traffic_job.go
+++ b/web/job/xray_traffic_job.go
@@ -3,6 +3,7 @@ package job
 import (
 	"encoding/json"
 
+	"github.com/mhsanaei/3x-ui/v3/config"
 	"github.com/mhsanaei/3x-ui/v3/logger"
 	"github.com/mhsanaei/3x-ui/v3/web/service"
 	"github.com/mhsanaei/3x-ui/v3/web/websocket"
@@ -137,7 +138,7 @@ func (j *XrayTrafficJob) informTrafficToExternalAPI(inboundTraffics []*xray.Traf
 		logger.Warning("get ExternalTrafficInformURI failed:", err)
 		return
 	}
-	informURL, err = service.SanitizePublicHTTPURL(informURL, false)
+	informURL, err = service.SanitizePublicHTTPURL(informURL, config.AllowPrivateIPs())
 	if err != nil {
 		logger.Warning("ExternalTrafficInformURI blocked:", err)
 		return

--- a/web/service/tgbot.go
+++ b/web/service/tgbot.go
@@ -341,7 +341,7 @@ func (t *Tgbot) NewBot(token string, proxyUrl string, apiServerUrl string) (*tel
 
 	// Validate API server URL if provided
 	if apiServerUrl != "" {
-		safeURL, err := SanitizePublicHTTPURL(apiServerUrl, false)
+		safeURL, err := SanitizePublicHTTPURL(apiServerUrl, config.AllowPrivateIPs())
 		if err != nil {
 			logger.Warningf("Invalid or blocked API server URL, using default: %v", err)
 			apiServerUrl = ""


### PR DESCRIPTION
## What does this pull request do?

Adds an option to bypass the private/internal IP address checks introduced in #4275.

When the `ALLOW_PRIVATE_IPS` environment variable is set to `true`, the private IP validation logic is skipped.

## Which part of the application is affected by this change?

* [ ] Frontend
* [x] Backend

## Type of change

* [x] Bug fix
* [ ] New feature
* [ ] Refactor
* [ ] Other

## Related issue

* Fixes #4420
