### PR TITLE
Add pulse animation to client online status indicator

### DIFF
--- a/frontend/src/pages/inbounds/ClientRowTable.vue
+++ b/frontend/src/pages/inbounds/ClientRowTable.vue
@@ -336,7 +336,7 @@ function confirmBulkDelete() {
               <template v-else-if="isClientOnline(client.email)">{{ t('online') }}</template>
               <template v-else>{{ t('offline') }}</template>
             </template>
-            <a-badge :color="statusBadgeColor(client)" />
+            <a-badge :color="statusBadgeColor(client)" :class="{ 'client-online-pulse': client.enable && isClientOnline(client.email) }" />
           </a-tooltip>
           <div class="client-id-stack">
             <a-tooltip :title="client.email">
@@ -440,7 +440,7 @@ function confirmBulkDelete() {
               <template v-else-if="isClientOnline(client.email)">{{ t('online') }}</template>
               <template v-else>{{ t('offline') }}</template>
             </template>
-            <a-badge :color="statusBadgeColor(client)" />
+            <a-badge :color="statusBadgeColor(client)" :class="{ 'client-online-pulse': client.enable && isClientOnline(client.email) }" />
           </a-tooltip>
           <a-tooltip :title="client.email">
             <span class="client-email">{{ client.email }}</span>
@@ -837,5 +837,14 @@ function confirmBulkDelete() {
 .client-card-head :deep(.ant-badge-status-dot) {
   width: 9px;
   height: 9px;
+}
+
+.client-online-pulse :deep(.ant-badge-status-dot) {
+  animation: client-online-pulse 1.2s ease-in-out infinite;
+}
+
+@keyframes client-online-pulse {
+  0%, 100% { transform: scale(1); opacity: 1; }
+  50% { transform: scale(1.6); opacity: 0.3; }
 }
 </style>


### PR DESCRIPTION
Fixes #4442

In mobile view, the only indicator for a client's online/offline status is a small colored badge dot that requires tapping to trigger a tooltip — making it impossible to scan the list at a glance.

This PR adds a CSS pulse animation (scale + opacity breathing) to the badge dot when a client is online and enabled. Offline and disabled clients keep a static dot.

**Changes** (`frontend/src/pages/inbounds/ClientRowTable.vue`):
- Added `:class` binding to the `<a-badge>` in both desktop table and mobile card views
- Added `@keyframes client-online-pulse` — 1.2s ease-in-out loop, scale 1 to 1.6, opacity 1 to 0.3
