### PR TITLE
add Hysteria2 client "allow insecure" setting

### DIFF
--- a/database/model/model.go
+++ b/database/model/model.go
@@ -179,6 +179,7 @@ type Client struct {
 	Flow       string         `json:"flow,omitempty"`               // Flow control (XTLS)
 	Reverse    *ClientReverse `json:"reverse,omitempty"`            // VLESS simple reverse proxy settings
 	Auth       string         `json:"auth,omitempty"`               // Auth password (Hysteria)
+	AllowInsecure bool        `json:"allowInsecure,omitempty"`      // Per-client TLS insecure flag (Hysteria2)
 	Email      string         `json:"email"`                        // Client email identifier
 	LimitIP    int            `json:"limitIp"`                      // IP limit for this client
 	TotalGB    int64          `json:"totalGB" form:"totalGB"`       // Total traffic limit in GB

--- a/frontend/src/models/inbound.js
+++ b/frontend/src/models/inbound.js
@@ -2224,7 +2224,7 @@ export class Inbound extends XrayCommonClass {
         return url.toString();
     }
 
-    genHysteriaLink(address = '', port = this.port, remark = '', clientAuth) {
+    genHysteriaLink(address = '', port = this.port, remark = '', clientAuth, clientAllowInsecure) {
         const protocol = this.settings.version == 2 ? "hysteria2" : "hysteria";
         const link = `${protocol}://${clientAuth}@${address}:${port}`;
 
@@ -2232,7 +2232,7 @@ export class Inbound extends XrayCommonClass {
         params.set("security", "tls");
         if (this.stream.tls.settings.fingerprint?.length > 0) params.set("fp", this.stream.tls.settings.fingerprint);
         if (this.stream.tls.alpn?.length > 0) params.set("alpn", this.stream.tls.alpn);
-        if (this.stream.tls.settings.allowInsecure) params.set("insecure", "1");
+        if (clientAllowInsecure ?? this.stream.tls.settings.allowInsecure) params.set("insecure", "1");
         if (this.stream.tls.settings.echConfigList?.length > 0) params.set("ech", this.stream.tls.settings.echConfigList);
         if (this.stream.tls.sni?.length > 0) params.set("sni", this.stream.tls.sni);
 
@@ -2343,7 +2343,13 @@ export class Inbound extends XrayCommonClass {
             case Protocols.TROJAN:
                 return this.genTrojanLink(address, port, forceTls, remark, client.password);
             case Protocols.HYSTERIA:
-                return this.genHysteriaLink(address, port, remark, client.auth.length > 0 ? client.auth : this.stream.hysteria.auth);
+                return this.genHysteriaLink(
+                    address,
+                    port,
+                    remark,
+                    client.auth.length > 0 ? client.auth : this.stream.hysteria.auth,
+                    client.allowInsecure,
+                );
             default: return '';
         }
     }
@@ -2952,15 +2958,18 @@ Inbound.HysteriaSettings = class extends Inbound.Settings {
 Inbound.HysteriaSettings.Hysteria = class extends Inbound.ClientBase {
     constructor(
         auth = RandomUtil.randomSeq(10),
+        allowInsecure = false,
         email, limitIp, totalGB, expiryTime, enable, tgId, subId, comment, reset, created_at, updated_at,
     ) {
         super(email, limitIp, totalGB, expiryTime, enable, tgId, subId, comment, reset, created_at, updated_at);
         this.auth = auth;
+        this.allowInsecure = allowInsecure;
     }
 
     toJson() {
         return {
             auth: this.auth,
+            allowInsecure: this.allowInsecure,
             ...this._clientBaseToJson(),
         };
     }
@@ -2968,6 +2977,7 @@ Inbound.HysteriaSettings.Hysteria = class extends Inbound.ClientBase {
     static fromJson(json = {}) {
         return new Inbound.HysteriaSettings.Hysteria(
             json.auth,
+            json.allowInsecure ?? false,
             ...Inbound.ClientBase.commonArgsFromJson(json),
         );
     }

--- a/frontend/src/models/outbound.js
+++ b/frontend/src/models/outbound.js
@@ -570,6 +570,7 @@ export class TlsStreamSettings extends CommonClass {
         alpn = [],
         fingerprint = '',
         echConfigList = '',
+        allowInsecure = false,
         verifyPeerCertByName = '',
         pinnedPeerCertSha256 = '',
     ) {
@@ -578,6 +579,7 @@ export class TlsStreamSettings extends CommonClass {
         this.alpn = alpn;
         this.fingerprint = fingerprint;
         this.echConfigList = echConfigList;
+        this.allowInsecure = allowInsecure;
         this.verifyPeerCertByName = verifyPeerCertByName;
         this.pinnedPeerCertSha256 = pinnedPeerCertSha256;
     }
@@ -588,6 +590,7 @@ export class TlsStreamSettings extends CommonClass {
             json.alpn,
             json.fingerprint,
             json.echConfigList,
+            json.allowInsecure,
             json.verifyPeerCertByName,
             json.pinnedPeerCertSha256,
         );
@@ -599,6 +602,7 @@ export class TlsStreamSettings extends CommonClass {
             alpn: this.alpn,
             fingerprint: this.fingerprint,
             echConfigList: this.echConfigList,
+            allowInsecure: this.allowInsecure,
             verifyPeerCertByName: this.verifyPeerCertByName,
             pinnedPeerCertSha256: this.pinnedPeerCertSha256
         };
@@ -1540,7 +1544,8 @@ export class Outbound extends CommonClass {
             let alpn = urlParams.get('alpn');
             let sni = urlParams.get('sni') ?? '';
             let ech = urlParams.get('ech') ?? '';
-            stream.tls = new TlsStreamSettings(sni, alpn ? alpn.split(',') : [], fp, ech);
+            const insecure = ['1', 'true'].includes((urlParams.get('insecure') ?? '').toLowerCase());
+            stream.tls = new TlsStreamSettings(sni, alpn ? alpn.split(',') : [], fp, ech, insecure);
         }
 
         // Set hysteria stream settings

--- a/frontend/src/pages/inbounds/ClientFormModal.vue
+++ b/frontend/src/pages/inbounds/ClientFormModal.vue
@@ -271,6 +271,9 @@ const title = computed(() =>
         </template>
         <a-input v-model:value="client.auth" />
       </a-form-item>
+      <a-form-item v-if="protocol === Protocols.HYSTERIA" label="Allow Insecure">
+        <a-switch v-model:checked="client.allowInsecure" />
+      </a-form-item>
 
       <a-form-item v-if="isVmessOrVless">
         <template #label>

--- a/frontend/src/pages/inbounds/InboundFormModal.vue
+++ b/frontend/src/pages/inbounds/InboundFormModal.vue
@@ -1690,6 +1690,9 @@ watch(() => inbound.value?.protocol, () => stampAdvancedTextFor('stream'));
             <a-form-item label="Session Resumption">
               <a-switch v-model:checked="inbound.stream.tls.enableSessionResumption" />
             </a-form-item>
+            <a-form-item label="Allow Insecure">
+              <a-switch v-model:checked="inbound.stream.tls.settings.allowInsecure" />
+            </a-form-item>
 
 
             <!-- Cert array — file path or inline content per row -->

--- a/frontend/src/pages/xray/OutboundFormModal.vue
+++ b/frontend/src/pages/xray/OutboundFormModal.vue
@@ -894,6 +894,9 @@ function regenerateWgKeys() {
               <a-form-item label="Pinned SHA256">
                 <a-input v-model:value="outbound.stream.tls.pinnedPeerCertSha256" placeholder="base64 SHA256" />
               </a-form-item>
+              <a-form-item label="Allow Insecure">
+                <a-switch v-model:checked="outbound.stream.tls.allowInsecure" />
+              </a-form-item>
             </template>
 
             <template v-if="outbound.stream.isReality">

--- a/sub/subService.go
+++ b/sub/subService.go
@@ -446,6 +446,7 @@ func (s *SubService) genHysteriaLink(inbound *model.Inbound, email string) strin
 		}
 	}
 	auth := clients[clientIndex].Auth
+	clientAllowInsecure := clients[clientIndex].AllowInsecure
 	params := make(map[string]string)
 
 	params["security"] = "tls"
@@ -467,7 +468,9 @@ func (s *SubService) genHysteriaLink(inbound *model.Inbound, email string) strin
 		if fpValue, ok := searchKey(tlsSettings, "fingerprint"); ok {
 			params["fp"], _ = fpValue.(string)
 		}
-		if insecure, ok := searchKey(tlsSettings, "allowInsecure"); ok {
+		if clientAllowInsecure {
+			params["insecure"] = "1"
+		} else if insecure, ok := searchKey(tlsSettings, "allowInsecure"); ok {
 			if insecure.(bool) {
 				params["insecure"] = "1"
 			}


### PR DESCRIPTION
## What is the pull request?

⚠️ **Caution:** This fix is coded by AI.

- Add Allow Insecure switch for Hysteria client settings in Inbounds client modal
- Persist allowInsecure in Hysteria client model
- Use client-level allowInsecure when generating Hysteria/Hysteria2 links (fallback to inbound TLS setting)
- Add backend support so subscription links include insecure=1 from client allowInsecure
Closes: https://github.com/MHSanaei/3x-ui/issues/4445"

<!-- Briefly describe the changes introduced by this pull request -->

## Which part of the application is affected by the change?

- Frontend and Backend

## Type of Changes

- New feature

## Screenshots

<img width="844" height="771" alt="image" src="https://github.com/user-attachments/assets/2777ac96-bf3c-4556-b0a1-61cdcc54b682" />


<!-- Add screenshots to illustrate the changes -->
<!-- Remove this section if it is not applicable. -->