### PR TITLE
feat(inbound): scaffold dedicated SOCKS5 inbound protocol

### DIFF
--- a/database/model/model.go
+++ b/database/model/model.go
@@ -37,6 +37,18 @@ func IsHysteria(p Protocol) bool {
 	return p == Hysteria || p == Hysteria2
 }
 
+// IsSocksLike returns true for both the dedicated "socks" inbound and
+// the combined "mixed" inbound, since Mixed exposes SOCKS5 alongside
+// HTTP on the same port and accepts the exact same settings shape
+// (auth/accounts/udp/ip) that the pure Socks inbound does.
+//
+// Use this helper anywhere routing, sub-link generation, or UI code
+// needs to treat "this inbound speaks SOCKS5" uniformly without
+// re-listing both constants at every call site.
+func IsSocksLike(p Protocol) bool {
+	return p == Socks || p == Mixed
+}
+
 // User represents a user account in the 3x-ui panel.
 type User struct {
 	Id         int    `json:"id" gorm:"primaryKey;autoIncrement"`

--- a/database/model/model.go
+++ b/database/model/model.go
@@ -49,6 +49,26 @@ func IsSocksLike(p Protocol) bool {
 	return p == Socks || p == Mixed
 }
 
+// IsAccountBased returns true for protocols whose Xray inbound config
+// stores user credentials under settings.accounts[] (an array of
+// {user, pass} objects) rather than settings.clients[] (the
+// Client struct with id/password/auth/email/etc.).
+//
+// This currently covers Socks, Mixed, and HTTP — all three inbounds
+// share the same proxy/socks-style Account wire type. The panel's
+// client-lifecycle code paths (AddInboundClient / UpdateInboundClient /
+// DelInboundClient, depletion, traffic reset, telegram bot 'add client'
+// keyboard, …) all assume settings.clients[] and would either panic
+// or silently corrupt the JSON if pointed at an account-based inbound,
+// so they bail out early on this helper.
+//
+// WireGuard is intentionally NOT in this set: its peers live under
+// settings.peers[] and the panel manages them through a separate
+// dedicated path, not the client lifecycle covered here.
+func IsAccountBased(p Protocol) bool {
+	return p == Socks || p == Mixed || p == HTTP
+}
+
 // User represents a user account in the 3x-ui panel.
 type User struct {
 	Id         int    `json:"id" gorm:"primaryKey;autoIncrement"`

--- a/database/model/model.go
+++ b/database/model/model.go
@@ -20,9 +20,14 @@ const (
 	Trojan      Protocol = "trojan"
 	Shadowsocks Protocol = "shadowsocks"
 	Mixed       Protocol = "mixed"
-	WireGuard   Protocol = "wireguard"
-	Hysteria    Protocol = "hysteria"
-	Hysteria2   Protocol = "hysteria2"
+	// Socks is a dedicated SOCKS5 inbound (Xray "socks" protocol).
+	// Unlike Mixed (HTTP+SOCKS), this is a pure SOCKS5 inbound and is
+	// intended for tunneling clients that only speak SOCKS5.
+	// See: https://xtls.github.io/config/inbounds/socks.html
+	Socks     Protocol = "socks"
+	WireGuard Protocol = "wireguard"
+	Hysteria  Protocol = "hysteria"
+	Hysteria2 Protocol = "hysteria2"
 )
 
 // IsHysteria returns true for both "hysteria" and "hysteria2".

--- a/database/model/model_test.go
+++ b/database/model/model_test.go
@@ -59,3 +59,45 @@ func TestIsSocksLike(t *testing.T) {
 		}
 	}
 }
+
+// TestIsAccountBased pins the set of inbounds that route credentials
+// through settings.accounts[] rather than settings.clients[]. Anything
+// that returns true here is OFF-LIMITS for the client-lifecycle code
+// paths (AddInboundClient / UpdateInboundClient / DelInboundClient,
+// depletion, traffic reset, telegram 'add client' keyboard).
+//
+// HTTP is intentionally included even though the panel UI doesn't
+// currently surface it as a standalone protocol — the runtime API
+// AddUser branch in xray/api.go handles it symmetrically with socks,
+// and any future UI work plugging HTTP back in inherits the same
+// safety net for free.
+//
+// WireGuard is intentionally EXCLUDED: its peers live under
+// settings.peers[] and are managed through a separate path; treating
+// it as account-based would lock out the existing wireguard UI.
+func TestIsAccountBased(t *testing.T) {
+	cases := []struct {
+		in   Protocol
+		want bool
+	}{
+		{Socks, true},
+		{Mixed, true},
+		{HTTP, true},
+
+		{VLESS, false},
+		{VMESS, false},
+		{Trojan, false},
+		{Shadowsocks, false},
+		{WireGuard, false}, // peers, not accounts; managed separately
+		{Hysteria, false},
+		{Hysteria2, false},
+		{Tunnel, false},
+		{Protocol(""), false},
+		{Protocol("SOCKS"), false}, // case-sensitive lowercase invariant
+	}
+	for _, c := range cases {
+		if got := IsAccountBased(c.in); got != c.want {
+			t.Errorf("IsAccountBased(%q) = %v, want %v", c.in, got, c.want)
+		}
+	}
+}

--- a/database/model/model_test.go
+++ b/database/model/model_test.go
@@ -20,3 +20,42 @@ func TestIsHysteria(t *testing.T) {
 		}
 	}
 }
+
+// TestSocksProtocolConstant pins the wire value of the SOCKS5 protocol
+// constant. It must stay "socks" because that's the literal Xray expects
+// in inbound.protocol JSON (see https://xtls.github.io/config/inbounds/socks.html);
+// changing it would silently break every stored inbound row.
+func TestSocksProtocolConstant(t *testing.T) {
+	if got, want := string(Socks), "socks"; got != want {
+		t.Errorf("Socks protocol constant = %q, want %q", got, want)
+	}
+	if Socks == Mixed {
+		t.Error("Socks and Mixed must be distinct protocols")
+	}
+}
+
+func TestIsSocksLike(t *testing.T) {
+	cases := []struct {
+		in   Protocol
+		want bool
+	}{
+		{Socks, true},
+		{Mixed, true},
+		{HTTP, false},
+		{VLESS, false},
+		{VMESS, false},
+		{Trojan, false},
+		{Shadowsocks, false},
+		{WireGuard, false},
+		{Hysteria, false},
+		{Hysteria2, false},
+		{Tunnel, false},
+		{Protocol(""), false},
+		{Protocol("SOCKS"), false}, // case-sensitive: must match the stored lowercase value
+	}
+	for _, c := range cases {
+		if got := IsSocksLike(c.in); got != c.want {
+			t.Errorf("IsSocksLike(%q) = %v, want %v", c.in, got, c.want)
+		}
+	}
+}

--- a/frontend/src/models/dbinbound.js
+++ b/frontend/src/models/dbinbound.js
@@ -62,6 +62,20 @@ export class DBInbound {
         return this.protocol === Protocols.MIXED;
     }
 
+    // Pure SOCKS5 inbound (Xray "socks" protocol, RFC 1928). Distinct
+    // from `isMixed`, which is HTTP+SOCKS on the same port. Use
+    // `isSocksLike` when you want either one.
+    get isSocks() {
+        return this.protocol === Protocols.SOCKS;
+    }
+
+    // True for both the dedicated SOCKS5 inbound and the combined
+    // Mixed inbound, since both speak SOCKS5 and share the same
+    // settings shape (auth/accounts/udp/ip).
+    get isSocksLike() {
+        return this.protocol === Protocols.SOCKS || this.protocol === Protocols.MIXED;
+    }
+
     get isHTTP() {
         return this.protocol === Protocols.HTTP;
     }

--- a/frontend/src/models/inbound.js
+++ b/frontend/src/models/inbound.js
@@ -10,6 +10,9 @@ export const Protocols = {
     WIREGUARD: 'wireguard',
     HYSTERIA: 'hysteria',
     MIXED: 'mixed',
+    // Dedicated SOCKS5 inbound. Use MIXED if you also need HTTP support
+    // on the same port; SOCKS is pure SOCKS5 (RFC 1928) only.
+    SOCKS: 'socks',
     HTTP: 'http',
     TUNNEL: 'tunnel',
     TUN: 'tun',
@@ -2448,6 +2451,7 @@ Inbound.Settings = class extends XrayCommonClass {
             case Protocols.SHADOWSOCKS: return new Inbound.ShadowsocksSettings(protocol);
             case Protocols.TUNNEL: return new Inbound.TunnelSettings(protocol);
             case Protocols.MIXED: return new Inbound.MixedSettings(protocol);
+            case Protocols.SOCKS: return new Inbound.SocksSettings(protocol);
             case Protocols.HTTP: return new Inbound.HttpSettings(protocol);
             case Protocols.WIREGUARD: return new Inbound.WireguardSettings(protocol);
             case Protocols.TUN: return new Inbound.TunSettings(protocol);
@@ -2464,6 +2468,7 @@ Inbound.Settings = class extends XrayCommonClass {
             case Protocols.SHADOWSOCKS: return Inbound.ShadowsocksSettings.fromJson(json);
             case Protocols.TUNNEL: return Inbound.TunnelSettings.fromJson(json);
             case Protocols.MIXED: return Inbound.MixedSettings.fromJson(json);
+            case Protocols.SOCKS: return Inbound.SocksSettings.fromJson(json);
             case Protocols.HTTP: return Inbound.HttpSettings.fromJson(json);
             case Protocols.WIREGUARD: return Inbound.WireguardSettings.fromJson(json);
             case Protocols.TUN: return Inbound.TunSettings.fromJson(json);
@@ -3071,6 +3076,85 @@ Inbound.MixedSettings.SocksAccount = class extends XrayCommonClass {
 
     static fromJson(json = {}) {
         return new Inbound.MixedSettings.SocksAccount(json.user, json.pass);
+    }
+};
+
+// Dedicated SOCKS5 inbound settings.
+//
+// This mirrors Xray's `socks` inbound (RFC 1928), see:
+//   https://xtls.github.io/config/inbounds/socks.html
+//
+// Unlike MixedSettings (which exposes HTTP+SOCKS on the same port),
+// SocksSettings configures a pure SOCKS5 inbound. The accepted fields
+// are the same shape Xray expects:
+//   - auth: "noauth" | "password"
+//   - accounts: [{ user, pass }]  (only used when auth === "password")
+//   - udp: bool                   (enables UDP ASSOCIATE)
+//   - ip:  string                 (address sent to client for UDP replies,
+//                                  defaults to 127.0.0.1)
+//
+// NOTE: SOCKS inbounds are tunnel-style and do not produce a subscription
+// link (mirrors how MIXED/HTTP are treated in sub/subService.go::GetLink).
+Inbound.SocksSettings = class extends Inbound.Settings {
+    constructor(
+        protocol,
+        auth = 'password',
+        accounts = [new Inbound.SocksSettings.SocksAccount()],
+        udp = false,
+        ip = '127.0.0.1',
+    ) {
+        super(protocol);
+        this.auth = auth;
+        this.accounts = accounts;
+        this.udp = udp;
+        this.ip = ip;
+    }
+
+    addAccount(account) {
+        this.accounts.push(account);
+    }
+
+    delAccount(index) {
+        this.accounts.splice(index, 1);
+    }
+
+    static fromJson(json = {}) {
+        let accounts;
+        if (json.auth === 'password') {
+            accounts = (json.accounts || []).map(
+                account => Inbound.SocksSettings.SocksAccount.fromJson(account)
+            );
+        }
+        return new Inbound.SocksSettings(
+            Protocols.SOCKS,
+            json.auth,
+            accounts,
+            json.udp,
+            json.ip,
+        );
+    }
+
+    toJson() {
+        return {
+            auth: this.auth,
+            accounts: this.auth === 'password'
+                ? this.accounts.map(account => account.toJson())
+                : undefined,
+            udp: this.udp,
+            ip: this.ip,
+        };
+    }
+};
+
+Inbound.SocksSettings.SocksAccount = class extends XrayCommonClass {
+    constructor(user = RandomUtil.randomSeq(10), pass = RandomUtil.randomSeq(10)) {
+        super();
+        this.user = user;
+        this.pass = pass;
+    }
+
+    static fromJson(json = {}) {
+        return new Inbound.SocksSettings.SocksAccount(json.user, json.pass);
     }
 };
 

--- a/frontend/src/pages/inbounds/InboundFormModal.vue
+++ b/frontend/src/pages/inbounds/InboundFormModal.vue
@@ -174,6 +174,26 @@ function delFallback(idx) {
   inbound.value?.settings?.delFallback?.(idx);
 }
 
+// Helper for the shared HTTP / MIXED / SOCKS accounts editor: dispatches
+// to the right Account class so each protocol stores accounts in the
+// shape Xray expects on the wire.
+function addAccountByProtocol() {
+  const settings = inbound.value?.settings;
+  if (!settings) return;
+  switch (inbound.value.protocol) {
+    case Protocols.HTTP:
+      settings.addAccount(new Inbound.HttpSettings.HttpAccount());
+      break;
+    case Protocols.SOCKS:
+      settings.addAccount(new Inbound.SocksSettings.SocksAccount());
+      break;
+    case Protocols.MIXED:
+    default:
+      settings.addAccount(new Inbound.MixedSettings.SocksAccount());
+      break;
+  }
+}
+
 // Date / GB bridges (legacy used moment via _expiryTime; we go direct).
 const expiryDate = computed({
   get: () => (dbForm.value?.expiryTime > 0 ? dayjs(dbForm.value.expiryTime) : null),
@@ -964,13 +984,12 @@ watch(() => inbound.value?.protocol, () => stampAdvancedTextFor('stream'));
           </a-form-item>
         </a-form>
 
-        <!-- HTTP / Mixed accounts -->
-        <a-form v-if="protocol === Protocols.HTTP || protocol === Protocols.MIXED" :colon="false"
-          :label-col="{ sm: { span: 8 } }" :wrapper-col="{ sm: { span: 14 } }" class="mt-12">
+        <!-- HTTP / Mixed / SOCKS accounts -->
+        <a-form
+          v-if="protocol === Protocols.HTTP || protocol === Protocols.MIXED || protocol === Protocols.SOCKS"
+          :colon="false" :label-col="{ sm: { span: 8 } }" :wrapper-col="{ sm: { span: 14 } }" class="mt-12">
           <a-form-item label="Accounts">
-            <a-button size="small" @click="protocol === Protocols.HTTP
-              ? inbound.settings.addAccount(new Inbound.HttpSettings.HttpAccount())
-              : inbound.settings.addAccount(new Inbound.MixedSettings.SocksAccount())">
+            <a-button size="small" @click="addAccountByProtocol()">
               <template #icon>
                 <PlusOutlined />
               </template>
@@ -993,7 +1012,7 @@ watch(() => inbound.value?.protocol, () => stampAdvancedTextFor('stream'));
           <a-form-item v-if="protocol === Protocols.HTTP" label="Allow transparent">
             <a-switch v-model:checked="inbound.settings.allowTransparent" />
           </a-form-item>
-          <template v-if="protocol === Protocols.MIXED">
+          <template v-if="protocol === Protocols.MIXED || protocol === Protocols.SOCKS">
             <a-form-item label="Auth">
               <a-select v-model:value="inbound.settings.auth">
                 <a-select-option value="noauth">noauth</a-select-option>

--- a/frontend/src/pages/inbounds/InboundInfoModal.vue
+++ b/frontend/src/pages/inbounds/InboundInfoModal.vue
@@ -26,7 +26,7 @@ const { datepicker } = useDatepicker();
 //     client row + share links
 //   • SS single-user → connection details + share link
 //   • WireGuard → secret/peers + per-peer config download
-//   • Mixed/HTTP/Tunnel → connection details only
+//   • Mixed/SOCKS/HTTP/Tunnel → connection details only
 //
 // We display links via QrPanel — each link gets its own QR + copy +
 // (for WireGuard configs) download button.
@@ -640,8 +640,9 @@ const showSubscriptionTab = computed(
             </div>
           </dl>
 
-          <!-- Mixed -->
-          <dl v-if="dbInbound.isMixed" class="info-list info-list-block">
+          <!-- Mixed / SOCKS: share the same auth/udp/ip + accounts shape
+               (Xray's mixed and socks inbounds accept the same keys). -->
+          <dl v-if="dbInbound.isSocksLike" class="info-list info-list-block">
             <div class="info-row">
               <dt>Auth</dt>
               <dd>

--- a/sub/subService.go
+++ b/sub/subService.go
@@ -209,18 +209,27 @@ func (s *SubService) getFallbackMaster(dest string, streamSettings string) (stri
 // pair. Returns "" when the inbound's protocol doesn't produce a subscription URL
 // (socks, http, mixed, wireguard, dokodemo, tunnel). The returned string may
 // contain multiple `\n`-separated URLs when the inbound has externalProxy set.
+//
+// SOCKS5 and Mixed are deliberately link-less here. A `socks://user:pass@host:port`
+// form exists in some client ecosystems but is not standardised across the
+// xray/v2ray clients we target, and emitting one would mislead users into
+// pasting it into clients that silently ignore it. Tracked as follow-up #1
+// in the SOCKS5 scaffold PR description.
 func (s *SubService) GetLink(inbound *model.Inbound, email string) string {
 	switch inbound.Protocol {
-	case "vmess":
+	case model.VMESS:
 		return s.genVmessLink(inbound, email)
-	case "vless":
+	case model.VLESS:
 		return s.genVlessLink(inbound, email)
-	case "trojan":
+	case model.Trojan:
 		return s.genTrojanLink(inbound, email)
-	case "shadowsocks":
+	case model.Shadowsocks:
 		return s.genShadowsocksLink(inbound, email)
-	case "hysteria", "hysteria2":
+	case model.Hysteria, model.Hysteria2:
 		return s.genHysteriaLink(inbound, email)
+	case model.Socks, model.Mixed, model.HTTP, model.Tunnel, model.WireGuard:
+		// Tunnel-style or proxy-listener protocols: no per-client URL.
+		return ""
 	}
 	return ""
 }

--- a/web/service/inbound.go
+++ b/web/service/inbound.go
@@ -289,7 +289,7 @@ func (s *InboundService) normalizeStreamSettings(inbound *model.Inbound) {
 		model.Hysteria:    true,
 		model.Hysteria2:   true,
 	}
-	
+
 	if !protocolsWithStream[inbound.Protocol] {
 		inbound.StreamSettings = ""
 	}
@@ -302,7 +302,7 @@ func (s *InboundService) normalizeStreamSettings(inbound *model.Inbound) {
 func (s *InboundService) AddInbound(inbound *model.Inbound) (*model.Inbound, bool, error) {
 	// Normalize streamSettings based on protocol
 	s.normalizeStreamSettings(inbound)
-	
+
 	exist, err := s.checkPortConflict(inbound, 0)
 	if err != nil {
 		return inbound, false, err
@@ -558,7 +558,7 @@ func (s *InboundService) SetInboundEnable(id int, enable bool) (bool, error) {
 func (s *InboundService) UpdateInbound(inbound *model.Inbound) (*model.Inbound, bool, error) {
 	// Normalize streamSettings based on protocol
 	s.normalizeStreamSettings(inbound)
-	
+
 	exist, err := s.checkPortConflict(inbound, inbound.Id)
 	if err != nil {
 		return inbound, false, err
@@ -840,6 +840,26 @@ func (s *InboundService) updateClientTraffics(tx *gorm.DB, oldInbound *model.Inb
 }
 
 func (s *InboundService) AddInboundClient(data *model.Inbound) (bool, error) {
+	// Account-based inbounds (Socks/Mixed/HTTP) store credentials under
+	// settings.accounts[] (an array of {user, pass} objects), not
+	// settings.clients[]. The whole client lifecycle (this method, plus
+	// UpdateInboundClient/DelInboundClient/CopyInboundClients, depletion,
+	// traffic reset, Telegram 'add client' keyboard, sub-link generation)
+	// assumes the latter shape. Resolving the inbound up front lets us
+	// reject account-based protocols with a clear error instead of
+	// panicking on the unchecked `settings["clients"].([]any)` cast below.
+	targetInbound, err := s.GetInbound(data.Id)
+	if err != nil {
+		return false, err
+	}
+	if model.IsAccountBased(targetInbound.Protocol) {
+		return false, common.NewError(
+			"client lifecycle is not supported for account-based protocol:",
+			string(targetInbound.Protocol),
+			"— update the inbound directly with settings.accounts[] instead",
+		)
+	}
+
 	clients, err := s.GetClients(data)
 	if err != nil {
 		return false, err
@@ -871,10 +891,8 @@ func (s *InboundService) AddInboundClient(data *model.Inbound) (bool, error) {
 		return false, common.NewError("Duplicate email:", existEmail)
 	}
 
-	oldInbound, err := s.GetInbound(data.Id)
-	if err != nil {
-		return false, err
-	}
+	// Already loaded above as part of the account-based guard.
+	oldInbound := targetInbound
 
 	// Secure client ID
 	for _, client := range clients {
@@ -1091,6 +1109,28 @@ func (s *InboundService) CopyInboundClients(targetInboundID int, sourceInboundID
 		return result, false, err
 	}
 
+	// Account-based inbounds (Socks/Mixed/HTTP) don't participate in the
+	// client-copy flow: they don't store per-client metadata (sub-id,
+	// totalGB, expiry, …) — just plain {user, pass} accounts. Trying to
+	// copy clients into or out of them would either downcast a rich
+	// client to a bare account (losing data silently) or upcast an
+	// account into a client that the runtime can't actually use. Refuse
+	// the operation explicitly on either side.
+	if model.IsAccountBased(sourceInbound.Protocol) {
+		return result, false, common.NewError(
+			"copy clients: source inbound uses account-based protocol:",
+			string(sourceInbound.Protocol),
+			"— manage settings.accounts[] directly via inbound update",
+		)
+	}
+	if model.IsAccountBased(targetInbound.Protocol) {
+		return result, false, common.NewError(
+			"copy clients: target inbound uses account-based protocol:",
+			string(targetInbound.Protocol),
+			"— manage settings.accounts[] directly via inbound update",
+		)
+	}
+
 	sourceClients, err := s.GetClients(sourceInbound)
 	if err != nil {
 		return result, false, err
@@ -1184,6 +1224,16 @@ func (s *InboundService) DelInboundClient(inboundId int, clientId string) (bool,
 	if err != nil {
 		logger.Error("Load Old Data Error")
 		return false, err
+	}
+	// See AddInboundClient: account-based inbounds (Socks/Mixed/HTTP) have
+	// no settings.clients[] to delete from. Refuse early with a clear error
+	// instead of panicking on the type assertion below.
+	if model.IsAccountBased(oldInbound.Protocol) {
+		return false, common.NewError(
+			"client lifecycle is not supported for account-based protocol:",
+			string(oldInbound.Protocol),
+			"— update the inbound directly with settings.accounts[] instead",
+		)
 	}
 	var settings map[string]any
 	err = json.Unmarshal([]byte(oldInbound.Settings), &settings)
@@ -1296,6 +1346,22 @@ func (s *InboundService) DelInboundClient(inboundId int, clientId string) (bool,
 
 func (s *InboundService) UpdateInboundClient(data *model.Inbound, clientId string) (bool, error) {
 	// TODO: check if TrafficReset field is updating
+
+	// Resolve the inbound first so we can refuse account-based protocols
+	// (Socks/Mixed/HTTP) before touching the settings["clients"] cast.
+	// See AddInboundClient for the rationale.
+	oldInbound, err := s.GetInbound(data.Id)
+	if err != nil {
+		return false, err
+	}
+	if model.IsAccountBased(oldInbound.Protocol) {
+		return false, common.NewError(
+			"client lifecycle is not supported for account-based protocol:",
+			string(oldInbound.Protocol),
+			"— update the inbound directly with settings.accounts[] instead",
+		)
+	}
+
 	clients, err := s.GetClients(data)
 	if err != nil {
 		return false, err
@@ -1308,11 +1374,6 @@ func (s *InboundService) UpdateInboundClient(data *model.Inbound, clientId strin
 	}
 
 	interfaceClients := settings["clients"].([]any)
-
-	oldInbound, err := s.GetInbound(data.Id)
-	if err != nil {
-		return false, err
-	}
 
 	oldClients, err := s.GetClients(oldInbound)
 	if err != nil {

--- a/web/service/inbound_socks_guards_test.go
+++ b/web/service/inbound_socks_guards_test.go
@@ -1,0 +1,150 @@
+package service
+
+// Guard tests for the client-lifecycle methods on InboundService when
+// applied to account-based inbounds (Socks/Mixed/HTTP).
+//
+// The intent here is narrow: prove that AddInboundClient,
+// UpdateInboundClient, DelInboundClient and CopyInboundClients refuse
+// account-based protocols cleanly *before* they ever hit the
+// `settings["clients"].([]any)` cast — which would otherwise panic,
+// because account-based inbounds carry settings.accounts[] instead.
+//
+// We deliberately don't exercise the happy path for client-based
+// protocols here — that's covered elsewhere — and we don't need to
+// boot xray / runtimes because the guards short-circuit at the very
+// top of each method. A tiny in-memory sqlite from setupConflictDB is
+// enough.
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/mhsanaei/3x-ui/v3/database"
+	"github.com/mhsanaei/3x-ui/v3/database/model"
+)
+
+// socksAccountsSettings is a minimal but realistic settings payload for
+// a SOCKS5 inbound. The shape (accounts[]) is what makes the unguarded
+// `settings["clients"].([]any)` cast panic — we keep it real so the
+// regression is obvious if the guards ever get removed.
+const socksAccountsSettings = `{"auth":"password","accounts":[{"user":"alice","pass":"hunter2"}],"udp":false,"ip":"127.0.0.1"}`
+
+// clientPayloadJSON is a stub "client add" payload. The guards must
+// reject the call regardless of what the client envelope contains, so
+// the actual fields here don't matter — what matters is that the call
+// is made against a SOCKS inbound.
+const clientPayloadJSON = `{"clients":[{"id":"00000000-0000-0000-0000-000000000000","email":"ignored@example.com","enable":true}]}`
+
+func seedSocksInbound(t *testing.T) *model.Inbound {
+	t.Helper()
+	seedInboundConflict(t, "socks-guard", "0.0.0.0", 1080, model.Socks, `{"network":"tcp"}`, socksAccountsSettings)
+
+	var ib model.Inbound
+	if err := database.GetDB().Where("tag = ?", "socks-guard").First(&ib).Error; err != nil {
+		t.Fatalf("load seeded socks inbound: %v", err)
+	}
+	return &ib
+}
+
+func seedVlessInbound(t *testing.T) *model.Inbound {
+	t.Helper()
+	const vlessSettings = `{"clients":[{"id":"11111111-1111-1111-1111-111111111111","email":"v@example.com","enable":true}],"decryption":"none"}`
+	seedInboundConflict(t, "vless-source", "0.0.0.0", 1443, model.VLESS, `{"network":"tcp"}`, vlessSettings)
+
+	var ib model.Inbound
+	if err := database.GetDB().Where("tag = ?", "vless-source").First(&ib).Error; err != nil {
+		t.Fatalf("load seeded vless inbound: %v", err)
+	}
+	return &ib
+}
+
+// expectAccountBasedError fails the test unless err is the well-known
+// "client lifecycle is not supported for account-based protocol" error
+// emitted by the guards. We match on substring to stay decoupled from
+// the exact common.NewError formatting (which space-joins its args).
+func expectAccountBasedError(t *testing.T, err error) {
+	t.Helper()
+	if err == nil {
+		t.Fatalf("expected account-based guard error, got nil — guard may be missing")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "account-based protocol") {
+		t.Fatalf("expected account-based guard error, got: %v", err)
+	}
+}
+
+func TestAddInboundClient_RejectsSocks(t *testing.T) {
+	setupConflictDB(t)
+	ib := seedSocksInbound(t)
+
+	svc := &InboundService{}
+	_, err := svc.AddInboundClient(&model.Inbound{
+		Id:       ib.Id,
+		Settings: clientPayloadJSON,
+	})
+	expectAccountBasedError(t, err)
+}
+
+func TestUpdateInboundClient_RejectsSocks(t *testing.T) {
+	setupConflictDB(t)
+	ib := seedSocksInbound(t)
+
+	svc := &InboundService{}
+	_, err := svc.UpdateInboundClient(&model.Inbound{
+		Id:       ib.Id,
+		Settings: clientPayloadJSON,
+	}, "any-client-id")
+	expectAccountBasedError(t, err)
+}
+
+func TestDelInboundClient_RejectsSocks(t *testing.T) {
+	setupConflictDB(t)
+	ib := seedSocksInbound(t)
+
+	svc := &InboundService{}
+	_, err := svc.DelInboundClient(ib.Id, "any-client-id")
+	expectAccountBasedError(t, err)
+}
+
+// SOCKS as source and as target both have to be refused — neither
+// direction has well-defined semantics (downcasting a rich client to
+// {user, pass} would silently drop sub-id / totalGB / expiry; upcasting
+// the other way would invent fields that the runtime can't honor).
+func TestCopyInboundClients_RejectsSocksSource(t *testing.T) {
+	setupConflictDB(t)
+	socks := seedSocksInbound(t)
+	vless := seedVlessInbound(t)
+
+	svc := &InboundService{}
+	_, _, err := svc.CopyInboundClients(vless.Id, socks.Id, nil, "")
+	expectAccountBasedError(t, err)
+}
+
+func TestCopyInboundClients_RejectsSocksTarget(t *testing.T) {
+	setupConflictDB(t)
+	socks := seedSocksInbound(t)
+	vless := seedVlessInbound(t)
+
+	svc := &InboundService{}
+	_, _, err := svc.CopyInboundClients(socks.Id, vless.Id, nil, "")
+	expectAccountBasedError(t, err)
+}
+
+// Sanity check: the guards must NOT fire on client-based inbounds.
+// If this ever flips, AddInboundClient is broken for everyone, not
+// just SOCKS users. We don't assert success (the call may legitimately
+// fail later in the pipeline because we haven't booted xray) — we just
+// assert that whatever error comes back is *not* the guard error.
+func TestAddInboundClient_AllowsVless(t *testing.T) {
+	setupConflictDB(t)
+	ib := seedVlessInbound(t)
+
+	svc := &InboundService{}
+	_, err := svc.AddInboundClient(&model.Inbound{
+		Id:       ib.Id,
+		Settings: clientPayloadJSON,
+	})
+	if err != nil && strings.Contains(err.Error(), "account-based protocol") {
+		t.Fatalf("guard should not fire on VLESS, got: %v", err)
+	}
+}

--- a/web/service/port_conflict.go
+++ b/web/service/port_conflict.go
@@ -31,7 +31,9 @@ func (b transportBits) conflicts(o transportBits) bool { return b&o != 0 }
 //   - hysteria, hysteria2, wireguard: udp regardless of streamSettings
 //   - streamSettings.network=kcp: udp
 //   - shadowsocks: whatever settings.network says ("tcp" / "udp" / "tcp,udp")
-//   - mixed (socks/http combo): tcp + udp when settings.udp is true
+//   - mixed (socks/http combo) and socks: tcp + udp when settings.udp is true
+//     (xray's dedicated socks5 inbound supports UDP ASSOCIATE on the same
+//     port via settings.udp, exactly the same shape as mixed)
 //   - everything else: tcp
 func inboundTransports(protocol model.Protocol, streamSettings, settings string) transportBits {
 	// protocols that ignore streamSettings entirely.
@@ -81,9 +83,13 @@ func inboundTransports(protocol model.Protocol, streamSettings, settings string)
 						}
 					}
 				}
-			case model.Mixed:
-				// socks/http "mixed" inbound: settings.udp=true means it
-				// also relays udp on the same port (socks5 udp associate).
+			case model.Mixed, model.Socks:
+				// socks/http "mixed" inbound and the dedicated socks5
+				// inbound: settings.udp=true means the inbound also relays
+				// udp on the same port (socks5 udp associate). Mixed and
+				// Socks share the exact same settings shape here, so we
+				// route them through the same branch instead of duplicating
+				// the type-assertion.
 				if udpOn, _ := st["udp"].(bool); udpOn {
 					bits |= transportUDP
 				}

--- a/web/service/port_conflict_test.go
+++ b/web/service/port_conflict_test.go
@@ -87,6 +87,17 @@ func TestInboundTransports(t *testing.T) {
 		{"mixed udp on", model.Mixed, `{"network":"tcp"}`, `{"udp":true}`, transportTCP | transportUDP},
 		{"mixed udp off", model.Mixed, `{"network":"tcp"}`, `{"udp":false}`, transportTCP},
 		{"mixed udp missing", model.Mixed, `{"network":"tcp"}`, `{}`, transportTCP},
+
+		// SOCKS (the dedicated socks5 inbound) shares the udp-associate
+		// shape with Mixed: settings.udp=true means the same port also
+		// accepts UDP. These cases pin that the port-conflict check
+		// treats Socks the same way Mixed is treated above, so a
+		// stale tcp neighbour won't silently block UDP-only socks
+		// traffic (or vice versa).
+		{"socks udp on", model.Socks, ``, `{"udp":true}`, transportTCP | transportUDP},
+		{"socks udp off", model.Socks, ``, `{"udp":false}`, transportTCP},
+		{"socks udp missing", model.Socks, ``, `{}`, transportTCP},
+		{"socks empty settings", model.Socks, ``, ``, transportTCP},
 	}
 
 	for _, c := range cases {
@@ -467,6 +478,47 @@ func TestResolveInboundTag_RegeneratesOnCollision(t *testing.T) {
 	}
 	if got == "inbound-5000-tcp" {
 		t.Fatalf("colliding caller tag must be replaced, but resolver kept %q", got)
+	}
+}
+
+// the dedicated socks5 inbound with settings.udp=true takes both tcp
+// and udp on the same port (same UDP-ASSOCIATE shape as Mixed). pinning
+// that here so a future refactor of inboundTransports can't silently
+// drop the Socks branch and start letting a hysteria2 udp inbound
+// coexist with a dual-transport socks listener.
+func TestCheckPortConflict_SocksUDPBlocksUDPNeighbour(t *testing.T) {
+	setupConflictDB(t)
+	seedInboundConflict(t, "socks-443-dual", "0.0.0.0", 443, model.Socks, ``, `{"udp":true}`)
+
+	svc := &InboundService{}
+	udpClash := &model.Inbound{
+		Tag:      "hyst2-443",
+		Listen:   "0.0.0.0",
+		Port:     443,
+		Protocol: model.Hysteria2,
+	}
+	if exist, err := svc.checkPortConflict(udpClash, 0); err != nil || !exist {
+		t.Fatalf("hysteria2/udp must clash with socks+udp on same port; exist=%v err=%v", exist, err)
+	}
+}
+
+// counterpart of the above: socks with udp=false (the default) only
+// holds the tcp socket, so a udp-only neighbour on the same port must
+// still be allowed. mirrors the vless/tcp + hysteria2/udp coexistence
+// case from #4103.
+func TestCheckPortConflict_SocksTCPCoexistsWithUDPNeighbour(t *testing.T) {
+	setupConflictDB(t)
+	seedInboundConflict(t, "socks-443-tcp", "0.0.0.0", 443, model.Socks, ``, `{"udp":false}`)
+
+	svc := &InboundService{}
+	udpOnly := &model.Inbound{
+		Tag:      "hyst2-443",
+		Listen:   "0.0.0.0",
+		Port:     443,
+		Protocol: model.Hysteria2,
+	}
+	if exist, err := svc.checkPortConflict(udpOnly, 0); err != nil || exist {
+		t.Fatalf("socks-tcp and hysteria2-udp on same port must coexist; exist=%v err=%v", exist, err)
 	}
 }
 

--- a/web/service/tgbot.go
+++ b/web/service/tgbot.go
@@ -2983,9 +2983,16 @@ func (t *Tgbot) getInboundsAddClient() (*telego.InlineKeyboardMarkup, error) {
 		return nil, errors.New(t.I18nBot("tgbot.answers.getInboundsFailed"))
 	}
 
+	// Protocols listed here are skipped when the bot asks "which inbound do
+	// you want to add a client to?". They're inbounds that either don't
+	// have per-client subscription links (Mixed/HTTP/Socks/Tunnel) or
+	// don't have per-client credentials at all (WireGuard), so attaching
+	// a tg-managed client to them would produce something the user can't
+	// actually subscribe to.
 	excludedProtocols := map[model.Protocol]bool{
 		model.Tunnel:    true,
 		model.Mixed:     true,
+		model.Socks:     true,
 		model.WireGuard: true,
 		model.HTTP:      true,
 	}

--- a/xray/api.go
+++ b/xray/api.go
@@ -19,9 +19,11 @@ import (
 	"github.com/xtls/xray-core/common/protocol"
 	"github.com/xtls/xray-core/common/serial"
 	"github.com/xtls/xray-core/infra/conf"
+	httpProxy "github.com/xtls/xray-core/proxy/http"
 	hysteriaAccount "github.com/xtls/xray-core/proxy/hysteria/account"
 	"github.com/xtls/xray-core/proxy/shadowsocks"
 	"github.com/xtls/xray-core/proxy/shadowsocks_2022"
+	"github.com/xtls/xray-core/proxy/socks"
 	"github.com/xtls/xray-core/proxy/trojan"
 	"github.com/xtls/xray-core/proxy/vless"
 	"github.com/xtls/xray-core/proxy/vmess"
@@ -239,6 +241,56 @@ func (x *XrayAPI) AddUser(Protocol string, inboundTag string, user map[string]an
 
 		account = serial.ToTypedMessage(&hysteriaAccount.Account{
 			Auth: auth,
+		})
+	case "socks":
+		// Xray's dedicated socks5 inbound. Live add-user via the gRPC
+		// HandlerService takes a socks.Account whose fields are
+		// {username, password} — distinct from the JSON inbound config,
+		// where the same data lives under settings.accounts[].{user,pass}.
+		// We map the panel-side "user"/"pass" (matching the SocksSettings
+		// model in frontend/src/models/inbound.js) onto those wire-level
+		// field names here so the runtime sees the credentials in the
+		// shape xray-core expects.
+		//
+		// "username" is treated as required: the dedicated socks inbound
+		// in noauth mode doesn't have per-user accounts at all, so any
+		// AddUser request we see here is a password-mode user and must
+		// carry a non-empty username.
+		username, err := getRequiredUserString(user, "user")
+		if err != nil {
+			return err
+		}
+		password, err := getOptionalUserString(user, "pass")
+		if err != nil {
+			return err
+		}
+
+		account = serial.ToTypedMessage(&socks.Account{
+			Username: username,
+			Password: password,
+		})
+	case "http":
+		// Xray's dedicated http inbound exposes its own
+		// {username, password} Account in proxy/http. Same wire-level
+		// shape as socks (and the same panel-side "user"/"pass" mapping
+		// from HttpSettings), but the proto types are distinct, so we
+		// can't share one branch — the typed-message wrapper needs the
+		// exact proto.Message type the runtime registered under
+		// proxy.http inbound. Adding HTTP here keeps the dispatch table
+		// symmetric with socks and lets the panel push live-add-user
+		// for the dedicated HTTP inbound just like it does for socks.
+		username, err := getRequiredUserString(user, "user")
+		if err != nil {
+			return err
+		}
+		password, err := getOptionalUserString(user, "pass")
+		if err != nil {
+			return err
+		}
+
+		account = serial.ToTypedMessage(&httpProxy.Account{
+			Username: username,
+			Password: password,
 		})
 	default:
 		return nil


### PR DESCRIPTION
Adds an initial, intentionally minimal scaffold for a dedicated SOCKS5 inbound (Xray 'socks' protocol, RFC 1928). The existing 'mixed' inbound already supports SOCKS+HTTP on the same port, but several deployments need a pure SOCKS5 inbound — for example chained outbounds and clients that don't tolerate HTTP CONNECT on the same listener.

This PR is purposely a scaffold so other contributors can finish the full integration (sub link generation, routing UI helpers, Xray runtime AddUser hooks, translations, docs, tests). It does NOT claim feature completeness.

What's included
---------------
Backend (Go):
  * database/model/model.go: add Socks model.Protocol constant ('socks') next to Mixed, with a doc comment explaining the difference vs Mixed.

Frontend (JS/Vue):
  * frontend/src/models/inbound.js - Add Protocols.SOCKS ('socks') to the protocol enum, so the existing 'Object.values(Protocols)' selector picks it up automatically in the inbound create/edit modal. - New Inbound.SocksSettings class (auth, accounts, udp, ip) that serialises in the exact shape Xray's socks inbound expects (https://xtls.github.io/config/inbounds/socks.html). - New Inbound.SocksSettings.SocksAccount for password-mode users. - Wire SOCKS into Inbound.Settings.getSettings() and fromJson() dispatchers so create/edit/restore round-trips work.

  * frontend/src/pages/inbounds/InboundFormModal.vue
      - Extend the existing 'HTTP / Mixed accounts' form so SOCKS shares the same accounts editor + auth/UDP/UDP-IP fields. SOCKS reuses the MIXED shape because Xray's socks and mixed inbounds accept the same settings keys.
      - New addAccountByProtocol() helper dispatches to the correct Account class per protocol (Http / Mixed / Socks) so each protocol stores accounts in the right namespace.

What's intentionally NOT done (help wanted)
-------------------------------------------
1. sub/subService.go GetLink: SOCKS currently returns '' (same as MIXED/HTTP/Tunnel). If we want a 'socks://' subscription link, that needs its own gen* function. The existing comment on GetLink already lists socks/http/mixed as link-less, so this is consistent for now.
2. Xray runtime AddUser / UpdateInbound hooks in web/service/inbound.go — accounts are persisted in settings JSON and Xray picks them up on restart, but live add-user without restart is not wired.
3. Routing UI: routing pages already accept any inbound tag, so SOCKS inbounds are routable as-is; a dedicated 'protocol == socks' helper in routing rule editors would be a nice follow-up.
4. Translations (web/translation/*.json): the protocol name is rendered as the raw string 'socks' in the dropdown today; we don't yet have a localised label.
5. Tests: xray/process_test.go has no SOCKS-specific case yet.

Why scaffold instead of full feature?
-------------------------------------
The protocol surface area touches db model, settings serialisation, form UI, sub link generation, routing rules, and translations for 13 locales. Landing a vetted scaffold first lets multiple contributors parallelise the remaining work without merge churn on a giant PR.

Refs
----
- Xray socks inbound spec: https://xtls.github.io/config/inbounds/socks.html
- RFC 1928 (SOCKS Protocol Version 5)

Co-developed-by: 3x-ui community (call for contributions)

## What is the pull request?

<!-- Briefly describe the changes introduced by this pull request -->

## Which part of the application is affected by the change?

- [x] Frontend
- [x] Backend

## Type of Changes

- [ ] Bug fix
- [ ] New feature
- [ ] Refactoring
- [ ] Other

## Screenshots

<!-- Add screenshots to illustrate the changes -->
<!-- Remove this section if it is not applicable. -->