### PR TITLE
fix(frontend): prevent browser default background fill on login autofill

### DIFF
--- a/frontend/src/pages/login/LoginPage.vue
+++ b/frontend/src/pages/login/LoginPage.vue
@@ -469,6 +469,13 @@ function cycleTheme() {
   font-weight: 500;
 }
 
+.login-form :deep(input.ant-input:-webkit-autofill) {
+  -webkit-text-fill-color: var(--color-text) !important;
+  -webkit-box-shadow: 0 0 0 1000px var(--bg-card) inset !important;
+  box-shadow: 0 0 0 1000px var(--bg-card) inset !important;
+  transition: background-color 9999s ease-in-out 0s, color 9999s ease-in-out 0s;
+}
+
 .submit-row {
   margin-bottom: 0;
 }


### PR DESCRIPTION
## What is the pull request?

By default, when selecting a saved password in browsers (e.g. Chrome, Firefox) for autofill on the login screen of 3x-ui, the background of the input field automatically changes to the browser-defined colors (e.g. in Firefox it forces a yellow-ish background). This is inconsistent with the light/dark themes of 3x-ui and is very ugly in my opinion.

This pull request fixes that.

Please see the screenshots for more details :)

## Which part of the application is affected by the change?

- [X] Frontend
- [ ] Backend

## Type of Changes

- [X] Bug fix
- [ ] New feature
- [ ] Refactoring
- [ ] Other

## Screenshots

Before:

<img width="636" height="617" alt="image" src="https://github.com/user-attachments/assets/c58c8fe3-9c9e-4c85-a6ce-8aaebbcb7ef7" />

After:

<img width="637" height="614" alt="image" src="https://github.com/user-attachments/assets/c6ca54ae-75fe-494a-9e47-875541aa2862" />

Note:

Overriding the browser's autofill color was the default behavior before the release of version 3.0.

The code commit that introduced this is https://github.com/MHSanaei/3x-ui/commit/5ee62b25ca9a3bf0ce683adbba5b1b64ddea074e

<img width="1538" height="622" alt="image" src="https://github.com/user-attachments/assets/d21211c1-cff6-4742-9b8a-ae0b580c2425" />

```css
#app.login-app.dark #login input.ant-input:-webkit-autofill,
#app.login-app.dark #login input.ant-input:-webkit-autofill:hover,
#app.login-app.dark #login input.ant-input:-webkit-autofill:focus,
#app.login-app.dark #login .ant-input-password input:-webkit-autofill,
#app.login-app.dark #login .ant-input-password input:-webkit-autofill:hover,
#app.login-app.dark #login .ant-input-password input:-webkit-autofill:focus {
  -webkit-text-fill-color: var(--login-input-color, #d6dce6) !important;
  caret-color: var(--login-input-color, #d6dce6) !important;
  -webkit-box-shadow: 0 0 0 1000px var(--login-input-bg, #1d2433) inset !important;
  box-shadow: 0 0 0 1000px var(--login-input-bg, #1d2433) inset !important;
  transition: background-color 9999s ease-in-out 0s !important;
}

#app.login-app.dark #login input.ant-input:-moz-autofill,
#app.login-app.dark #login .ant-input-password input:-moz-autofill {
  -moz-text-fill-color: var(--login-input-color, #d6dce6) !important;
  caret-color: var(--login-input-color, #d6dce6) !important;
  box-shadow: 0 0 0 1000px var(--login-input-bg, #1d2433) inset !important;
}

#app.login-app.dark #login {
  --login-input-bg: var(--dark-color-surface-200);
  --login-input-color: var(--dark-color-text-primary);
}
```