### PR TITLE
fix: address open bug reports (#4539, #4538, #4535, #4531, #4515)

### DIFF
--- a/database/db.go
+++ b/database/db.go
@@ -142,11 +142,11 @@ func runSeeders(isUsersEmpty bool) error {
 	}
 
 	if empty && isUsersEmpty {
-		hashSeeder := &model.HistoryOfSeeders{
-			SeederName: "UserPasswordHash",
-		}
-		if err := db.Create(hashSeeder).Error; err != nil {
-			return err
+		seeders := []string{"UserPasswordHash", "ClientsTable"}
+		for _, name := range seeders {
+			if err := db.Create(&model.HistoryOfSeeders{SeederName: name}).Error; err != nil {
+				return err
+			}
 		}
 		return seedApiTokens()
 	}
@@ -236,6 +236,14 @@ func seedClientsFromInboundJSON() error {
 
 	return db.Transaction(func(tx *gorm.DB) error {
 		byEmail := map[string]*model.ClientRecord{}
+
+		var existing []model.ClientRecord
+		if err := tx.Find(&existing).Error; err != nil {
+			return err
+		}
+		for i := range existing {
+			byEmail[existing[i].Email] = &existing[i]
+		}
 
 		for _, inbound := range inbounds {
 			if strings.TrimSpace(inbound.Settings) == "" {

--- a/database/db_seed_test.go
+++ b/database/db_seed_test.go
@@ -1,0 +1,71 @@
+package database
+
+import (
+	"encoding/json"
+	"path/filepath"
+	"testing"
+
+	"github.com/mhsanaei/3x-ui/v3/database/model"
+)
+
+func TestSeedClientsFromInboundJSON_IsIdempotentAgainstExistingClients(t *testing.T) {
+	dbDir := t.TempDir()
+	t.Setenv("XUI_DB_FOLDER", dbDir)
+	if err := InitDB(filepath.Join(dbDir, "3x-ui.db")); err != nil {
+		t.Fatalf("InitDB failed: %v", err)
+	}
+	t.Cleanup(func() { _ = CloseDB() })
+
+	settings, err := json.Marshal(map[string]any{
+		"clients": []any{
+			map[string]any{
+				"id":      "ce8d33df-3a64-4f10-8f9b-91c3a8e0c001",
+				"email":   "alice@example.com",
+				"enable":  true,
+				"flow":    "",
+				"subId":   "alice-sub",
+				"comment": "from-inbound-json",
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("marshal settings: %v", err)
+	}
+	inbound := model.Inbound{
+		UserId:   1,
+		Port:     12345,
+		Protocol: model.VLESS,
+		Settings: string(settings),
+		Tag:      "test-inbound",
+	}
+	if err := db.Create(&inbound).Error; err != nil {
+		t.Fatalf("seed inbound: %v", err)
+	}
+
+	preExisting := &model.ClientRecord{
+		Email:   "alice@example.com",
+		UUID:    "ce8d33df-3a64-4f10-8f9b-91c3a8e0c001",
+		SubID:   "alice-sub",
+		Enable:  true,
+		Comment: "added-via-api",
+	}
+	if err := db.Create(preExisting).Error; err != nil {
+		t.Fatalf("seed client row: %v", err)
+	}
+
+	if err := db.Where("seeder_name = ?", "ClientsTable").Delete(&model.HistoryOfSeeders{}).Error; err != nil {
+		t.Fatalf("clear ClientsTable history: %v", err)
+	}
+
+	if err := seedClientsFromInboundJSON(); err != nil {
+		t.Fatalf("seedClientsFromInboundJSON should be idempotent against existing rows, got: %v", err)
+	}
+
+	var count int64
+	if err := db.Model(&model.ClientRecord{}).Where("email = ?", "alice@example.com").Count(&count).Error; err != nil {
+		t.Fatalf("count clients: %v", err)
+	}
+	if count != 1 {
+		t.Fatalf("alice@example.com should resolve to exactly one row, got %d", count)
+	}
+}

--- a/frontend/src/pages/clients/ClientInfoModal.tsx
+++ b/frontend/src/pages/clients/ClientInfoModal.tsx
@@ -40,9 +40,16 @@ export default function ClientInfoModal({
   onOpenChange,
 }: ClientInfoModalProps) {
   const { datepicker } = useDatepicker();
-  const expiryLabel = (ts?: number) => (!ts || ts <= 0 ? '∞' : IntlUtil.formatDate(ts, datepicker));
-  const dateLabel = (ts?: number) => (!ts || ts <= 0 ? '-' : IntlUtil.formatDate(ts, datepicker));
   const { t } = useTranslation();
+  const expiryLabel = (ts?: number) => {
+    if (!ts) return '∞';
+    if (ts < 0) {
+      const days = Math.round(ts / -86400000);
+      return `${t('pages.clients.delayedStart')}: ${days}d`;
+    }
+    return IntlUtil.formatDate(ts, datepicker);
+  };
+  const dateLabel = (ts?: number) => (!ts || ts <= 0 ? '-' : IntlUtil.formatDate(ts, datepicker));
   const [messageApi, messageContextHolder] = message.useMessage();
   const [links, setLinks] = useState<string[]>([]);
 
@@ -195,9 +202,9 @@ export default function ClientInfoModal({
               <tr>
                 <td>{t('pages.inbounds.expireDate')}</td>
                 <td>
-                  {!client.expiryTime || client.expiryTime <= 0
+                  {!client.expiryTime
                     ? <Tag color="purple">∞</Tag>
-                    : <Tag>{expiryLabel(client.expiryTime)}</Tag>}
+                    : <Tag color={client.expiryTime < 0 ? 'blue' : undefined}>{expiryLabel(client.expiryTime)}</Tag>}
                   {(client.expiryTime ?? 0) > 0 && (
                     <span className="hint">{IntlUtil.formatRelativeTime(client.expiryTime)}</span>
                   )}

--- a/sub/subClashService.go
+++ b/sub/subClashService.go
@@ -68,9 +68,7 @@ func (s *SubClashService) GetClash(subId string, host string) (string, string, e
 			traffic.Up = clientTraffic.Up
 			traffic.Down = clientTraffic.Down
 			traffic.Total = clientTraffic.Total
-			if clientTraffic.ExpiryTime > 0 {
-				traffic.ExpiryTime = clientTraffic.ExpiryTime
-			}
+			traffic.ExpiryTime = subscriptionExpiryFromClient(clientTraffic.ExpiryTime)
 		} else {
 			traffic.Up += clientTraffic.Up
 			traffic.Down += clientTraffic.Down
@@ -79,7 +77,8 @@ func (s *SubClashService) GetClash(subId string, host string) (string, string, e
 			} else {
 				traffic.Total += clientTraffic.Total
 			}
-			if clientTraffic.ExpiryTime != traffic.ExpiryTime {
+			normalized := subscriptionExpiryFromClient(clientTraffic.ExpiryTime)
+			if normalized != traffic.ExpiryTime {
 				traffic.ExpiryTime = 0
 			}
 		}

--- a/sub/subClashService.go
+++ b/sub/subClashService.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"maps"
 	"strings"
+	"time"
 
 	"github.com/goccy/go-json"
 	yaml "github.com/goccy/go-yaml"
@@ -63,12 +64,13 @@ func (s *SubClashService) GetClash(subId string, host string) (string, string, e
 		return "", "", nil
 	}
 
+	now := time.Now().UnixMilli()
 	for index, clientTraffic := range clientTraffics {
 		if index == 0 {
 			traffic.Up = clientTraffic.Up
 			traffic.Down = clientTraffic.Down
 			traffic.Total = clientTraffic.Total
-			traffic.ExpiryTime = subscriptionExpiryFromClient(clientTraffic.ExpiryTime)
+			traffic.ExpiryTime = subscriptionExpiryFromClient(now, clientTraffic.ExpiryTime)
 		} else {
 			traffic.Up += clientTraffic.Up
 			traffic.Down += clientTraffic.Down
@@ -77,7 +79,7 @@ func (s *SubClashService) GetClash(subId string, host string) (string, string, e
 			} else {
 				traffic.Total += clientTraffic.Total
 			}
-			normalized := subscriptionExpiryFromClient(clientTraffic.ExpiryTime)
+			normalized := subscriptionExpiryFromClient(now, clientTraffic.ExpiryTime)
 			if normalized != traffic.ExpiryTime {
 				traffic.ExpiryTime = 0
 			}

--- a/sub/subClashService.go
+++ b/sub/subClashService.go
@@ -363,6 +363,53 @@ func (s *SubClashService) applyTransport(proxy map[string]any, network string, s
 			proxy["grpc-opts"] = grpcOpts
 		}
 		return true
+	case "httpupgrade":
+		proxy["network"] = "httpupgrade"
+		hu, _ := stream["httpupgradeSettings"].(map[string]any)
+		opts := map[string]any{}
+		if hu != nil {
+			if path, ok := hu["path"].(string); ok && path != "" {
+				opts["path"] = path
+			}
+			host := ""
+			if v, ok := hu["host"].(string); ok && v != "" {
+				host = v
+			} else if headers, ok := hu["headers"].(map[string]any); ok {
+				host = searchHost(headers)
+			}
+			if host != "" {
+				opts["headers"] = map[string]any{"Host": host}
+			}
+		}
+		if len(opts) > 0 {
+			proxy["http-upgrade-opts"] = opts
+		}
+		return true
+	case "xhttp":
+		proxy["network"] = "xhttp"
+		xhttp, _ := stream["xhttpSettings"].(map[string]any)
+		opts := map[string]any{}
+		if xhttp != nil {
+			if path, ok := xhttp["path"].(string); ok && path != "" {
+				opts["path"] = path
+			}
+			host := ""
+			if v, ok := xhttp["host"].(string); ok && v != "" {
+				host = v
+			} else if headers, ok := xhttp["headers"].(map[string]any); ok {
+				host = searchHost(headers)
+			}
+			if host != "" {
+				opts["host"] = host
+			}
+			if mode, ok := xhttp["mode"].(string); ok && mode != "" {
+				opts["mode"] = mode
+			}
+		}
+		if len(opts) > 0 {
+			proxy["xhttp-opts"] = opts
+		}
+		return true
 	default:
 		return false
 	}

--- a/sub/subClashService_test.go
+++ b/sub/subClashService_test.go
@@ -1,0 +1,81 @@
+package sub
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestApplyTransport_XHTTP(t *testing.T) {
+	svc := &SubClashService{}
+	proxy := map[string]any{}
+	stream := map[string]any{
+		"xhttpSettings": map[string]any{
+			"path": "/xh",
+			"host": "example.com",
+			"mode": "auto",
+		},
+	}
+
+	if !svc.applyTransport(proxy, "xhttp", stream) {
+		t.Fatalf("applyTransport returned false for xhttp (#4531: would drop the inbound and yield an empty Clash YAML)")
+	}
+	if proxy["network"] != "xhttp" {
+		t.Fatalf("network = %v, want xhttp", proxy["network"])
+	}
+	opts, ok := proxy["xhttp-opts"].(map[string]any)
+	if !ok {
+		t.Fatalf("xhttp-opts missing or wrong type: %#v", proxy["xhttp-opts"])
+	}
+	want := map[string]any{"path": "/xh", "host": "example.com", "mode": "auto"}
+	if !reflect.DeepEqual(opts, want) {
+		t.Fatalf("xhttp-opts = %#v, want %#v", opts, want)
+	}
+}
+
+func TestApplyTransport_XHTTP_HostFromHeaders(t *testing.T) {
+	svc := &SubClashService{}
+	proxy := map[string]any{}
+	stream := map[string]any{
+		"xhttpSettings": map[string]any{
+			"path":    "/xh",
+			"headers": map[string]any{"Host": "via-header.example.com"},
+		},
+	}
+
+	if !svc.applyTransport(proxy, "xhttp", stream) {
+		t.Fatalf("applyTransport returned false for xhttp")
+	}
+	opts, _ := proxy["xhttp-opts"].(map[string]any)
+	if opts["host"] != "via-header.example.com" {
+		t.Fatalf("host should fall back to headers.Host, got %v", opts["host"])
+	}
+}
+
+func TestApplyTransport_HTTPUpgrade(t *testing.T) {
+	svc := &SubClashService{}
+	proxy := map[string]any{}
+	stream := map[string]any{
+		"httpupgradeSettings": map[string]any{
+			"path": "/hu",
+			"host": "example.com",
+		},
+	}
+
+	if !svc.applyTransport(proxy, "httpupgrade", stream) {
+		t.Fatalf("applyTransport returned false for httpupgrade")
+	}
+	if proxy["network"] != "httpupgrade" {
+		t.Fatalf("network = %v, want httpupgrade", proxy["network"])
+	}
+	opts, ok := proxy["http-upgrade-opts"].(map[string]any)
+	if !ok {
+		t.Fatalf("http-upgrade-opts missing: %#v", proxy["http-upgrade-opts"])
+	}
+	if opts["path"] != "/hu" {
+		t.Fatalf("path = %v, want /hu", opts["path"])
+	}
+	headers, _ := opts["headers"].(map[string]any)
+	if headers["Host"] != "example.com" {
+		t.Fatalf("headers.Host = %v, want example.com", headers["Host"])
+	}
+}

--- a/sub/subJsonService.go
+++ b/sub/subJsonService.go
@@ -130,9 +130,7 @@ func (s *SubJsonService) GetJson(subId string, host string) (string, string, err
 			traffic.Up = clientTraffic.Up
 			traffic.Down = clientTraffic.Down
 			traffic.Total = clientTraffic.Total
-			if clientTraffic.ExpiryTime > 0 {
-				traffic.ExpiryTime = clientTraffic.ExpiryTime
-			}
+			traffic.ExpiryTime = subscriptionExpiryFromClient(clientTraffic.ExpiryTime)
 		} else {
 			traffic.Up += clientTraffic.Up
 			traffic.Down += clientTraffic.Down
@@ -141,7 +139,8 @@ func (s *SubJsonService) GetJson(subId string, host string) (string, string, err
 			} else {
 				traffic.Total += clientTraffic.Total
 			}
-			if clientTraffic.ExpiryTime != traffic.ExpiryTime {
+			normalized := subscriptionExpiryFromClient(clientTraffic.ExpiryTime)
+			if normalized != traffic.ExpiryTime {
 				traffic.ExpiryTime = 0
 			}
 		}

--- a/sub/subJsonService.go
+++ b/sub/subJsonService.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"maps"
 	"strings"
+	"time"
 
 	"github.com/mhsanaei/3x-ui/v3/database/model"
 	"github.com/mhsanaei/3x-ui/v3/logger"
@@ -125,12 +126,13 @@ func (s *SubJsonService) GetJson(subId string, host string) (string, string, err
 	}
 
 	// Prepare statistics
+	now := time.Now().UnixMilli()
 	for index, clientTraffic := range clientTraffics {
 		if index == 0 {
 			traffic.Up = clientTraffic.Up
 			traffic.Down = clientTraffic.Down
 			traffic.Total = clientTraffic.Total
-			traffic.ExpiryTime = subscriptionExpiryFromClient(clientTraffic.ExpiryTime)
+			traffic.ExpiryTime = subscriptionExpiryFromClient(now, clientTraffic.ExpiryTime)
 		} else {
 			traffic.Up += clientTraffic.Up
 			traffic.Down += clientTraffic.Down
@@ -139,7 +141,7 @@ func (s *SubJsonService) GetJson(subId string, host string) (string, string, err
 			} else {
 				traffic.Total += clientTraffic.Total
 			}
-			normalized := subscriptionExpiryFromClient(clientTraffic.ExpiryTime)
+			normalized := subscriptionExpiryFromClient(now, clientTraffic.ExpiryTime)
 			if normalized != traffic.ExpiryTime {
 				traffic.ExpiryTime = 0
 			}

--- a/sub/subService.go
+++ b/sub/subService.go
@@ -114,9 +114,7 @@ func (s *SubService) GetSubs(subId string, host string) ([]string, int64, xray.C
 			traffic.Up = clientTraffic.Up
 			traffic.Down = clientTraffic.Down
 			traffic.Total = clientTraffic.Total
-			if clientTraffic.ExpiryTime > 0 {
-				traffic.ExpiryTime = clientTraffic.ExpiryTime
-			}
+			traffic.ExpiryTime = subscriptionExpiryFromClient(clientTraffic.ExpiryTime)
 		} else {
 			traffic.Up += clientTraffic.Up
 			traffic.Down += clientTraffic.Down
@@ -125,13 +123,24 @@ func (s *SubService) GetSubs(subId string, host string) ([]string, int64, xray.C
 			} else {
 				traffic.Total += clientTraffic.Total
 			}
-			if clientTraffic.ExpiryTime != traffic.ExpiryTime {
+			normalized := subscriptionExpiryFromClient(clientTraffic.ExpiryTime)
+			if normalized != traffic.ExpiryTime {
 				traffic.ExpiryTime = 0
 			}
 		}
 	}
 	traffic.Enable = hasEnabledClient
 	return result, lastOnline, traffic, nil
+}
+
+func subscriptionExpiryFromClient(expiryTime int64) int64 {
+	if expiryTime > 0 {
+		return expiryTime
+	}
+	if expiryTime < 0 {
+		return time.Now().UnixMilli() + (-expiryTime)
+	}
+	return 0
 }
 
 func (s *SubService) getInboundsBySubId(subId string) ([]*model.Inbound, error) {

--- a/sub/subService.go
+++ b/sub/subService.go
@@ -108,13 +108,13 @@ func (s *SubService) GetSubs(subId string, host string) ([]string, int64, xray.C
 		}
 	}
 
-	// Prepare statistics
+	now := time.Now().UnixMilli()
 	for index, clientTraffic := range clientTraffics {
 		if index == 0 {
 			traffic.Up = clientTraffic.Up
 			traffic.Down = clientTraffic.Down
 			traffic.Total = clientTraffic.Total
-			traffic.ExpiryTime = subscriptionExpiryFromClient(clientTraffic.ExpiryTime)
+			traffic.ExpiryTime = subscriptionExpiryFromClient(now, clientTraffic.ExpiryTime)
 		} else {
 			traffic.Up += clientTraffic.Up
 			traffic.Down += clientTraffic.Down
@@ -123,7 +123,7 @@ func (s *SubService) GetSubs(subId string, host string) ([]string, int64, xray.C
 			} else {
 				traffic.Total += clientTraffic.Total
 			}
-			normalized := subscriptionExpiryFromClient(clientTraffic.ExpiryTime)
+			normalized := subscriptionExpiryFromClient(now, clientTraffic.ExpiryTime)
 			if normalized != traffic.ExpiryTime {
 				traffic.ExpiryTime = 0
 			}
@@ -133,12 +133,12 @@ func (s *SubService) GetSubs(subId string, host string) ([]string, int64, xray.C
 	return result, lastOnline, traffic, nil
 }
 
-func subscriptionExpiryFromClient(expiryTime int64) int64 {
+func subscriptionExpiryFromClient(nowMs, expiryTime int64) int64 {
 	if expiryTime > 0 {
 		return expiryTime
 	}
 	if expiryTime < 0 {
-		return time.Now().UnixMilli() + (-expiryTime)
+		return nowMs + (-expiryTime)
 	}
 	return 0
 }

--- a/sub/subService_test.go
+++ b/sub/subService_test.go
@@ -5,24 +5,24 @@ import (
 	"encoding/json"
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/mhsanaei/3x-ui/v3/database/model"
 )
 
 func TestSubscriptionExpiryFromClient(t *testing.T) {
-	if got := subscriptionExpiryFromClient(0); got != 0 {
+	const now = int64(1_700_000_000_000)
+	const oneDayMs = int64(86_400_000)
+	if got := subscriptionExpiryFromClient(now, 0); got != 0 {
 		t.Fatalf("zero expiry should stay zero, got %d", got)
 	}
-	if got := subscriptionExpiryFromClient(1_700_000_000_000); got != 1_700_000_000_000 {
+	if got := subscriptionExpiryFromClient(now, 1_700_000_000_000); got != 1_700_000_000_000 {
 		t.Fatalf("positive expiry should pass through, got %d", got)
 	}
-	const oneDayMs = int64(86_400_000)
-	before := time.Now().UnixMilli()
-	got := subscriptionExpiryFromClient(-oneDayMs)
-	after := time.Now().UnixMilli()
-	if got < before+oneDayMs || got > after+oneDayMs {
-		t.Fatalf("delayed-start expiry should land ~1 day from now, got %d (window %d..%d)", got, before+oneDayMs, after+oneDayMs)
+	if got := subscriptionExpiryFromClient(now, -oneDayMs); got != now+oneDayMs {
+		t.Fatalf("delayed-start expiry should be now+|value|, got %d, want %d", got, now+oneDayMs)
+	}
+	if a, b := subscriptionExpiryFromClient(now, -oneDayMs), subscriptionExpiryFromClient(now, -oneDayMs); a != b {
+		t.Fatalf("same now+value should be deterministic across calls, got %d vs %d (#4545 review)", a, b)
 	}
 }
 

--- a/sub/subService_test.go
+++ b/sub/subService_test.go
@@ -5,9 +5,26 @@ import (
 	"encoding/json"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/mhsanaei/3x-ui/v3/database/model"
 )
+
+func TestSubscriptionExpiryFromClient(t *testing.T) {
+	if got := subscriptionExpiryFromClient(0); got != 0 {
+		t.Fatalf("zero expiry should stay zero, got %d", got)
+	}
+	if got := subscriptionExpiryFromClient(1_700_000_000_000); got != 1_700_000_000_000 {
+		t.Fatalf("positive expiry should pass through, got %d", got)
+	}
+	const oneDayMs = int64(86_400_000)
+	before := time.Now().UnixMilli()
+	got := subscriptionExpiryFromClient(-oneDayMs)
+	after := time.Now().UnixMilli()
+	if got < before+oneDayMs || got > after+oneDayMs {
+		t.Fatalf("delayed-start expiry should land ~1 day from now, got %d (window %d..%d)", got, before+oneDayMs, after+oneDayMs)
+	}
+}
 
 func TestFindClientIndex(t *testing.T) {
 	clients := []model.Client{

--- a/web/job/check_hash_storage.go
+++ b/web/job/check_hash_storage.go
@@ -16,6 +16,9 @@ func NewCheckHashStorageJob() *CheckHashStorageJob {
 
 // Run removes expired hash entries from the Telegram bot's hash storage.
 func (j *CheckHashStorageJob) Run() {
-	// Remove expired hashes from storage
-	j.tgbotService.GetHashStorage().RemoveExpiredHashes()
+	storage := j.tgbotService.GetHashStorage()
+	if storage == nil {
+		return
+	}
+	storage.RemoveExpiredHashes()
 }

--- a/web/job/check_hash_storage_test.go
+++ b/web/job/check_hash_storage_test.go
@@ -1,0 +1,12 @@
+package job
+
+import "testing"
+
+func TestCheckHashStorageJob_RunWithoutPanicWhenStorageNil(t *testing.T) {
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("CheckHashStorageJob.Run panicked when storage is nil: %v", r)
+		}
+	}()
+	NewCheckHashStorageJob().Run()
+}

--- a/web/job/node_traffic_sync_job.go
+++ b/web/job/node_traffic_sync_job.go
@@ -101,10 +101,6 @@ func (j *NodeTrafficSyncJob) Run() {
 		j.structural.set()
 	}
 
-	if !websocket.HasClients() {
-		return
-	}
-
 	lastOnline, err := j.inboundService.GetClientsLastOnline()
 	if err != nil {
 		logger.Warning("node traffic sync: get last-online failed:", err)
@@ -114,6 +110,10 @@ func (j *NodeTrafficSyncJob) Run() {
 	}
 
 	j.inboundService.RefreshOnlineClientsFromMap(lastOnline)
+
+	if !websocket.HasClients() {
+		return
+	}
 
 	online := j.inboundService.GetOnlineClients()
 	if online == nil {

--- a/web/job/xray_traffic_job.go
+++ b/web/job/xray_traffic_job.go
@@ -65,18 +65,6 @@ func (j *XrayTrafficJob) Run() {
 		j.xrayService.SetToNeedRestart()
 	}
 
-	// If no frontend client is connected, skip all WebSocket broadcasting
-	// routines — including the active-client DB query and JSON marshaling.
-	if !websocket.HasClients() {
-		return
-	}
-
-	// Online presence + traffic deltas — small payload, always fits in WS.
-	// Force non-nil slice/map so JSON marshalling produces [] / {} instead of
-	// `null` when everyone is offline. The frontend's traffic handler treats
-	// a missing/null onlineClients field as "no update", so without this the
-	// "everyone went offline" transition was silently dropped — stale online
-	// users lingered in the list and the online filter kept showing them.
 	lastOnlineMap, err := j.inboundService.GetClientsLastOnline()
 	if err != nil {
 		logger.Warning("get clients last online failed:", err)
@@ -84,12 +72,11 @@ func (j *XrayTrafficJob) Run() {
 	if lastOnlineMap == nil {
 		lastOnlineMap = make(map[string]int64)
 	}
-
-	// Determine online clients from lastOnline timestamps with a 5-second
-	// grace period instead of just the current 5-second traffic poll. This
-	// prevents idle-but-connected clients from randomly disappearing from
-	// the UI between polling windows.
 	j.inboundService.RefreshOnlineClientsFromMap(lastOnlineMap)
+
+	if !websocket.HasClients() {
+		return
+	}
 
 	onlineClients := j.inboundService.GetOnlineClients()
 	if onlineClients == nil {
@@ -102,11 +89,6 @@ func (j *XrayTrafficJob) Run() {
 		"lastOnlineMap":  lastOnlineMap,
 	})
 
-	// Full snapshot every cycle: absolute per-client counters and inbound
-	// totals. Frontend overwrites both in place. The previous delta path
-	// (activeEmails -> GetActiveClientTraffics) silently omitted the
-	// clients array whenever nobody moved bytes in the cycle, leaving the
-	// client rows in the UI stuck at stale traffic/remained/all-time.
 	clientStatsPayload := map[string]any{}
 	if stats, err := j.inboundService.GetAllClientTraffics(); err != nil {
 		logger.Warning("get all client traffics for websocket failed:", err)
@@ -122,8 +104,6 @@ func (j *XrayTrafficJob) Run() {
 		websocket.BroadcastClientStats(clientStatsPayload)
 	}
 
-	// Outbounds list is small (one row per outbound, no per-client expansion)
-	// so the full snapshot still fits comfortably in WS.
 	if updatedOutbounds, err := j.outboundService.GetOutboundsTraffic(); err == nil && updatedOutbounds != nil {
 		websocket.BroadcastOutbounds(updatedOutbounds)
 	} else if err != nil {

--- a/web/service/client.go
+++ b/web/service/client.go
@@ -222,9 +222,7 @@ func (s *ClientService) SyncInbound(tx *gorm.DB, inboundId int, clients []model.
 			if incoming.Auth != "" {
 				row.Auth = incoming.Auth
 			}
-			if incoming.Flow != "" {
-				row.Flow = incoming.Flow
-			}
+			row.Flow = incoming.Flow
 			if incoming.Security != "" {
 				row.Security = incoming.Security
 			}

--- a/web/service/client.go
+++ b/web/service/client.go
@@ -213,12 +213,24 @@ func (s *ClientService) SyncInbound(tx *gorm.DB, inboundId int, clients []model.
 			}
 			row = incoming
 		} else {
-			row.UUID = incoming.UUID
-			row.Password = incoming.Password
-			row.Auth = incoming.Auth
-			row.Flow = incoming.Flow
-			row.Security = incoming.Security
-			row.Reverse = incoming.Reverse
+			if incoming.UUID != "" {
+				row.UUID = incoming.UUID
+			}
+			if incoming.Password != "" {
+				row.Password = incoming.Password
+			}
+			if incoming.Auth != "" {
+				row.Auth = incoming.Auth
+			}
+			if incoming.Flow != "" {
+				row.Flow = incoming.Flow
+			}
+			if incoming.Security != "" {
+				row.Security = incoming.Security
+			}
+			if incoming.Reverse != "" {
+				row.Reverse = incoming.Reverse
+			}
 			row.SubID = incoming.SubID
 			row.LimitIP = incoming.LimitIP
 			row.TotalGB = incoming.TotalGB

--- a/web/service/client_sync_multiprotocol_test.go
+++ b/web/service/client_sync_multiprotocol_test.go
@@ -31,8 +31,9 @@ func TestSyncInbound_PreservesCredentialsAcrossProtocols(t *testing.T) {
 	const sharedEmail = "shared@example.com"
 	const wantUUID = "ce8d33df-3a64-4f10-8f9b-91c3a8e0c001"
 	const wantAuth = "h2-auth-token"
+	const wantFlow = "xtls-rprx-vision"
 
-	vlessClient := model.Client{Email: sharedEmail, ID: wantUUID, Enable: true, Flow: "xtls-rprx-vision"}
+	vlessClient := model.Client{Email: sharedEmail, ID: wantUUID, Enable: true, Flow: wantFlow}
 	if err := svc.SyncInbound(nil, vlessInbound.Id, []model.Client{vlessClient}); err != nil {
 		t.Fatalf("vless SyncInbound: %v", err)
 	}
@@ -52,7 +53,61 @@ func TestSyncInbound_PreservesCredentialsAcrossProtocols(t *testing.T) {
 	if row.Auth != wantAuth {
 		t.Errorf("Auth not persisted: got %q, want %q", row.Auth, wantAuth)
 	}
-	if row.Flow != "xtls-rprx-vision" {
-		t.Errorf("Flow was clobbered by Hysteria sync: got %q, want xtls-rprx-vision", row.Flow)
+
+	vlessList, err := svc.ListForInbound(nil, vlessInbound.Id)
+	if err != nil {
+		t.Fatalf("ListForInbound(vless): %v", err)
+	}
+	if len(vlessList) != 1 || vlessList[0].Flow != wantFlow {
+		t.Errorf("VLESS inbound should still report flow=%q via FlowOverride, got %#v", wantFlow, vlessList)
+	}
+
+	hysteriaList, err := svc.ListForInbound(nil, hysteriaInbound.Id)
+	if err != nil {
+		t.Fatalf("ListForInbound(hysteria): %v", err)
+	}
+	if len(hysteriaList) != 1 || hysteriaList[0].Flow != "" {
+		t.Errorf("Hysteria inbound should report empty flow, got %#v", hysteriaList)
+	}
+}
+
+func TestSyncInbound_AllowsClearingFlow(t *testing.T) {
+	dbDir := t.TempDir()
+	t.Setenv("XUI_DB_FOLDER", dbDir)
+	if err := database.InitDB(filepath.Join(dbDir, "3x-ui.db")); err != nil {
+		t.Fatalf("InitDB: %v", err)
+	}
+	t.Cleanup(func() { _ = database.CloseDB() })
+
+	db := database.GetDB()
+
+	vless := &model.Inbound{Tag: "vless-in", Enable: true, Port: 10003, Protocol: model.VLESS}
+	if err := db.Create(vless).Error; err != nil {
+		t.Fatalf("create vless inbound: %v", err)
+	}
+
+	svc := ClientService{}
+	const email = "alice@example.com"
+	const uid = "ce8d33df-3a64-4f10-8f9b-91c3a8e0c002"
+
+	withFlow := model.Client{Email: email, ID: uid, Enable: true, Flow: "xtls-rprx-vision"}
+	if err := svc.SyncInbound(nil, vless.Id, []model.Client{withFlow}); err != nil {
+		t.Fatalf("vless SyncInbound (set flow): %v", err)
+	}
+
+	cleared := model.Client{Email: email, ID: uid, Enable: true, Flow: ""}
+	if err := svc.SyncInbound(nil, vless.Id, []model.Client{cleared}); err != nil {
+		t.Fatalf("vless SyncInbound (clear flow): %v", err)
+	}
+
+	list, err := svc.ListForInbound(nil, vless.Id)
+	if err != nil {
+		t.Fatalf("ListForInbound: %v", err)
+	}
+	if len(list) != 1 {
+		t.Fatalf("expected 1 client, got %d", len(list))
+	}
+	if list[0].Flow != "" {
+		t.Errorf("flow should be clearable on the owning inbound, got %q (Copilot review on #4545)", list[0].Flow)
 	}
 }

--- a/web/service/client_sync_multiprotocol_test.go
+++ b/web/service/client_sync_multiprotocol_test.go
@@ -1,0 +1,58 @@
+package service
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/mhsanaei/3x-ui/v3/database"
+	"github.com/mhsanaei/3x-ui/v3/database/model"
+)
+
+func TestSyncInbound_PreservesCredentialsAcrossProtocols(t *testing.T) {
+	dbDir := t.TempDir()
+	t.Setenv("XUI_DB_FOLDER", dbDir)
+	if err := database.InitDB(filepath.Join(dbDir, "3x-ui.db")); err != nil {
+		t.Fatalf("InitDB: %v", err)
+	}
+	t.Cleanup(func() { _ = database.CloseDB() })
+
+	db := database.GetDB()
+
+	vlessInbound := &model.Inbound{Tag: "vless-in", Enable: true, Port: 10001, Protocol: model.VLESS}
+	if err := db.Create(vlessInbound).Error; err != nil {
+		t.Fatalf("create vless inbound: %v", err)
+	}
+	hysteriaInbound := &model.Inbound{Tag: "hy-in", Enable: true, Port: 10002, Protocol: model.Hysteria2}
+	if err := db.Create(hysteriaInbound).Error; err != nil {
+		t.Fatalf("create hysteria inbound: %v", err)
+	}
+
+	svc := ClientService{}
+	const sharedEmail = "shared@example.com"
+	const wantUUID = "ce8d33df-3a64-4f10-8f9b-91c3a8e0c001"
+	const wantAuth = "h2-auth-token"
+
+	vlessClient := model.Client{Email: sharedEmail, ID: wantUUID, Enable: true, Flow: "xtls-rprx-vision"}
+	if err := svc.SyncInbound(nil, vlessInbound.Id, []model.Client{vlessClient}); err != nil {
+		t.Fatalf("vless SyncInbound: %v", err)
+	}
+
+	hysteriaClient := model.Client{Email: sharedEmail, Auth: wantAuth, Enable: true}
+	if err := svc.SyncInbound(nil, hysteriaInbound.Id, []model.Client{hysteriaClient}); err != nil {
+		t.Fatalf("hysteria SyncInbound: %v", err)
+	}
+
+	var row model.ClientRecord
+	if err := db.Where("email = ?", sharedEmail).First(&row).Error; err != nil {
+		t.Fatalf("lookup client row: %v", err)
+	}
+	if row.UUID != wantUUID {
+		t.Errorf("UUID was clobbered by Hysteria sync: got %q, want %q", row.UUID, wantUUID)
+	}
+	if row.Auth != wantAuth {
+		t.Errorf("Auth not persisted: got %q, want %q", row.Auth, wantAuth)
+	}
+	if row.Flow != "xtls-rprx-vision" {
+		t.Errorf("Flow was clobbered by Hysteria sync: got %q, want xtls-rprx-vision", row.Flow)
+	}
+}


### PR DESCRIPTION
## Summary

Bundles five independent bug fixes against open issues — each commit is self-contained and can be reviewed (or reverted) in isolation. All include regression tests where the fix is testable in a unit harness.

## Closes

- Closes #4539
- Closes #4538
- Closes #4535
- Closes #4531
- Closes #4515

## Type of change

- [x] Bug fix
- [x] Tests only (regression tests added per commit)

## Areas affected

- [x] Backend (API endpoints, login, settings)
- [x] Xray config generation
- [x] Subscription (share links / Clash / JSON)
- [x] Database / migrations
- [x] Frontend (UI / panel pages)
- [x] Telegram bot

## What's in this PR

### `ea926826` — fix: hash-storage panic on SIGHUP + seeder dup-key crash loop (#4539)
Two bugs that combine into an unrecoverable crash loop after a user enables the Telegram bot on a fresh install.

- `CheckHashStorageJob.Run` panics with a nil pointer dereference. The cron job is scheduled whenever settings say the bot is enabled, but `Tgbot.Start` only runs on full startup (not on the `StartPanelOnly` SIGHUP path). Toggling the bot on via the panel + save triggers SIGHUP, the package-level hash storage stays nil, and the cron fires 2 minutes later and exits 2. Fix: nil-check the storage in the job.
- `seedClientsFromInboundJSON` is not idempotent. The fresh-install early-return path recorded only `UserPasswordHash` + `ApiTokensTable`, never `ClientsTable`. After the admin added clients (which `SyncInbound` writes to the clients table), the next start ran the seeder for the first time, hit existing emails, and crashed with `SQLSTATE 23505` on `idx_clients_email` — turning the panic above into an unrecoverable crash loop on PostgreSQL. Fix: record `ClientsTable` in the fresh-install path AND hydrate the seeder's `byEmail` cache from existing rows so it merges instead of inserts.

Regression tests: `web/job/check_hash_storage_test.go`, `database/db_seed_test.go`.

### `97967535` — fix(clients): preserve protocol-specific credentials across multi-inbound syncs (#4538)
`fillProtocolDefaults` only populates the credential relevant to the inbound's protocol (UUID for VLESS, Auth for Hysteria, Password for Trojan/Shadowsocks). Each inbound's `settings.clients` JSON therefore carries the same client with only one of those fields set. `SyncInbound`'s update path was unconditionally copying every credential column from incoming to the existing row, so the second protocol's sync (e.g. Hysteria after VLESS) wrote `UUID=""` over a valid VLESS UUID. The config generator then emitted `{"email": "..."}` with no `id`, and xray-core crashed with `common/uuid: invalid UUID:`.

Fix: guard `UUID`/`Password`/`Auth`/`Flow`/`Security`/`Reverse` against empty overwrites. Other fields (LimitIP, TotalGB, Comment, …) keep copy-everything behavior so admins can still clear them through the panel.

Regression test: `web/service/client_sync_multiprotocol_test.go`.

### `64122ad8` — fix(expiry): show delayed-start countdown in subscribe and client info (#4535)
A client with "start after first use" expiry stores the duration as a negative ms count (e.g. `-86400000` = 1 day after first connect). The clients page row already renders this as "Delayed start: 1d", but two other surfaces treated negative values as zero:

- Subscription header (`subService` / `subClashService` / `subJsonService`): only carried `ExpiryTime` forward when `> 0`, so the header sent `expire=0` and every client appeared unlimited.
- `ClientInfoModal`: both the helper and the render guard treated `<= 0` as "no expiry", showing an infinity tag instead of the delay.

Fix: new `subscriptionExpiryFromClient` helper maps negative durations onto `now + |value|` so subscription clients see an actual countdown timestamp. `ClientInfoModal` now matches the clients-page convention.

Regression test: `sub/subService_test.go::TestSubscriptionExpiryFromClient`.

### `3df0ed21` — feat(clash): emit xhttp and httpupgrade transports in subscription (#4531)
Clash `applyTransport` only had cases for `tcp`/`ws`/`grpc`. Inbounds with `network: xhttp` (or `httpupgrade`) fell through to `default: return false` → `buildProxy` returned nil → the inbound was dropped from the proxies list. Subscriptions consisting entirely of xhttp inbounds came back empty (404, or `"Error!"` on older builds), and mihomo refused to parse.

Fix: add a case for each, mapping the inbound's stream settings onto the Mihomo opts blocks:
- `xhttp` → `xhttp-opts: { path, host, mode }`
- `httpupgrade` → `http-upgrade-opts: { path, headers: { Host } }`

Host falls back to the headers map when the dedicated field is empty, matching the existing ws behavior.

Regression test: `sub/subClashService_test.go` (3 cases).

### `934f9bc2` — fix(online): refresh online-clients list even when no WS frontend is connected (#4515)
`XrayTrafficJob` and `NodeTrafficSyncJob` both gated the entire post-traffic block behind `websocket.HasClients()` to skip expensive broadcasts when no browser is open. That block included `RefreshOnlineClientsFromMap`, which is the only thing keeping the in-memory `p.onlineClients` list fresh.

Three non-WS consumers read that same list:
- Telegram bot (`p.GetOnlineClients` in 3 places in tgbot.go)
- REST `POST /panel/api/onlines`
- Internal alerts that check whether a client is online

When no browser was watching the dashboard, the list went stale and stayed empty — the bot reported "nobody online" and the API returned `[]` even when xray had active sessions.

Fix: move `RefreshOnlineClientsFromMap` above the `HasClients` guard in both jobs. The refresh is one cheap `SELECT email, last_online` + an in-memory slice rebuild. Only the actual `Broadcast*` calls and the heavier `GetAllClientTraffics` / `GetInboundsTrafficSummary` queries remain gated.

## Test plan

- [x] `go build ./...` clean
- [x] `go test ./...` green (new regression tests pass; existing suite unchanged)
- [x] `go vet ./...` clean
- [x] `npm run lint && npm run typecheck && npm run build` clean
- [ ] Reproduce #4539 by enabling TG bot on a fresh install, saving settings to trigger SIGHUP, and confirming no panic 2 minutes later
- [ ] Reproduce #4538 by adding a VLESS and a Hysteria2 inbound that share a client email, confirming xray starts cleanly and `bin/config.json` carries both `id` and `auth`
- [ ] Reproduce #4535 by setting a client to "start after first use" with N days, opening "more info" and the in-panel subscribe page — both should show `Delayed start: Nd` instead of ∞
- [ ] Reproduce #4531 by importing a VLESS+xhttp+Reality subscription into mihomo — should parse and connect
- [ ] Reproduce #4515 by stopping all browser tabs and confirming TG bot's `/usage`-style commands still report active sessions