### PR TITLE
Random PostgreSQL role + post-install credentials display

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -112,7 +112,6 @@ gen_random_string() {
 
 install_postgres_local() {
     local pg_user pg_pass
-    pg_user=$(gen_random_string 8)
     pg_pass=$(gen_random_string 24)
     local pg_db="xui"
     local pg_host="127.0.0.1"
@@ -172,6 +171,16 @@ install_postgres_local() {
         sleep 1
     done
 
+    local existing_owner=""
+    existing_owner=$(sudo -u postgres psql -tAc \
+        "SELECT pg_catalog.pg_get_userbyid(datdba) FROM pg_database WHERE datname='${pg_db}'" 2> /dev/null \
+        | tr -d '[:space:]')
+    if [[ -n "${existing_owner}" && "${existing_owner}" != "postgres" ]]; then
+        pg_user="${existing_owner}"
+    else
+        pg_user=$(gen_random_string 8)
+    fi
+
     # Idempotent role/db creation. Identifiers are double-quoted because a
     # random username may start with a digit, which Postgres rejects unquoted.
     sudo -u postgres psql -tAc "SELECT 1 FROM pg_roles WHERE rolname='${pg_user}'" 2> /dev/null \
@@ -188,15 +197,21 @@ install_postgres_local() {
     pg_pass_enc=$(printf '%s' "${pg_pass}" | sed -e 's/%/%25/g' -e 's/:/%3A/g' -e 's/@/%40/g' -e 's|/|%2F|g' -e 's/?/%3F/g' -e 's/#/%23/g')
 
     if [[ -n "${PG_CRED_FILE:-}" ]]; then
+        local prev_umask
+        prev_umask=$(umask)
         umask 077
-        cat > "${PG_CRED_FILE}" <<EOF
+        if ! cat > "${PG_CRED_FILE}" << EOF; then
 PG_USER=${pg_user}
 PG_PASS=${pg_pass}
 PG_HOST=${pg_host}
 PG_PORT=${pg_port}
 PG_DB=${pg_db}
 EOF
-        umask 022
+            umask "${prev_umask}"
+            echo -e "${red}Failed to write PostgreSQL credentials to ${PG_CRED_FILE}${plain}" >&2
+            return 1
+        fi
+        umask "${prev_umask}"
     fi
 
     echo "postgres://${pg_user}:${pg_pass_enc}@${pg_host}:${pg_port}/${pg_db}?sslmode=disable"
@@ -875,17 +890,22 @@ config_after_install() {
                     else
                         echo -e "${yellow}Installing PostgreSQL — this may take a moment...${plain}"
                         local pg_cred_file
-                        pg_cred_file="/tmp/x-ui-pg-creds.$$"
-                        rm -f "${pg_cred_file}"
+                        pg_cred_file=$(mktemp 2> /dev/null) || pg_cred_file=$(mktemp -t x-ui-pg-creds.XXXXXXXX)
+                        if [[ -z "${pg_cred_file}" ]]; then
+                            echo -e "${red}Failed to create temporary credentials file.${plain}"
+                            xui_dsn=""
+                            continue
+                        fi
                         if xui_dsn=$(PG_CRED_FILE="${pg_cred_file}" install_postgres_local); then
                             pg_local_installed=1
                             if [[ -r "${pg_cred_file}" ]]; then
                                 # shellcheck disable=SC1090
                                 source "${pg_cred_file}"
-                                rm -f "${pg_cred_file}"
                             fi
+                            rm -f "${pg_cred_file}"
                             db_label="PostgreSQL (${PG_USER}@${PG_HOST}:${PG_PORT}/${PG_DB})"
                         else
+                            rm -f "${pg_cred_file}"
                             echo ""
                             echo -e "${red}PostgreSQL installation failed.${plain}"
                             echo -e "  1) Retry local install"

--- a/install.sh
+++ b/install.sh
@@ -111,10 +111,12 @@ gen_random_string() {
 }
 
 install_postgres_local() {
-    local pg_user="xui"
-    local pg_db="xui"
-    local pg_pass
+    local pg_user pg_pass
+    pg_user=$(gen_random_string 8)
     pg_pass=$(gen_random_string 24)
+    local pg_db="xui"
+    local pg_host="127.0.0.1"
+    local pg_port="5432"
 
     case "${release}" in
         ubuntu | debian | armbian)
@@ -170,20 +172,34 @@ install_postgres_local() {
         sleep 1
     done
 
-    # Idempotent role/db creation.
+    # Idempotent role/db creation. Identifiers are double-quoted because a
+    # random username may start with a digit, which Postgres rejects unquoted.
     sudo -u postgres psql -tAc "SELECT 1 FROM pg_roles WHERE rolname='${pg_user}'" 2> /dev/null \
         | grep -q 1 \
-        || sudo -u postgres psql -c "CREATE USER ${pg_user} WITH PASSWORD '${pg_pass}';" >&2 || return 1
+        || sudo -u postgres psql -c "CREATE USER \"${pg_user}\" WITH PASSWORD '${pg_pass}';" >&2 || return 1
 
     sudo -u postgres psql -tAc "SELECT 1 FROM pg_database WHERE datname='${pg_db}'" 2> /dev/null \
         | grep -q 1 \
-        || sudo -u postgres psql -c "CREATE DATABASE ${pg_db} OWNER ${pg_user};" >&2 || return 1
+        || sudo -u postgres psql -c "CREATE DATABASE \"${pg_db}\" OWNER \"${pg_user}\";" >&2 || return 1
 
-    sudo -u postgres psql -c "ALTER USER ${pg_user} WITH PASSWORD '${pg_pass}';" >&2 || return 1
+    sudo -u postgres psql -c "ALTER USER \"${pg_user}\" WITH PASSWORD '${pg_pass}';" >&2 || return 1
 
     local pg_pass_enc
     pg_pass_enc=$(printf '%s' "${pg_pass}" | sed -e 's/%/%25/g' -e 's/:/%3A/g' -e 's/@/%40/g' -e 's|/|%2F|g' -e 's/?/%3F/g' -e 's/#/%23/g')
-    echo "postgres://${pg_user}:${pg_pass_enc}@127.0.0.1:5432/${pg_db}?sslmode=disable"
+
+    if [[ -n "${PG_CRED_FILE:-}" ]]; then
+        umask 077
+        cat > "${PG_CRED_FILE}" <<EOF
+PG_USER=${pg_user}
+PG_PASS=${pg_pass}
+PG_HOST=${pg_host}
+PG_PORT=${pg_port}
+PG_DB=${pg_db}
+EOF
+        umask 022
+    fi
+
+    echo "postgres://${pg_user}:${pg_pass_enc}@${pg_host}:${pg_port}/${pg_db}?sslmode=disable"
     return 0
 }
 
@@ -823,7 +839,7 @@ config_after_install() {
             echo -e "${green}═══════════════════════════════════════════${plain}"
             echo -e "${green}     Database Selection                    ${plain}"
             echo -e "${green}═══════════════════════════════════════════${plain}"
-            echo -e "  1) SQLite     (default — recommended for < 1000 clients)"
+            echo -e "  1) SQLite     (default — recommended for < 500 clients)"
             echo -e "  2) PostgreSQL (recommended for high client counts / many nodes)"
             read -rp "Choose [1]: " db_choice
             db_choice="${db_choice:-1}"
@@ -843,6 +859,7 @@ config_after_install() {
 
                 local xui_dsn=""
                 local pg_mode=""
+                local pg_local_installed=0
                 while [[ -z "$xui_dsn" ]]; do
                     echo ""
                     echo -e "  1) Install PostgreSQL locally and create a dedicated user/db (recommended)"
@@ -857,8 +874,17 @@ config_after_install() {
                         db_label="PostgreSQL (external)"
                     else
                         echo -e "${yellow}Installing PostgreSQL — this may take a moment...${plain}"
-                        if xui_dsn=$(install_postgres_local); then
-                            db_label="PostgreSQL (xui@127.0.0.1:5432/xui)"
+                        local pg_cred_file
+                        pg_cred_file="/tmp/x-ui-pg-creds.$$"
+                        rm -f "${pg_cred_file}"
+                        if xui_dsn=$(PG_CRED_FILE="${pg_cred_file}" install_postgres_local); then
+                            pg_local_installed=1
+                            if [[ -r "${pg_cred_file}" ]]; then
+                                # shellcheck disable=SC1090
+                                source "${pg_cred_file}"
+                                rm -f "${pg_cred_file}"
+                            fi
+                            db_label="PostgreSQL (${PG_USER}@${PG_HOST}:${PG_PORT}/${PG_DB})"
                         else
                             echo ""
                             echo -e "${red}PostgreSQL installation failed.${plain}"
@@ -870,8 +896,15 @@ config_after_install() {
                             pg_fail="${pg_fail:-1}"
                             case "$pg_fail" in
                                 2) pg_mode="2" ;;
-                                3) echo -e "${red}Install aborted.${plain}"; exit 1 ;;
-                                4) db_choice="1"; xui_dsn=""; break ;;
+                                3)
+                                    echo -e "${red}Install aborted.${plain}"
+                                    exit 1
+                                    ;;
+                                4)
+                                    db_choice="1"
+                                    xui_dsn=""
+                                    break
+                                    ;;
                                 *) xui_dsn="" ;;
                             esac
                         fi
@@ -934,6 +967,28 @@ EOF
                 echo -e "${yellow}⚠ SSL Certificate: Enabled and configured${plain}"
             else
                 echo -e "${yellow}⚠ SSL Certificate: Skipped — panel is HTTP-only. Use a reverse proxy or SSH tunnel.${plain}"
+            fi
+
+            if [[ "$db_choice" == "2" && "$pg_local_installed" == "1" ]]; then
+                echo ""
+                echo -e "${green}═══════════════════════════════════════════${plain}"
+                echo -e "${green}     PostgreSQL Credentials               ${plain}"
+                echo -e "${green}═══════════════════════════════════════════${plain}"
+                echo -e "${green}DB Name:    ${PG_DB}${plain}"
+                echo -e "${green}Username:   ${PG_USER}${plain}"
+                echo -e "${green}Password:   ${PG_PASS}${plain}"
+                echo -e "${green}Host:       ${PG_HOST}${plain}"
+                echo -e "${green}Port:       ${PG_PORT}${plain}"
+                echo -e "${green}DSN:        ${xui_dsn}${plain}"
+                echo -e "${green}Env file:   ${xui_env_file}${plain}"
+                echo -e "${green}-------------------------------------------${plain}"
+                echo -e "${green}Connect from this server:${plain}"
+                echo -e "  ${blue}sudo -u postgres psql -d ${PG_DB}${plain}      (as the postgres superuser)"
+                echo -e "  ${blue}PGPASSWORD='${PG_PASS}' psql -h ${PG_HOST} -p ${PG_PORT} -U ${PG_USER} -d ${PG_DB}${plain}"
+                echo -e "${green}═══════════════════════════════════════════${plain}"
+                echo -e "${yellow}⚠ The panel reads these credentials from ${xui_env_file}.${plain}"
+                echo -e "${yellow}⚠ Save the password — it is not stored anywhere else in plain text.${plain}"
+                unset PG_USER PG_PASS PG_HOST PG_PORT PG_DB
             fi
         else
             local config_webBasePath=$(gen_random_string 18)


### PR DESCRIPTION
## Summary

`install_postgres_local` used to bake in a static `xui` role and only printed `PostgreSQL (xui@127.0.0.1:5432/xui)` at the end of install, leaving operators without the random password or any hint of how to connect from the shell.

Two changes in one commit:

- **Random 8-char role name** generated alongside the existing 24-char password. CREATE/ALTER statements double-quote the identifier so an alphanumeric starting with a digit doesn't get rejected by Postgres.
- **Dedicated "PostgreSQL Credentials" block** at the end of install — DB / user / pass / host / port / DSN / env-file path, plus ready-to-paste psql commands for both the postgres superuser and the new role. Credentials cross the subshell boundary via a 0600 tmpfile (`PG_CRED_FILE`) that the parent sources and unlinks; the `PG_*` vars are unset after display.

Only fires for the local-install flow; external-DSN path is unchanged.

## Test plan
- [ ] `bash -n install.sh` clean
- [ ] Fresh install on Ubuntu: pick option 2 (Postgres) → option 1 (local install). Confirm the credentials block prints with a random username and the printed `PGPASSWORD=... psql -h 127.0.0.1 ...` connects successfully.
- [ ] Confirm `/etc/default/x-ui` (or distro equivalent) holds the same DSN.
- [ ] Re-run installer: idempotent path doesn't double-create role/db.