### PR TITLE
feat(sub): add HEAD method support for subscription endpoints

### DIFF
--- a/sub/subController.go
+++ b/sub/subController.go
@@ -101,13 +101,16 @@ func NewSUBController(
 func (a *SUBController) initRouter(g *gin.RouterGroup) {
 	gLink := g.Group(a.subPath)
 	gLink.GET(":subid", a.subs)
+	gLink.HEAD(":subid", a.subs)
 	if a.jsonEnabled {
 		gJson := g.Group(a.subJsonPath)
 		gJson.GET(":subid", a.subJsons)
+		gJson.HEAD(":subid", a.subJsons)
 	}
 	if a.clashEnabled {
 		gClash := g.Group(a.subClashPath)
 		gClash.GET(":subid", a.subClashs)
+		gClash.HEAD(":subid", a.subClashs)
 	}
 }
 


### PR DESCRIPTION
## Summary

Add HTTP `HEAD` method support for all subscription endpoints (`/sub`, `/json`, `/clash`) by registering `.HEAD()` routes alongside existing `.GET()` routes in `initRouter()`.

## Why

Currently, subscription endpoints only register `GET` routes. Proxy clients and monitoring tools that need to periodically check traffic quota (via the `Subscription-Userinfo` response header) are forced to download the entire response body every time — even though they only need the headers.

By adding `HEAD` route registration, clients can retrieve `Subscription-Userinfo` (upload/download/total/expire) with a lightweight request that returns no response body, per [RFC 9110 §9.3.2](https://httpwg.org/specs/rfc9110.html#HEAD). Go's `net/http` automatically suppresses the body while preserving all headers including `Content-Length`.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactoring (no behavior change)
- [ ] Documentation
- [ ] Tests only
- [ ] Build / CI / tooling
- [ ] Other

## Areas affected

- [ ] Frontend (UI / panel pages)
- [ ] Backend (API endpoints, login, settings)
- [ ] Xray config generation
- [x] Subscription (share links / Clash / JSON)
- [ ] Statistics / traffic counters
- [ ] Database / migrations
- [ ] Install / upgrade script
- [ ] Docker image
- [ ] Multi-node (sub-nodes)
- [ ] Telegram bot

## How was this tested?

```bash
# Before: HEAD returns 404
curl -I https://panel-host/sub/<subid>
# HTTP/1.1 404 Not Found

# After: HEAD returns 200 with subscription headers, no body
curl -I https://panel-host/sub/<subid>
# HTTP/1.1 200 OK
# Subscription-Userinfo: upload=123; download=456; total=10737418240; expire=1735689600
# Content-Length: 1234
# (no body)

# GET still works exactly as before
curl https://panel-host/sub/<subid>
# (returns full subscription links as usual)