### PR TITLE
fix(i18n): add 1-year expiration to language cookie

### DIFF
--- a/frontend/src/utils/index.ts
+++ b/frontend/src/utils/index.ts
@@ -858,13 +858,13 @@ export class LanguageManager {
       });
 
       if (LanguageManager.isSupportLanguage(lang)) {
-        CookieManager.setCookie('lang', lang);
+        CookieManager.setCookie('lang', lang, 365);
       } else {
-        CookieManager.setCookie('lang', 'en-US');
+        CookieManager.setCookie('lang', 'en-US', 365);
         window.location.reload();
       }
     } else {
-      CookieManager.setCookie('lang', 'en-US');
+      CookieManager.setCookie('lang', 'en-US', 365);
       window.location.reload();
     }
 
@@ -875,7 +875,7 @@ export class LanguageManager {
     if (!LanguageManager.isSupportLanguage(language)) {
       language = 'en-US';
     }
-    CookieManager.setCookie('lang', language);
+    CookieManager.setCookie('lang', language, 365);
     window.location.reload();
   }
 


### PR DESCRIPTION
## Summary

Added a 1-year expiration time to the `lang` cookie in the frontend to make it a persistent cookie instead of a session cookie.

## Why

Previously, the `lang` cookie was set without an expiration date, which made it a Session Cookie. This caused users to lose their UI language preference every time they closed and reopened their browser. Additionally, because the backend relies on this cookie to determine the localized language for prompts and errors (`web/locale/locale.go`), the backend would also fall back to English/browser defaults upon browser restart. 
Adding a 1-year expiration ensures the user's language setting persists properly and improves the overall user experience.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactoring (no behavior change)
- [ ] Documentation
- [ ] Tests only
- [ ] Build / CI / tooling
- [ ] Other

## Areas affected

- [x] Frontend (UI / panel pages)
- [ ] Backend (API endpoints, login, settings)
- [ ] Xray config generation
- [ ] Subscription (share links / Clash / JSON)
- [ ] Statistics / traffic counters
- [ ] Database / migrations
- [ ] Install / upgrade script
- [ ] Docker image
- [ ] Multi-node (sub-nodes)
- [ ] Telegram bot

## How was this tested?

1. Open the panel UI in the browser and change the language from the default (e.g., to `zh-CN`).
2. Verify in the browser's DevTools (Application -> Cookies) that the `lang` cookie now has an `Expires/Max-Age` set to 1 year in the future, rather than `Session`.
3. Completely close the browser (all tabs/windows).
4. Reopen the browser and visit the panel UI again.
5. Confirmed that the previously selected language is preserved correctly instead of reverting to the default.

## Screenshots / recordings

N/A

## Breaking changes

None.

## Checklist

- [x] I tested the change locally and confirmed the described behavior.
- [ ] I added or updated tests for the new behavior (when applicable).
- [x] `go build ./...` and the test suite pass locally.
- [x] For frontend changes: `npm run lint`, `npm run typecheck`, and `npm run build` pass.
- [ ] I updated the Wiki / README / API docs if user-facing behavior changed.
- [x] My commits follow the project's existing message style.
- [x] I have no unrelated changes mixed into this PR.