### PR TITLE
fix(tgbot): ignore commands for other bots

### DIFF
--- a/web/service/tgbot.go
+++ b/web/service/tgbot.go
@@ -495,6 +495,10 @@ func (t *Tgbot) OnReceive() {
 		}, th.TextEqual(t.I18nBot("tgbot.buttons.closeKeyboard")))
 
 		h.HandleMessage(func(ctx *th.Context, message telego.Message) error {
+			if !t.isCommandForCurrentBot(&message) {
+				return nil
+			}
+
 			// Use goroutine with worker pool for concurrent command processing
 			go func() {
 				messageWorkerPool <- struct{}{}        // Acquire worker
@@ -682,6 +686,22 @@ func (t *Tgbot) answerCommand(message *telego.Message, chatId int64, isAdmin boo
 	if msg != "" {
 		t.sendResponse(chatId, msg, onlyMessage, isAdmin)
 	}
+}
+
+func (t *Tgbot) isCommandForCurrentBot(message *telego.Message) bool {
+	return isCommandForBot(message.Text, botUsername())
+}
+
+func botUsername() string {
+	if bot == nil {
+		return ""
+	}
+	return bot.Username()
+}
+
+func isCommandForBot(text string, username string) bool {
+	_, commandUsername, _ := tu.ParseCommand(text)
+	return commandUsername == "" || username == "" || strings.EqualFold(commandUsername, username)
 }
 
 // sendResponse sends the response message based on the onlyMessage flag.

--- a/web/service/tgbot_test.go
+++ b/web/service/tgbot_test.go
@@ -99,3 +99,27 @@ func TestTgbotProxyDialerNoneWhenEmpty(t *testing.T) {
 		t.Fatal("Dial must be nil when no proxy is configured")
 	}
 }
+
+func TestIsCommandForBotAllowsUntargetedCommand(t *testing.T) {
+	if !isCommandForBot("/status", "panel_bot") {
+		t.Fatal("untargeted commands must remain accepted")
+	}
+}
+
+func TestIsCommandForBotAllowsMatchingUsername(t *testing.T) {
+	if !isCommandForBot("/status@panel_bot", "Panel_Bot") {
+		t.Fatal("commands targeted to this bot must be accepted")
+	}
+}
+
+func TestIsCommandForBotRejectsOtherUsername(t *testing.T) {
+	if isCommandForBot("/status@other_bot", "panel_bot") {
+		t.Fatal("commands targeted to another bot must be ignored")
+	}
+}
+
+func TestIsCommandForBotKeepsLegacyBehaviorWhenUsernameUnavailable(t *testing.T) {
+	if !isCommandForBot("/status@panel_bot", "") {
+		t.Fatal("commands must remain accepted when the current bot username is unavailable")
+	}
+}


### PR DESCRIPTION
## Summary

Ignore Telegram commands that explicitly target a different bot username before the 3x-ui bot command handler clears state or sends a response.

## Why

Telegram groups can contain multiple bots. When a user sends a command like /status@other_bot, 3x-ui should not process it as its own command.

Closes #4893

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactoring (no behavior change)
- [ ] Documentation
- [ ] Tests only
- [ ] Build / CI / tooling
- [ ] Other

## Areas affected

- [ ] Frontend (UI / panel pages)
- [ ] Backend (API endpoints, login, settings)
- [ ] Xray config generation
- [ ] Subscription (share links / Clash / JSON)
- [ ] Statistics / traffic counters
- [ ] Database / migrations
- [ ] Install / upgrade script
- [ ] Docker image
- [ ] Multi-node (sub-nodes)
- [x] Telegram bot

## How was this tested?

- `go test ./web/service -run 'Test(IsCommandForBot|TgbotProxyDialer|LoginAttempt|IsSupportedBotProxyScheme)'
- `npm ci`
- `npm run build`
- `go test ./...`
- `go build ./...`

## Screenshots / recordings

N/A

## Breaking changes

None

## Checklist

- [x] I tested the change locally and confirmed the described behavior.
- [x] I added or updated tests for the new behavior (when applicable).
- [x] `go build ./...` and the test suite pass locally.
- [ ] For frontend changes: `npm run lint`, `npm run typecheck`, and `npm run build` pass.
- [ ] I updated the Wiki / README / API docs if user-facing behavior changed.
- [x] My commits follow the project's existing message style.
- [x] I have no unrelated changes mixed into this PR.
