### PR TITLE
fix(clients): restore shared subId compatibility

### DIFF
--- a/web/service/client.go
+++ b/web/service/client.go
@@ -600,18 +600,6 @@ func (s *ClientService) Create(inboundSvc *InboundService, payload *ClientCreate
 		}
 	}
 
-	if client.SubID != "" {
-		var subTaken int64
-		if err := database.GetDB().Model(&model.ClientRecord{}).
-			Where("sub_id = ? AND email <> ?", client.SubID, client.Email).
-			Count(&subTaken).Error; err != nil {
-			return false, err
-		}
-		if subTaken > 0 {
-			return false, common.NewError("subId already in use:", client.SubID)
-		}
-	}
-
 	needRestart := false
 	for _, ibId := range payload.InboundIds {
 		inbound, getErr := inboundSvc.GetInbound(ibId)
@@ -793,18 +781,6 @@ func (s *ClientService) Update(inboundSvc *InboundService, id int, updated model
 			Where("id = ?", id).
 			Update("email", updated.Email).Error; err != nil {
 			return false, err
-		}
-	}
-
-	if updated.SubID != "" {
-		var subCollision int64
-		if err := database.GetDB().Model(&model.ClientRecord{}).
-			Where("sub_id = ? AND id <> ?", updated.SubID, id).
-			Count(&subCollision).Error; err != nil {
-			return false, err
-		}
-		if subCollision > 0 {
-			return false, common.NewError("Duplicate subId:", updated.SubID)
 		}
 	}
 
@@ -3219,9 +3195,7 @@ func (s *ClientService) BulkCreate(inboundSvc *InboundService, payloads []Client
 	}
 	prep := make([]prepared, 0, len(payloads))
 	emails := make([]string, 0, len(payloads))
-	subIDs := make([]string, 0, len(payloads))
 	seenEmail := make(map[string]struct{}, len(payloads))
-	seenSubID := make(map[string]string, len(payloads))
 
 	for i := range payloads {
 		client := payloads[i].Client
@@ -3261,16 +3235,10 @@ func (s *ClientService) BulkCreate(inboundSvc *InboundService, payloads []Client
 			skip(email, "email already in use: "+email)
 			continue
 		}
-		if owner, ok := seenSubID[client.SubID]; ok && owner != le {
-			skip(email, "subId already in use: "+client.SubID)
-			continue
-		}
 		seenEmail[le] = struct{}{}
-		seenSubID[client.SubID] = le
 
 		prep = append(prep, prepared{client: client, inboundIds: payloads[i].InboundIds})
 		emails = append(emails, email)
-		subIDs = append(subIDs, client.SubID)
 	}
 
 	if len(prep) == 0 {
@@ -3290,18 +3258,6 @@ func (s *ClientService) BulkCreate(inboundSvc *InboundService, payloads []Client
 			existingEmailSub[strings.ToLower(rows[i].Email)] = rows[i].SubID
 		}
 	}
-	existingSubOwner := make(map[string]string, len(subIDs))
-	for start := 0; start < len(subIDs); start += lookupChunk {
-		end := min(start+lookupChunk, len(subIDs))
-		var rows []model.ClientRecord
-		if e := db.Where("sub_id IN ?", subIDs[start:end]).Find(&rows).Error; e != nil {
-			return result, false, e
-		}
-		for i := range rows {
-			existingSubOwner[rows[i].SubID] = strings.ToLower(rows[i].Email)
-		}
-	}
-
 	inboundCache := make(map[int]*model.Inbound)
 	getIb := func(id int) (*model.Inbound, error) {
 		if ib, ok := inboundCache[id]; ok {
@@ -3326,11 +3282,6 @@ func (s *ClientService) BulkCreate(inboundSvc *InboundService, payloads []Client
 		if existSub, ok := existingEmailSub[le]; ok && existSub != prep[idx].client.SubID {
 			failed[idx] = true
 			reason[idx] = "email already in use: " + prep[idx].client.Email
-			continue
-		}
-		if owner, ok := existingSubOwner[prep[idx].client.SubID]; ok && owner != le {
-			failed[idx] = true
-			reason[idx] = "subId already in use: " + prep[idx].client.SubID
 			continue
 		}
 

--- a/web/service/client_shared_subid_test.go
+++ b/web/service/client_shared_subid_test.go
@@ -1,0 +1,121 @@
+package service
+
+import (
+	"testing"
+
+	"github.com/mhsanaei/3x-ui/v3/database"
+	"github.com/mhsanaei/3x-ui/v3/database/model"
+)
+
+func TestClientCreateAllowsSharedSubID(t *testing.T) {
+	setupBulkDB(t)
+	svc := &ClientService{}
+	inboundSvc := &InboundService{}
+	ib := mkInbound(t, 23001, model.VLESS, `{"clients":[]}`)
+
+	clients := []model.Client{
+		{Email: "alpha@x", ID: "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa", SubID: "shared-sub", Enable: true},
+		{Email: "beta@x", ID: "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb", SubID: "shared-sub", Enable: true},
+	}
+	for _, client := range clients {
+		if _, err := svc.Create(inboundSvc, &ClientCreatePayload{Client: client, InboundIds: []int{ib.Id}}); err != nil {
+			t.Fatalf("Create(%q): %v", client.Email, err)
+		}
+	}
+
+	list, err := svc.ListForInbound(nil, ib.Id)
+	if err != nil {
+		t.Fatalf("ListForInbound: %v", err)
+	}
+	if got := sortedEmails(list); len(got) != 2 || got[0] != "alpha@x" || got[1] != "beta@x" {
+		t.Fatalf("expected both shared-sub clients on inbound, got %v", got)
+	}
+	for _, client := range list {
+		if client.SubID != "shared-sub" {
+			t.Fatalf("client %q should keep shared subId, got %q", client.Email, client.SubID)
+		}
+	}
+}
+
+func TestClientUpdateAllowsSharedSubID(t *testing.T) {
+	setupBulkDB(t)
+	svc := &ClientService{}
+	inboundSvc := &InboundService{}
+	ib := mkInbound(t, 23002, model.VLESS, `{"clients":[]}`)
+
+	seed := []model.Client{
+		{Email: "alpha@x", ID: "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa", SubID: "shared-sub", Enable: true},
+		{Email: "beta@x", ID: "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb", SubID: "beta-sub", Enable: true},
+	}
+	for _, client := range seed {
+		if _, err := svc.Create(inboundSvc, &ClientCreatePayload{Client: client, InboundIds: []int{ib.Id}}); err != nil {
+			t.Fatalf("Create(%q): %v", client.Email, err)
+		}
+	}
+
+	beta, err := svc.GetRecordByEmail(nil, "beta@x")
+	if err != nil {
+		t.Fatalf("GetRecordByEmail(beta): %v", err)
+	}
+	updated := beta.ToClient()
+	updated.SubID = "shared-sub"
+	if _, err := svc.Update(inboundSvc, beta.Id, *updated); err != nil {
+		t.Fatalf("Update(beta shared subId): %v", err)
+	}
+
+	reloaded, err := inboundSvc.GetInbound(ib.Id)
+	if err != nil {
+		t.Fatalf("GetInbound: %v", err)
+	}
+	list, err := inboundSvc.GetClients(reloaded)
+	if err != nil {
+		t.Fatalf("GetClients: %v", err)
+	}
+	if got := sortedEmails(list); len(got) != 2 || got[0] != "alpha@x" || got[1] != "beta@x" {
+		t.Fatalf("expected both clients after update, got %v", got)
+	}
+	for _, client := range list {
+		if client.SubID != "shared-sub" {
+			t.Fatalf("client %q should have shared subId after update, got %q", client.Email, client.SubID)
+		}
+	}
+}
+
+func TestBulkCreateAllowsSharedSubID(t *testing.T) {
+	setupBulkDB(t)
+	svc := &ClientService{}
+	inboundSvc := &InboundService{}
+	ib := mkInbound(t, 23003, model.VLESS, `{"clients":[]}`)
+
+	if _, err := svc.Create(inboundSvc, &ClientCreatePayload{
+		Client:     model.Client{Email: "alpha@x", ID: "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa", SubID: "shared-sub", Enable: true},
+		InboundIds: []int{ib.Id},
+	}); err != nil {
+		t.Fatalf("seed alpha: %v", err)
+	}
+
+	result, _, err := svc.BulkCreate(inboundSvc, []ClientCreatePayload{
+		{
+			Client:     model.Client{Email: "beta@x", ID: "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb", SubID: "shared-sub", Enable: true},
+			InboundIds: []int{ib.Id},
+		},
+		{
+			Client:     model.Client{Email: "gamma@x", ID: "cccccccc-cccc-cccc-cccc-cccccccccccc", SubID: "shared-sub", Enable: true},
+			InboundIds: []int{ib.Id},
+		},
+	})
+	if err != nil {
+		t.Fatalf("BulkCreate: %v", err)
+	}
+	if result.Created != 2 || len(result.Skipped) != 0 {
+		t.Fatalf("expected two created and no skipped clients, got created=%d skipped=%v", result.Created, result.Skipped)
+	}
+
+	var count int64
+	if err := database.GetDB().Model(&model.ClientRecord{}).Where("sub_id = ?", "shared-sub").Count(&count).Error; err != nil {
+		t.Fatalf("count shared-sub records: %v", err)
+	}
+	if count != 3 {
+		t.Fatalf("expected 3 client records sharing subId, got %d", count)
+	}
+}


### PR DESCRIPTION
## Summary

Restore compatibility for shared client subscription IDs by allowing multiple clients to use the same `subId` again. Email uniqueness is still enforced; `subId` is treated as a subscription grouping key.

## Why

Some existing deployments use one subscription ID to expose several client configs/transports under the same subscription URL. This used to work, and the subscription generator still supports it by returning every enabled client matching the requested `subId`.

The recent service-layer uniqueness checks blocked new or edited clients with an existing `subId`, causing `subId already in use` / `Duplicate subId` errors even though the database schema does not enforce `sub_id` uniqueness.

Refs #4759, #4927, #4953, #4785.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactoring (no behavior change)
- [ ] Documentation
- [ ] Tests only
- [ ] Build / CI / tooling
- [ ] Other

## Areas affected

- [ ] Frontend (UI / panel pages)
- [x] Backend (API endpoints, login, settings)
- [ ] Xray config generation
- [x] Subscription (share links / Clash / JSON)
- [ ] Statistics / traffic counters
- [ ] Database / migrations
- [ ] Install / upgrade script
- [ ] Docker image
- [ ] Multi-node (sub-nodes)
- [ ] Telegram bot

## How was this tested?

Added regression tests covering shared `subId` behavior for:

- single client create
- client update
- bulk client create

Commands run:

```sh
env CGO_ENABLED=1 go test ./web/service -run SharedSubID
env CGO_ENABLED=1 go test ./web/service
env CGO_ENABLED=1 go test ./web/service ./sub ./web/controller
git diff --check
```

I also tried:

```sh
env CGO_ENABLED=1 go test ./...
```

That command is blocked in this checkout because `web/web.go` embeds `web/dist`, which is not present:

```text
web/web.go:44:12: pattern all:dist: no matching files found
```

## Screenshots / recordings

N/A.

## Breaking changes

None. This restores the previous shared-subscription behavior and does not require a migration or API payload changes.

## Checklist

- [x] I tested the change locally and confirmed the described behavior.
- [x] I added or updated tests for the new behavior (when applicable).
- [ ] `go build ./...` and the test suite pass locally.
- [ ] For frontend changes: `npm run lint`, `npm run typecheck`, and `npm run build` pass.
- [x] I updated the Wiki / README / API docs if user-facing behavior changed.
- [x] My commits follow the project's existing message style.
- [x] I have no unrelated changes mixed into this PR.
