### PR TITLE
fix(subscription): include XHTTP padding options in Clash output

### DIFF
--- a/sub/subClashService.go
+++ b/sub/subClashService.go
@@ -428,6 +428,21 @@ func (s *SubClashService) applyTransport(proxy map[string]any, network string, s
 			if mode, ok := xhttp["mode"].(string); ok && mode != "" {
 				opts["mode"] = mode
 			}
+			if value, ok := xhttp["xPaddingObfsMode"].(bool); ok {
+				opts["x-padding-obfs-mode"] = value
+			}
+			paddingFields := map[string]string{
+				"xPaddingBytes":     "x-padding-bytes",
+				"xPaddingKey":       "x-padding-key",
+				"xPaddingHeader":    "x-padding-header",
+				"xPaddingPlacement": "x-padding-placement",
+				"xPaddingMethod":    "x-padding-method",
+			}
+			for source, target := range paddingFields {
+				if value, ok := xhttp[source].(string); ok && value != "" {
+					opts[target] = value
+				}
+			}
 		}
 		if len(opts) > 0 {
 			proxy["xhttp-opts"] = opts

--- a/sub/subClashService_test.go
+++ b/sub/subClashService_test.go
@@ -44,9 +44,15 @@ func TestApplyTransport_XHTTP(t *testing.T) {
 	proxy := map[string]any{}
 	stream := map[string]any{
 		"xhttpSettings": map[string]any{
-			"path": "/xh",
-			"host": "example.com",
-			"mode": "auto",
+			"path":              "/xh",
+			"host":              "example.com",
+			"mode":              "auto",
+			"xPaddingObfsMode":  true,
+			"xPaddingBytes":     "100-1000",
+			"xPaddingKey":       "trace",
+			"xPaddingHeader":    "X-Trace-ID",
+			"xPaddingPlacement": "queryInHeader",
+			"xPaddingMethod":    "tokenish",
 		},
 	}
 
@@ -60,7 +66,45 @@ func TestApplyTransport_XHTTP(t *testing.T) {
 	if !ok {
 		t.Fatalf("xhttp-opts missing or wrong type: %#v", proxy["xhttp-opts"])
 	}
-	want := map[string]any{"path": "/xh", "host": "example.com", "mode": "auto"}
+	want := map[string]any{
+		"path":                "/xh",
+		"host":                "example.com",
+		"mode":                "auto",
+		"x-padding-obfs-mode": true,
+		"x-padding-bytes":     "100-1000",
+		"x-padding-key":       "trace",
+		"x-padding-header":    "X-Trace-ID",
+		"x-padding-placement": "queryInHeader",
+		"x-padding-method":    "tokenish",
+	}
+	if !reflect.DeepEqual(opts, want) {
+		t.Fatalf("xhttp-opts = %#v, want %#v", opts, want)
+	}
+}
+
+func TestApplyTransport_XHTTP_OmitsEmptyPaddingStringsAndPreservesFalse(t *testing.T) {
+	svc := &SubClashService{}
+	proxy := map[string]any{}
+	stream := map[string]any{
+		"xhttpSettings": map[string]any{
+			"path":              "/xh",
+			"xPaddingObfsMode":  false,
+			"xPaddingBytes":     "",
+			"xPaddingKey":       "",
+			"xPaddingHeader":    "",
+			"xPaddingPlacement": "",
+			"xPaddingMethod":    "",
+		},
+	}
+
+	if !svc.applyTransport(proxy, "xhttp", stream) {
+		t.Fatalf("applyTransport returned false for xhttp")
+	}
+	opts, ok := proxy["xhttp-opts"].(map[string]any)
+	if !ok {
+		t.Fatalf("xhttp-opts missing or wrong type: %#v", proxy["xhttp-opts"])
+	}
+	want := map[string]any{"path": "/xh", "x-padding-obfs-mode": false}
 	if !reflect.DeepEqual(opts, want) {
 		t.Fatalf("xhttp-opts = %#v, want %#v", opts, want)
 	}


### PR DESCRIPTION
## What changed

Map the six Xray XHTTP padding fields from `xhttpSettings` into Mihomo's `xhttp-opts` keys when generating Clash subscriptions:

- `xPaddingObfsMode` -> `x-padding-obfs-mode`
- `xPaddingBytes` -> `x-padding-bytes`
- `xPaddingKey` -> `x-padding-key`
- `xPaddingHeader` -> `x-padding-header`
- `xPaddingPlacement` -> `x-padding-placement`
- `xPaddingMethod` -> `x-padding-method`

Empty string values are omitted, while an explicitly present boolean value is preserved. Existing path, host, and mode behavior is unchanged.

## Why

The regular VLESS subscription retains these fields in `extra`, but the Clash/Mihomo YAML generator previously emitted only path, host, and mode. Mihomo clients therefore imported an incomplete XHTTP configuration.

The key names and value types match Mihomo v1.19.27's `XHTTPOptions` and VLESS-extra conversion.

## Validation

- `go test ./sub`
- `go test ./...`