### PR TITLE
Allow to use several clients in one subscription

### DIFF
--- a/web/service/client.go
+++ b/web/service/client.go
@@ -600,18 +600,6 @@ func (s *ClientService) Create(inboundSvc *InboundService, payload *ClientCreate
 		}
 	}
 
-	if client.SubID != "" {
-		var subTaken int64
-		if err := database.GetDB().Model(&model.ClientRecord{}).
-			Where("sub_id = ? AND email <> ?", client.SubID, client.Email).
-			Count(&subTaken).Error; err != nil {
-			return false, err
-		}
-		if subTaken > 0 {
-			return false, common.NewError("subId already in use:", client.SubID)
-		}
-	}
-
 	needRestart := false
 	for _, ibId := range payload.InboundIds {
 		inbound, getErr := inboundSvc.GetInbound(ibId)
@@ -793,18 +781,6 @@ func (s *ClientService) Update(inboundSvc *InboundService, id int, updated model
 			Where("id = ?", id).
 			Update("email", updated.Email).Error; err != nil {
 			return false, err
-		}
-	}
-
-	if updated.SubID != "" {
-		var subCollision int64
-		if err := database.GetDB().Model(&model.ClientRecord{}).
-			Where("sub_id = ? AND id <> ?", updated.SubID, id).
-			Count(&subCollision).Error; err != nil {
-			return false, err
-		}
-		if subCollision > 0 {
-			return false, common.NewError("Duplicate subId:", updated.SubID)
 		}
 	}
 


### PR DESCRIPTION
## Summary

This change allows to use one SubID for different clients.
This reverts commit 88a3677318116615ce80a4a2e6b5b9c3e7bea93e.

## Why

I provide several URLs on one inbound to my friends to prevent connection collision when they are trying connect to my servers on a different devices. I don't know why but for reasons unknown to me, in rare cases where multiple connections are established from different devices, connection issues arise.

In addition, following the implementation of the node-based system, when migrating from v2.x to v3.x, different UUIDs are currently being used for the same clients across different servers, which makes it difficult to consolidate them all into a single subscription due to this rule.   

Formally it should looks like:

Inbounds+Clients:
| Node | Email | UUID | SubID |
|---|---|---|---|
| SomeOfHost | Fred (PC) | 0f700c16-8c7c-4e0f-ae82-870cdbce2863 | aljqd0mwtd6sfek7 |
| AbstractServer | Fred (PC) | f668dcb2-7102-43a0-9228-b181bcb200c0 | aljqd0mwtd6sfek7 |
| SomeOfHost  | Fred (Smartphone) | c8ca992b-e1e7-4c0c-8a8e-3a1c2f774c0f | aljqd0mwtd6sfek7 |
| AbstractServer | Fred (Smartphone) | 86e7b788-2782-412e-a22a-2c3275868767 | aljqd0mwtd6sfek7 |
| SomeOfHost | Jack (PC) | 2849f8e7-4619-4cd5-908b-ea3b12305a0f | vjspmfh3noukdeiy |
| AbstractServer | Jack (PC) | ca581956-5d40-407c-a2e5-4c5f068e4b37 | vjspmfh3noukdeiy |
| SomeOfHost | Jack (Smartphone) | 38e712af-d762-4b54-abd0-721037d0bea5 | vjspmfh3noukdeiy |
| AbstractServer | Jack (Smartphone) | 036be987-edf0-4ac8-8f40-711d0ab40a2b | vjspmfh3noukdeiy |

Sub `aljqd0mwtd6sfek7`:
```
SomeOfHost - Fred (PC)
AbstractServer - Fred (PC)
SomeOfHost - Fred (Smartphone)
AbstractServer - Fred (Smartphone)
```

Sub `vjspmfh3noukdeiy`:
```
SomeOfHost - Jack (PC)
AbstractServer - Jack (PC)
SomeOfHost - Jack (Smartphone)
AbstractServer - Jack (Smartphone)
```


## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactoring (no behavior change)
- [ ] Documentation
- [ ] Tests only
- [ ] Build / CI / tooling
- [x] Other

## Areas affected

- [ ] Frontend (UI / panel pages)
- [x] Backend (API endpoints, login, settings)
- [ ] Xray config generation
- [x] Subscription (share links / Clash / JSON)
- [ ] Statistics / traffic counters
- [ ] Database / migrations
- [ ] Install / upgrade script
- [ ] Docker image
- [ ] Multi-node (sub-nodes)
- [ ] Telegram bot

## How was this tested?

1. Create Client 1. Copy its SubID.
2. Create Client 2 using Client 1’s SubID.
3. Retrieve the URLs using the subscription and the SubID used earlier. Both clients should be returned.

## Breaking changes

None

## Checklist

- [x] I tested the change locally and confirmed the described behavior.
- [x] I added or updated tests for the new behavior (when applicable).
- [x] `go build ./...` and the test suite pass locally.
- [x] For frontend changes: `npm run lint`, `npm run typecheck`, and `npm run build` pass.
- [x] I updated the Wiki / README / API docs if user-facing behavior changed.
- [x] My commits follow the project's existing message style.
- [x] I have no unrelated changes mixed into this PR.
