### PR TITLE
fix(sub): emit VLESS encryption in Clash configs

### DIFF
--- a/sub/subClashService.go
+++ b/sub/subClashService.go
@@ -221,8 +221,11 @@ func (s *SubClashService) buildProxy(inbound *model.Inbound, client model.Client
 		}
 		var inboundSettings map[string]any
 		json.Unmarshal([]byte(inbound.Settings), &inboundSettings)
-		if encryption, ok := inboundSettings["encryption"].(string); ok && encryption != "" {
-			proxy["packet-encoding"] = encryption
+		if encryption, ok := inboundSettings["encryption"].(string); ok {
+			encryption = strings.TrimSpace(encryption)
+			if encryption != "" && encryption != "none" {
+				proxy["encryption"] = encryption
+			}
 		}
 	case model.Trojan:
 		proxy["type"] = "trojan"

--- a/sub/subClashService_test.go
+++ b/sub/subClashService_test.go
@@ -3,6 +3,8 @@ package sub
 import (
 	"reflect"
 	"testing"
+
+	"github.com/mhsanaei/3x-ui/v3/database/model"
 )
 
 func TestEnsureUniqueProxyNames(t *testing.T) {
@@ -111,5 +113,62 @@ func TestApplyTransport_HTTPUpgrade(t *testing.T) {
 	headers, _ := opts["headers"].(map[string]any)
 	if headers["Host"] != "example.com" {
 		t.Fatalf("headers.Host = %v, want example.com", headers["Host"])
+	}
+}
+
+func TestBuildProxy_VLESSPostQuantumEncryptionUsesMihomoEncryptionField(t *testing.T) {
+	svc := &SubClashService{SubService: &SubService{remarkModel: "-i"}}
+	encryption := "mlkem768x25519plus.native.0rtt.client"
+	inbound := &model.Inbound{
+		Listen:   "203.0.113.1",
+		Port:     443,
+		Protocol: model.VLESS,
+		Remark:   "pq",
+		Settings: `{"encryption":"` + encryption + `"}`,
+	}
+	client := model.Client{ID: "11111111-2222-4333-8444-555555555555"}
+	stream := map[string]any{
+		"network": "xhttp",
+		"xhttpSettings": map[string]any{
+			"path": "/",
+			"mode": "auto",
+		},
+		"security": "reality",
+		"realitySettings": map[string]any{
+			"publicKey":  "pub",
+			"serverName": "example.com",
+			"shortId":    "abcd",
+		},
+	}
+
+	proxy := svc.buildProxy(inbound, client, stream, "")
+
+	if proxy["encryption"] != encryption {
+		t.Fatalf("encryption = %v, want %q", proxy["encryption"], encryption)
+	}
+}
+
+func TestBuildProxy_VLESSNoneEncryptionOmittedForClash(t *testing.T) {
+	svc := &SubClashService{SubService: &SubService{remarkModel: "-i"}}
+	inbound := &model.Inbound{
+		Listen:   "203.0.113.1",
+		Port:     443,
+		Protocol: model.VLESS,
+		Remark:   "plain",
+		Settings: `{"encryption":"none"}`,
+	}
+	client := model.Client{ID: "11111111-2222-4333-8444-555555555555"}
+	stream := map[string]any{
+		"network":  "tcp",
+		"security": "none",
+		"tcpSettings": map[string]any{
+			"header": map[string]any{"type": "none"},
+		},
+	}
+
+	proxy := svc.buildProxy(inbound, client, stream, "")
+
+	if _, ok := proxy["encryption"]; ok {
+		t.Fatalf("plain vless encryption should be omitted for mihomo: %#v", proxy)
 	}
 }


### PR DESCRIPTION
## What changed

Emit non-empty, non-`none` VLESS inbound `encryption` values as Mihomo's `encryption` field when generating Clash subscriptions.

- Preserve post-quantum VLESS authentication strings such as `mlkem768x25519plus...` under `encryption`
- Stop writing VLESS encryption values into `packet-encoding`
- Omit `encryption: none` from Clash output
- Add regression coverage for post-quantum and `none` VLESS encryption

## Why

3x-ui keeps the VLESS client-side `encryption` value in inbound settings so regular VLESS links and JSON outbounds can carry it, while stripping it from the server-side Xray inbound config. The Clash generator previously mapped that value to `packet-encoding`, which Mihomo treats as UDP packet encoding rather than VLESS encryption.

As a result, post-quantum VLESS nodes could be imported by Clash/Mihomo with an invalid field mapping and fail to connect even when the regular VLESS subscription worked. The generated Clash YAML now matches Mihomo's VLESS proxy schema.

Fixes #5018.

## Validation

- `go test ./sub`