### PR TITLE
fix(subClashService): improve merging of clash rules in YAML

### DIFF
--- a/sub/subClashService.go
+++ b/sub/subClashService.go
@@ -573,10 +573,14 @@ func mergeClashRulesYAML(base map[string]any, raw string) error {
 	case []any:
 		mergeClashRules(base, typed)
 	case map[string]any:
-		if rules, ok := typed["rules"]; ok {
-			if ruleList, ok := asAnySlice(rules); ok {
-				mergeClashRules(base, ruleList)
+		for key, value := range typed {
+			if key == "rules" {
+				if ruleList, ok := asAnySlice(value); ok {
+					mergeClashRules(base, ruleList)
+				}
+				continue
 			}
+			base[key] = value
 		}
 	default:
 		mergeClashRules(base, linesToClashRules(raw))


### PR DESCRIPTION
## Summary

improve merging of clash rules in YAML

## Why
Currently, the Clash/Mihomo Global Routing Rules feature in 3x-ui only preserves the rules section and strips away other top-level configurations like rule-providers.
Closes #5044

## Type of change

- [x] New feature

## Areas affected

- [x] Subscription (Clash)
