### PR TITLE
fix(update.sh): allow skipping ssl setup when updating

### DIFF
--- a/update.sh
+++ b/update.sh
@@ -582,12 +582,14 @@ prompt_and_setup_ssl() {
     echo -e "${green}1.${plain} Let's Encrypt for Domain (90-day validity, auto-renews)"
     echo -e "${green}2.${plain} Let's Encrypt for IP Address (6-day validity, auto-renews)"
     echo -e "${green}3.${plain} Custom SSL Certificate (Path to existing files)"
+    echo -e "${green}4.${plain} Skip SSL (advanced — behind reverse proxy / SSH tunnel only)"
     echo -e "${blue}Note:${plain} Options 1 & 2 require port 80 open. Option 3 requires manual paths."
+    echo -e "${blue}Note:${plain} Option 4 serves the panel over plain HTTP — only safe behind nginx/Caddy or an SSH tunnel."
     read -rp "Choose an option (default 2 for IP): " ssl_choice
     ssl_choice="${ssl_choice// /}" # Trim whitespace
 
-    # Default to 2 (IP cert) if input is empty or invalid (not 1 or 3)
-    if [[ "$ssl_choice" != "1" && "$ssl_choice" != "3" ]]; then
+    # Default to 2 (IP cert) if input is empty or invalid (not 1, 3 or 4)
+    if [[ "$ssl_choice" != "1" && "$ssl_choice" != "3" && "$ssl_choice" != "4" ]]; then
         ssl_choice="2"
     fi
 
@@ -705,6 +707,41 @@ prompt_and_setup_ssl() {
             echo -e "${yellow}Note: You are responsible for renewing these files externally.${plain}"
 
             systemctl restart x-ui > /dev/null 2>&1 || rc-service x-ui restart > /dev/null 2>&1
+            ;;
+        4)
+            echo ""
+            echo -e "${red}⚠ Panel will be installed WITHOUT SSL/TLS.${plain}"
+            echo -e "${yellow}Login credentials and cookies will travel as plain HTTP.${plain}"
+            echo -e "${yellow}Only safe when:${plain}"
+            echo -e "${yellow}  • A reverse proxy (nginx, Caddy, Traefik) terminates TLS for you, or${plain}"
+            echo -e "${yellow}  • You access the panel exclusively via SSH tunnel${plain}"
+            echo ""
+
+            SSL_SCHEME="http"
+            SSL_HOST="${server_ip}"
+
+            local bind_local=""
+            read -rp "Bind the panel to 127.0.0.1 only? (recommended — forces SSH tunnel / reverse-proxy access) [y/N]: " bind_local
+            if [[ "$bind_local" == "y" || "$bind_local" == "Y" ]]; then
+                ${xui_folder}/x-ui setting -listenIP "127.0.0.1" > /dev/null 2>&1
+                SSL_HOST="127.0.0.1"
+                echo -e "${green}✓ Panel bound to 127.0.0.1 only. It is now unreachable from the public internet.${plain}"
+                echo ""
+                echo -e "${green}SSH Port Forwarding — open the panel from your local machine via:${plain}"
+                echo -e "  Standard SSH command:"
+                echo -e "  ${yellow}ssh -L 2222:127.0.0.1:${panel_port} root@${server_ip}${plain}"
+                echo -e "  If using an SSH key:"
+                echo -e "  ${yellow}ssh -i <sshkeypath> -L 2222:127.0.0.1:${panel_port} root@${server_ip}${plain}"
+                echo -e "  Then open in your browser:"
+                echo -e "  ${yellow}http://localhost:2222/${web_base_path}${plain}"
+                echo ""
+                echo -e "${yellow}Alternative: point a reverse proxy (nginx/Caddy) at 127.0.0.1:${panel_port} and let it terminate TLS.${plain}"
+            else
+                echo -e "${yellow}Panel will listen on all interfaces over plain HTTP. Make sure something else is terminating TLS in front of it.${plain}"
+            fi
+
+            systemctl restart x-ui > /dev/null 2>&1 || rc-service x-ui restart > /dev/null 2>&1
+            echo -e "${green}✓ SSL setup skipped.${plain}"
             ;;
         *)
             echo -e "${red}Invalid option. Skipping SSL setup.${plain}"


### PR DESCRIPTION
## Summary

<!-- What does this PR do? One or two sentences. -->

Sync "Skip SSL" option from `install.sh` to `update.sh`, allowing user to skip SSL setup.

## Why

<!--
What problem does this solve, or what use case does it enable?
Link related issues here: "Closes #123", "Refs #456".
-->

As reported in #4898 the update script `update.sh` doesn't allow user to skip SSL setup, while install script `install.sh` does. It doesn't make sense that they should behave differently.

Skipping SSL makes it easy to use reverse proxy, which is more flexible (and sometimes actually safer) for advanced users.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactoring (no behavior change)
- [ ] Documentation
- [ ] Tests only
- [ ] Build / CI / tooling
- [ ] Other

## Areas affected

- [ ] Frontend (UI / panel pages)
- [ ] Backend (API endpoints, login, settings)
- [ ] Xray config generation
- [ ] Subscription (share links / Clash / JSON)
- [ ] Statistics / traffic counters
- [ ] Database / migrations
- [x] Install / upgrade script
- [ ] Docker image
- [ ] Multi-node (sub-nodes)
- [ ] Telegram bot

## How was this tested?

<!--
Concrete steps the reviewer can repeat. For UI changes: which page,
which actions, which browser. For backend: which endpoint, which payload,
which response. Mention any new unit/integration tests added.
-->

I performed an installation in VM and no error was reported. Since I'm porting existing code, the fix should be safe.

## Checklist

- [x] I tested the change locally and confirmed the described behavior.
- [ ] ~~I added or updated tests for the new behavior (when applicable).~~ (Not applicable)
- [x] `go build ./...` and the test suite pass locally.
- [ ] ~~For frontend changes: `npm run lint`, `npm run typecheck`, and `npm run build` pass.~~ (Not applicable)
- [ ] ~~I updated the Wiki / README / API docs if user-facing behavior changed.~~ (Not applicable)
- [x] My commits follow the project's existing message style.
- [x] I have no unrelated changes mixed into this PR.
