### PR TITLE
test(frontend): mock axios globally to prevent flaky network errors on CI

### DIFF
--- a/frontend/src/test/setup.components.ts
+++ b/frontend/src/test/setup.components.ts
@@ -74,3 +74,12 @@ afterEach(async () => {
     await new Promise((resolve) => setTimeout(resolve, 0));
   }
 });
+
+vi.mock('axios', () => {
+  return {
+    default: {
+      get: vi.fn().mockResolvedValue({ data: { success: true, obj: {} } }),
+      post: vi.fn().mockResolvedValue({ data: { success: true, obj: {} } }),
+    }
+  };
+});


### PR DESCRIPTION
This mocks axios globally in the component test setup to prevent 'AxiosError: Network Error' and 'window is not defined' unhandled exceptions caused by delayed network rejections during test teardown. Tests now complete strictly synchronously before JSDOM destroys the window.