### PR TITLE
fix(ui): correct inline style syntax in client counts column on inbounds page

### DIFF
--- a/frontend/src/pages/inbounds/list/useInboundColumns.tsx
+++ b/frontend/src/pages/inbounds/list/useInboundColumns.tsx
@@ -171,7 +171,7 @@ export function useInboundColumns({
                     </div>
                   )}
                 >
-                  <Tag color="green" className="client-count-tag" style={{ margin: 0, padding: '0 2px' }}>{cc.active.length}</Tag>
+                  <Tag color="green" className="client-count-tag" style={{ margin: 0, marginRight: 4, padding: '0 2px' }}>{cc.active.length}</Tag>
                 </Popover>
               )}
               {cc.deactive.length > 0 && (
@@ -183,7 +183,7 @@ export function useInboundColumns({
                     </div>
                   )}
                 >
-                  <Tag className="client-count-tag" style={{ margin: 0, padding: '0 2px' }}>{cc.deactive.length}</Tag>
+                  <Tag className="client-count-tag" style={{ margin: 0, marginRight: 4, padding: '0 2px' }}>{cc.deactive.length}</Tag>
                 </Popover>
               )}
               {cc.depleted.length > 0 && (
@@ -195,7 +195,7 @@ export function useInboundColumns({
                     </div>
                   )}
                 >
-                  <Tag color="red" className="client-count-tag" style={{ margin: 0, padding: '0 2px' }}>{cc.depleted.length}</Tag>
+                  <Tag color="red" className="client-count-tag" style={{ margin: 0, marginRight: 4, padding: '0 2px' }}>{cc.depleted.length}</Tag>
                 </Popover>
               )}
               {cc.online.length > 0 && (


### PR DESCRIPTION
Before:
<img width="471" height="87" alt="image" src="https://github.com/user-attachments/assets/05a3469a-d4c4-43f6-b4a8-8258ec1436f8" />

After:
<img width="524" height="76" alt="image" src="https://github.com/user-attachments/assets/2ae7e275-3374-4538-9b54-8af947194a3a" />
