### PR TITLE
fix: propagate inbound traffic reset to nodes

### DIFF
--- a/web/runtime/local.go
+++ b/web/runtime/local.go
@@ -159,3 +159,7 @@ func (l *Local) ResetClientTraffic(_ context.Context, _ *model.Inbound, _ string
 func (l *Local) ResetAllTraffics(_ context.Context) error {
 	return nil
 }
+
+func (l *Local) ResetInboundTraffic(_ context.Context, _ *model.Inbound) error {
+	return nil
+}

--- a/web/runtime/remote.go
+++ b/web/runtime/remote.go
@@ -399,6 +399,11 @@ func (r *Remote) ResetAllTraffics(ctx context.Context) error {
 	return err
 }
 
+func (r *Remote) ResetInboundTraffic(ctx context.Context, ib *model.Inbound) error {
+	_, err := r.do(ctx, http.MethodPost, fmt.Sprintf("panel/api/inbounds/%d/resetTraffic", ib.Id), nil)
+	return err
+}
+
 type TrafficSnapshot struct {
 	Inbounds     []*model.Inbound
 	OnlineEmails []string

--- a/web/runtime/runtime.go
+++ b/web/runtime/runtime.go
@@ -26,5 +26,6 @@ type Runtime interface {
 	RestartXray(ctx context.Context) error
 
 	ResetClientTraffic(ctx context.Context, ib *model.Inbound, email string) error
+	ResetInboundTraffic(ctx context.Context, ib *model.Inbound) error
 	ResetAllTraffics(ctx context.Context) error
 }

--- a/web/service/inbound.go
+++ b/web/service/inbound.go
@@ -3011,15 +3011,41 @@ func (s *InboundService) resetAllTrafficsLocked() error {
 		return err
 	}
 
+	nodes, err := (&NodeService{}).GetAll()
+	if err == nil {
+		for _, node := range nodes {
+			if rt, err := runtime.GetManager().RuntimeFor(&node.Id); err == nil {
+				if e := rt.ResetAllTraffics(context.Background()); e != nil {
+					logger.Warning("ResetAllTraffics: remote propagation to", rt.Name(), "failed:", e)
+				}
+			}
+		}
+	}
+
 	return nil
 }
 
 func (s *InboundService) ResetInboundTraffic(id int) error {
 	return submitTrafficWrite(func() error {
 		db := database.GetDB()
-		return db.Model(model.Inbound{}).
+		if err := db.Model(model.Inbound{}).
 			Where("id = ?", id).
-			Updates(map[string]any{"up": 0, "down": 0}).Error
+			Updates(map[string]any{"up": 0, "down": 0}).Error; err != nil {
+			return err
+		}
+
+		inbound, err := s.GetInbound(id)
+		if err == nil && inbound != nil && inbound.NodeID != nil {
+			if rt, rterr := s.runtimeFor(inbound); rterr == nil {
+				if e := rt.ResetInboundTraffic(context.Background(), inbound); e != nil {
+					logger.Warning("ResetInboundTraffic: remote propagation to", rt.Name(), "failed:", e)
+				}
+			} else {
+				logger.Warning("ResetInboundTraffic: runtime lookup failed:", rterr)
+			}
+		}
+
+		return nil
 	})
 }
 


### PR DESCRIPTION
### Issue
Fixes https://github.com/MHSanaei/3x-ui/issues/5100

Traffic resets initiated by the master panel were only executing a database update and were not propagating to remote nodes. This affected both manual resets per inbound and the periodic traffic reset job for all inbounds.

### Solution
- Added `ResetInboundTraffic(ctx context.Context, ib *model.Inbound) error` to the `Runtime` interface and implemented it in `Remote` (calling `POST panel/api/inbounds/:id/resetTraffic`) and `Local`.
- In `InboundService.ResetInboundTraffic`, the reset is now propagated via `rt.ResetInboundTraffic(...)` to the node owning the inbound.
- In `InboundService.resetAllTrafficsLocked`, the reset is now batched and propagated via `rt.ResetAllTraffics(ctx)` to all active nodes.
