### PR TITLE
fix: auto-enable clients when resetting traffic

### DIFF
--- a/web/service/client.go
+++ b/web/service/client.go
@@ -1493,7 +1493,6 @@ func (s *ClientService) ResetTrafficByEmail(inboundSvc *InboundService, email st
 	if err != nil {
 		return false, err
 	}
-
 	needRestart := false
 	if !rec.Enable {
 		updated := rec.ToClient()


### PR DESCRIPTION
When a client's traffic is exhausted, the panel automatically disables the client and pushes enable: false to the nodes. However, when an admin clicked 'Reset Traffic' or used bulk reset, the counters were zeroed but the client was left disabled. This forced administrators to manually re-enable the client across the central panel and remote nodes.

This patch updates ResetTrafficByEmail and BulkResetTraffic to automatically set Enable: true for any previously disabled client and push the updated settings to nodes, ensuring the client is instantly restored upon traffic reset.

## Summary

<!-- What does this PR do? One or two sentences. -->

## Why

<!--
What problem does this solve, or what use case does it enable?
Link related issues here: "Closes #123", "Refs #456".
-->

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactoring (no behavior change)
- [ ] Documentation
- [ ] Tests only
- [ ] Build / CI / tooling
- [ ] Other

## Areas affected

- [ ] Frontend (UI / panel pages)
- [ ] Backend (API endpoints, login, settings)
- [ ] Xray config generation
- [ ] Subscription (share links / Clash / JSON)
- [ ] Statistics / traffic counters
- [ ] Database / migrations
- [ ] Install / upgrade script
- [ ] Docker image
- [ ] Multi-node (sub-nodes)
- [ ] Telegram bot

## How was this tested?

<!--
Concrete steps the reviewer can repeat. For UI changes: which page,
which actions, which browser. For backend: which endpoint, which payload,
which response. Mention any new unit/integration tests added.
-->

## Screenshots / recordings

<!-- Required for UI changes. Drag images or GIFs here. Remove if N/A. -->

## Breaking changes

<!--
Does this change require existing users to update their config, run a
migration, or change their API calls? If yes, describe the migration path.
Write "None" if there are no breaking changes.
-->

## Checklist

- [ ] I tested the change locally and confirmed the described behavior.
- [ ] I added or updated tests for the new behavior (when applicable).
- [ ] `go build ./...` and the test suite pass locally.
- [ ] For frontend changes: `npm run lint`, `npm run typecheck`, and `npm run build` pass.
- [ ] I updated the Wiki / README / API docs if user-facing behavior changed.
- [ ] My commits follow the project's existing message style.
- [ ] I have no unrelated changes mixed into this PR.
