### PR TITLE
fix: properly enable BBR and mute sysctl errors on restricted OS configurations (#5160)

### DIFF
--- a/x-ui.sh
+++ b/x-ui.sh
@@ -695,7 +695,7 @@ disable_bbr() {
             sysctl -w net.ipv4.tcp_window_scaling="$(echo "$old_settings" | awk -F: '{print $4}')"
         fi
         rm /etc/sysctl.d/99-bbr-x-ui.conf
-        sysctl --system
+        sysctl --system 2>/dev/null
     else
         # Replace BBR with CUBIC configurations
         if [ -f "/etc/sysctl.conf" ]; then
@@ -703,7 +703,7 @@ disable_bbr() {
             sed -i 's/net.ipv4.tcp_congestion_control=bbr/net.ipv4.tcp_congestion_control=cubic/' /etc/sysctl.conf
             sed -i 's/net.ipv4.tcp_ecn=1/net.ipv4.tcp_ecn=2/' /etc/sysctl.conf
             sed -i 's/net.ipv4.tcp_window_scaling=1/net.ipv4.tcp_window_scaling=0/' /etc/sysctl.conf
-            sysctl -p
+            sysctl -p 2>/dev/null
         fi
     fi
 
@@ -736,7 +736,7 @@ enable_bbr() {
             sed -i 's/^net.ipv4.tcp_ecn/# &/' /etc/sysctl.conf
             sed -i 's/^net.ipv4.tcp_window_scaling/# &/' /etc/sysctl.conf
         fi
-        sysctl --system
+        sysctl --system 2>/dev/null
     else
         sed -i '/net.core.default_qdisc/d' /etc/sysctl.conf
         sed -i '/net.ipv4.tcp_congestion_control/d' /etc/sysctl.conf
@@ -746,7 +746,7 @@ enable_bbr() {
         echo "net.ipv4.tcp_congestion_control=bbr" | tee -a /etc/sysctl.conf
         echo "net.ipv4.tcp_ecn=1" | tee -a /etc/sysctl.conf
         echo "net.ipv4.tcp_window_scaling=1" | tee -a /etc/sysctl.conf
-        sysctl -p
+        sysctl -p 2>/dev/null
     fi
 
     # Verify that BBR is enabled

--- a/x-ui.sh
+++ b/x-ui.sh
@@ -688,8 +688,12 @@ disable_bbr() {
 
     if [ -f "/etc/sysctl.d/99-bbr-x-ui.conf" ]; then
         old_settings=$(head -1 /etc/sysctl.d/99-bbr-x-ui.conf | tr -d '#')
-        sysctl -w net.core.default_qdisc="${old_settings%:*}"
-        sysctl -w net.ipv4.tcp_congestion_control="${old_settings#*:}"
+        sysctl -w net.core.default_qdisc="$(echo "$old_settings" | awk -F: '{print $1}')"
+        sysctl -w net.ipv4.tcp_congestion_control="$(echo "$old_settings" | awk -F: '{print $2}')"
+        if [ "$(echo "$old_settings" | awk -F: '{print NF}')" -ge 4 ]; then
+            sysctl -w net.ipv4.tcp_ecn="$(echo "$old_settings" | awk -F: '{print $3}')"
+            sysctl -w net.ipv4.tcp_window_scaling="$(echo "$old_settings" | awk -F: '{print $4}')"
+        fi
         rm /etc/sysctl.d/99-bbr-x-ui.conf
         sysctl --system
     else
@@ -697,6 +701,8 @@ disable_bbr() {
         if [ -f "/etc/sysctl.conf" ]; then
             sed -i 's/net.core.default_qdisc=fq/net.core.default_qdisc=pfifo_fast/' /etc/sysctl.conf
             sed -i 's/net.ipv4.tcp_congestion_control=bbr/net.ipv4.tcp_congestion_control=cubic/' /etc/sysctl.conf
+            sed -i 's/net.ipv4.tcp_ecn=1/net.ipv4.tcp_ecn=2/' /etc/sysctl.conf
+            sed -i 's/net.ipv4.tcp_window_scaling=1/net.ipv4.tcp_window_scaling=0/' /etc/sysctl.conf
             sysctl -p
         fi
     fi
@@ -717,21 +723,29 @@ enable_bbr() {
     # Enable BBR
     if [ -d "/etc/sysctl.d/" ]; then
         {
-            echo "#$(sysctl -n net.core.default_qdisc):$(sysctl -n net.ipv4.tcp_congestion_control)"
+            echo "#$(sysctl -n net.core.default_qdisc):$(sysctl -n net.ipv4.tcp_congestion_control):$(sysctl -n net.ipv4.tcp_ecn):$(sysctl -n net.ipv4.tcp_window_scaling)"
             echo "net.core.default_qdisc = fq"
             echo "net.ipv4.tcp_congestion_control = bbr"
+            echo "net.ipv4.tcp_ecn = 1"
+            echo "net.ipv4.tcp_window_scaling = 1"
         } > "/etc/sysctl.d/99-bbr-x-ui.conf"
         if [ -f "/etc/sysctl.conf" ]; then
             # Backup old settings from sysctl.conf, if any
             sed -i 's/^net.core.default_qdisc/# &/' /etc/sysctl.conf
             sed -i 's/^net.ipv4.tcp_congestion_control/# &/' /etc/sysctl.conf
+            sed -i 's/^net.ipv4.tcp_ecn/# &/' /etc/sysctl.conf
+            sed -i 's/^net.ipv4.tcp_window_scaling/# &/' /etc/sysctl.conf
         fi
         sysctl --system
     else
         sed -i '/net.core.default_qdisc/d' /etc/sysctl.conf
         sed -i '/net.ipv4.tcp_congestion_control/d' /etc/sysctl.conf
+        sed -i '/net.ipv4.tcp_ecn/d' /etc/sysctl.conf
+        sed -i '/net.ipv4.tcp_window_scaling/d' /etc/sysctl.conf
         echo "net.core.default_qdisc=fq" | tee -a /etc/sysctl.conf
         echo "net.ipv4.tcp_congestion_control=bbr" | tee -a /etc/sysctl.conf
+        echo "net.ipv4.tcp_ecn=1" | tee -a /etc/sysctl.conf
+        echo "net.ipv4.tcp_window_scaling=1" | tee -a /etc/sysctl.conf
         sysctl -p
     fi
 


### PR DESCRIPTION
Fixes #5160

## Summary

This PR addresses two related issues with BBR enabling in x-ui.sh:
1. It adds 
et.ipv4.tcp_ecn and 
et.ipv4.tcp_window_scaling to the BBR enable script, as these are often required for optimal performance.
2. It mutes stderr on sysctl --system and sysctl -p. On restricted environments (e.g. LXC or OpenVZ), system configuration files that set properties like 
et.ipv4.conf.all.accept_source_route fail, causing sysctl to throw errors in the terminal which confuse users into thinking the BBR script failed. By muting stderr, these unrelated system-level errors are hidden.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactoring (no behavior change)
- [ ] Documentation
- [ ] Tests only
- [ ] Build / CI / tooling
- [ ] Other

## Areas affected

- [ ] Frontend (UI / panel pages)
- [ ] Backend (API endpoints, login, settings)
- [ ] Xray config generation
- [ ] Subscription (share links / Clash / JSON)
- [ ] Statistics / traffic counters
- [ ] Database / migrations
- [x] Install / upgrade script
- [ ] Docker image
- [ ] Multi-node (sub-nodes)
- [ ] Telegram bot

## Checklist

- [x] I tested the change locally and confirmed the described behavior.
- [ ] I added or updated tests for the new behavior (when applicable).
- [ ] \go build ./...\ and the test suite pass locally.
- [ ] For frontend changes: \
pm run lint\, \
pm run typecheck\, and \
pm run build\ pass.
- [ ] I updated the Wiki / README / API docs if user-facing behavior changed.
- [x] My commits follow the project's existing message style.
- [x] I have no unrelated changes mixed into this PR.