### PR TITLE
fix: deduplicate clients in subscription links (#5134)

### DIFF
--- a/internal/sub/clash_service.go
+++ b/internal/sub/clash_service.go
@@ -34,6 +34,7 @@ func (s *SubClashService) GetClash(subId string, host string) (string, string, e
 
 	var proxies []map[string]any
 
+	seenKey := make(map[string]struct{})
 	seenEmails := make(map[string]struct{})
 	for _, inbound := range inbounds {
 		clients, err := s.inboundService.GetClients(inbound)
@@ -46,6 +47,12 @@ func (s *SubClashService) GetClash(subId string, host string) (string, string, e
 		s.SubService.projectThroughFallbackMaster(inbound)
 		for _, client := range clients {
 			if client.SubID == subId {
+				key := fmt.Sprintf("%d|%s", inbound.Id, client.Email)
+				if _, dup := seenKey[key]; dup {
+					continue
+				}
+				seenKey[key] = struct{}{}
+
 				seenEmails[client.Email] = struct{}{}
 				proxies = append(proxies, s.getProxies(inbound, client, host)...)
 			}

--- a/internal/sub/json_service.go
+++ b/internal/sub/json_service.go
@@ -72,6 +72,7 @@ func (s *SubJsonService) GetJson(subId string, host string) (string, string, err
 	var header string
 	var configArray []json_util.RawMessage
 
+	seenKey := make(map[string]struct{})
 	seenEmails := make(map[string]struct{})
 	// Prepare Inbounds
 	for _, inbound := range inbounds {
@@ -86,6 +87,12 @@ func (s *SubJsonService) GetJson(subId string, host string) (string, string, err
 
 		for _, client := range clients {
 			if client.SubID == subId {
+				key := fmt.Sprintf("%d|%s", inbound.Id, client.Email)
+				if _, dup := seenKey[key]; dup {
+					continue
+				}
+				seenKey[key] = struct{}{}
+
 				seenEmails[client.Email] = struct{}{}
 				configArray = append(configArray, s.getConfig(inbound, client, host)...)
 			}

--- a/internal/sub/service.go
+++ b/internal/sub/service.go
@@ -132,6 +132,7 @@ func (s *SubService) GetSubs(subId string, host string) ([]string, []string, int
 		s.emailInRemark = true
 	}
 
+	seenKey := make(map[string]struct{})
 	seenEmails := make(map[string]struct{})
 	for _, inbound := range inbounds {
 		clients, err := s.inboundService.GetClients(inbound)
@@ -144,6 +145,12 @@ func (s *SubService) GetSubs(subId string, host string) ([]string, []string, int
 		s.projectThroughFallbackMaster(inbound)
 		for _, client := range clients {
 			if client.SubID == subId {
+				key := fmt.Sprintf("%d|%s", inbound.Id, client.Email)
+				if _, dup := seenKey[key]; dup {
+					continue
+				}
+				seenKey[key] = struct{}{}
+
 				if client.Enable {
 					hasEnabledClient = true
 				}


### PR DESCRIPTION
Fixes #5134.

## Summary

This PR deduplicates clients by email when building subscription links, JSON, and Clash configs.

## Why

Closes #5134

When generating subscription data (\GetSubs\, \GetJson\, \GetClash\), the code iterated over the legacy \settings.clients\ array of an inbound without guarding against duplicates. If a remote node's DB (or legacy state) contained duplicate client objects for the same \subId\, the subscription builder emitted duplicate links or proxy objects. This fix explicitly deduplicates clients by their unique email per inbound before appending them to the output, ensuring clean subscriptions regardless of dirty DB state.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactoring (no behavior change)
- [ ] Documentation
- [ ] Tests only
- [ ] Build / CI / tooling
- [ ] Other

## Areas affected

- [ ] Frontend (UI / panel pages)
- [ ] Backend (API endpoints, login, settings)
- [ ] Xray config generation
- [x] Subscription (share links / Clash / JSON)
- [ ] Statistics / traffic counters
- [ ] Database / migrations
- [ ] Install / upgrade script
- [ ] Docker image
- [ ] Multi-node (sub-nodes)
- [ ] Telegram bot

## How was this tested?

1. Duplicated a client in the DB manually or setup a client that replicates dirty state in \settings.clients\.
2. Evaluated the output of \/sub/\, \/json/\ and \/clash/\ before the fix to verify duplicate subscriptions were returned.
3. Evaluated the output after applying the fix to verify that deduplication now yields only a single entry per inbound, per client email.

## Screenshots / recordings

N/A

## Breaking changes

None.

## Checklist

- [x] I tested the change locally and confirmed the described behavior.
- [ ] I added or updated tests for the new behavior (when applicable).
- [x] \go build ./...\ and the test suite pass locally.
- [ ] For frontend changes: \
pm run lint\, \
pm run typecheck\, and \
pm run build\ pass.
- [ ] I updated the Wiki / README / API docs if user-facing behavior changed.
- [x] My commits follow the project's existing message style.
- [x] I have no unrelated changes mixed into this PR.