### PR TITLE
fix: prevent traffic doubling on cloned nodes

### DIFF
--- a/internal/web/service/inbound_node.go
+++ b/internal/web/service/inbound_node.go
@@ -161,6 +161,11 @@ func (s *InboundService) setRemoteTrafficLocked(nodeID int, snap *runtime.Traffi
 	// node_id fallback downstream (#4983).
 	var nodeRow model.Node
 	db.Select("guid").Where("id = ?", nodeID).First(&nodeRow)
+
+	if nodeRow.Guid != "" && nodeRow.Guid == s.panelGuid() {
+		logger.Warningf("setRemoteTraffic: node %d has identical panelGuid to this master! Ignoring sync to prevent data corruption (cloned database detected). Do not clone the master database to a node.", nodeID)
+		return false, errors.New("node has identical panelGuid to master (cloned database detected)")
+	}
 	originGuidFor := func(snapIb *model.Inbound) string {
 		if snapIb.OriginNodeGuid != "" {
 			return snapIb.OriginNodeGuid


### PR DESCRIPTION
### What this PR does
Prevents a severe bug where migrating an inbound to a new node server completely fills users' traffic quotas and disables them on the master panel, by detecting and blocking traffic syncs from nodes running cloned databases.

### The Problem
If an administrator sets up a new node server by copying the `x-ui.db` database from the Master panel (to save setup time) and then points an existing node to this new server, the new node inherently contains the entire historical traffic for all users. 

When the master panel pulls traffic from this node via `FetchTrafficSnapshot`, the node reports `cs.Up` as the total aggregate master traffic (e.g., 500GB). The master compares this against its existing `node_client_traffics` baseline for that node (e.g., `base.Up` = 50GB). Because `cs.Up` is significantly larger than `base.Up`, the master calculates the delta (`deltaUp = 500GB - 50GB = 450GB`) and mistakenly adds it to the user's total traffic again. This effectively doubles their historical usage, instantly maxing out their volume limit and disabling them.

### The Solution
When a panel is first initialized, it generates a stable `panelGuid` stored in its `settings` table. A cloned database inherently retains the original master's `panelGuid`. 

This PR modifies `setRemoteTrafficLocked` in `internal/web/service/inbound_node.go` to check if the incoming node's `panelGuid` exactly matches the master's `panelGuid`. If they are identical, it rejects the traffic synchronization and logs a clear warning about the cloned database, entirely bypassing the traffic duplication logic without affecting legitimate node migrations or setup flows.

### How to test
1. Set up a master panel with at least one active client accumulating traffic.
2. Clone the `x-ui.db` from the master to a secondary server running the panel.
3. Add the secondary server as a Node in the master panel and assign an inbound to it.
4. Verify that the master panel logs `setRemoteTraffic: node <id> has identical panelGuid to this master! Ignoring sync to prevent data corruption (cloned database detected).` instead of syncing the duplicate traffic and maxing out the user's volume.
