### PR TITLE
fix: sync global traffic to nodes to enforce accurate client termination and UI reporting

### DIFF
--- a/internal/web/controller/inbound.go
+++ b/internal/web/controller/inbound.go
@@ -11,6 +11,7 @@ import (
 	"github.com/mhsanaei/3x-ui/v3/internal/web/service"
 	"github.com/mhsanaei/3x-ui/v3/internal/web/session"
 	"github.com/mhsanaei/3x-ui/v3/internal/web/websocket"
+	"github.com/mhsanaei/3x-ui/v3/internal/xray"
 
 	"github.com/gin-gonic/gin"
 )
@@ -77,6 +78,8 @@ func (a *InboundController) initRouter(g *gin.RouterGroup) {
 	g.POST("/resetAllTraffics", a.resetAllTraffics)
 	g.POST("/import", a.importInbound)
 	g.POST("/:id/fallbacks", a.setFallbacks)
+	g.POST("/pushClientTraffics", a.pushClientTraffics)
+	g.GET("/pushedBaselines", a.getPushedBaselines)
 }
 
 // getInbounds retrieves the list of inbounds for the logged-in user.
@@ -337,6 +340,29 @@ func (a *InboundController) resetAllTraffics(c *gin.Context) {
 		a.xrayService.SetToNeedRestart()
 	}
 	jsonMsg(c, I18nWeb(c, "pages.inbounds.toasts.resetAllTrafficSuccess"), nil)
+}
+
+func (a *InboundController) pushClientTraffics(c *gin.Context) {
+	var traffics []*xray.ClientTraffic
+	if err := c.ShouldBindJSON(&traffics); err != nil {
+		jsonMsg(c, I18nWeb(c, "somethingWentWrong"), err)
+		return
+	}
+	err := a.inboundService.AcceptGlobalTraffic(traffics)
+	if err != nil {
+		jsonMsg(c, I18nWeb(c, "somethingWentWrong"), err)
+		return
+	}
+	jsonMsg(c, "success", nil)
+}
+
+func (a *InboundController) getPushedBaselines(c *gin.Context) {
+	baselines, err := a.inboundService.GetPushedBaselines()
+	if err != nil {
+		jsonMsg(c, "error", err)
+		return
+	}
+	jsonObj(c, baselines, nil)
 }
 
 // importInbound imports an inbound configuration from provided data.

--- a/internal/web/job/node_traffic_sync_job.go
+++ b/internal/web/job/node_traffic_sync_job.go
@@ -148,6 +148,24 @@ func (j *NodeTrafficSyncJob) Run() {
 		logger.Warning("node traffic sync: get all client traffics for websocket failed:", err)
 	} else if len(stats) > 0 {
 		clientStats["clients"] = stats
+
+		for _, n := range nodes {
+			if !n.Enable || n.Status != "online" {
+				continue
+			}
+			rt, err := mgr.RemoteFor(n)
+			if err == nil {
+				go func(node *model.Node, remote runtime.Runtime) {
+					ctx, cancel := context.WithTimeout(context.Background(), nodeTrafficSyncRequestTimeout)
+					defer cancel()
+					if r, ok := remote.(*runtime.Remote); ok {
+						if err := r.PushAllClientTraffics(ctx, stats); err != nil {
+							logger.Warning("push global traffic to", node.Name, "failed:", err)
+						}
+					}
+				}(n, rt)
+			}
+		}
 	}
 	if summary, err := j.inboundService.GetInboundsTrafficSummary(); err != nil {
 		logger.Warning("node traffic sync: get inbounds summary for websocket failed:", err)

--- a/internal/web/runtime/remote.go
+++ b/internal/web/runtime/remote.go
@@ -18,6 +18,7 @@ import (
 	"github.com/mhsanaei/3x-ui/v3/internal/database/model"
 	"github.com/mhsanaei/3x-ui/v3/internal/logger"
 	"github.com/mhsanaei/3x-ui/v3/internal/util/netsafe"
+	"github.com/mhsanaei/3x-ui/v3/internal/xray"
 )
 
 const remoteHTTPTimeout = 10 * time.Second
@@ -404,6 +405,11 @@ func (r *Remote) ResetInboundTraffic(ctx context.Context, ib *model.Inbound) err
 	return err
 }
 
+type NodeTrafficCounter struct {
+	Up   int64 `json:"up"`
+	Down int64 `json:"down"`
+}
+
 type TrafficSnapshot struct {
 	Inbounds     []*model.Inbound
 	OnlineEmails []string
@@ -414,6 +420,7 @@ type TrafficSnapshot struct {
 	// the per-GUID endpoint — OnlineEmails is the fallback then.
 	OnlineTree    map[string][]string
 	LastOnlineMap map[string]int64
+	PushedBaselines map[string]NodeTrafficCounter `json:"pushedBaselines"`
 }
 
 func (r *Remote) FetchTrafficSnapshot(ctx context.Context) (*TrafficSnapshot, error) {
@@ -449,7 +456,17 @@ func (r *Remote) FetchTrafficSnapshot(ctx context.Context) (*TrafficSnapshot, er
 		_ = json.Unmarshal(envLastOnline.Obj, &snap.LastOnlineMap)
 	}
 
+	envPushed, err := r.do(ctx, http.MethodGet, "panel/api/inbounds/pushedBaselines", nil)
+	if err == nil && len(envPushed.Obj) > 0 {
+		_ = json.Unmarshal(envPushed.Obj, &snap.PushedBaselines)
+	}
+
 	return snap, nil
+}
+
+func (r *Remote) PushAllClientTraffics(ctx context.Context, traffics []*xray.ClientTraffic) error {
+	_, err := r.do(ctx, http.MethodPost, "panel/api/inbounds/pushClientTraffics", traffics)
+	return err
 }
 
 func wireInbound(ib *model.Inbound) url.Values {

--- a/internal/web/service/inbound_node.go
+++ b/internal/web/service/inbound_node.go
@@ -124,10 +124,7 @@ const resetGracePeriodMs int64 = 30000
 // long after a real disconnect.
 const onlineGracePeriodMs int64 = 20000
 
-type nodeTrafficCounter struct {
-	Up   int64
-	Down int64
-}
+
 
 func (s *InboundService) upsertNodeBaseline(tx *gorm.DB, nodeID int, email string, up, down int64) error {
 	return tx.Clauses(clause.OnConflict{
@@ -213,7 +210,7 @@ func (s *InboundService) setRemoteTrafficLocked(nodeID int, snap *runtime.Traffi
 		centralCSByEmail[centralClientStats[i].Email] = &centralClientStats[i]
 	}
 
-	nodeBaselines := make(map[string]nodeTrafficCounter)
+	nodeBaselines := make(map[string]runtime.NodeTrafficCounter)
 	var baselineRows []model.NodeClientTraffic
 	if err := db.Model(&model.NodeClientTraffic{}).
 		Where("node_id = ?", nodeID).
@@ -221,7 +218,7 @@ func (s *InboundService) setRemoteTrafficLocked(nodeID int, snap *runtime.Traffi
 		return false, err
 	}
 	for i := range baselineRows {
-		nodeBaselines[baselineRows[i].Email] = nodeTrafficCounter{Up: baselineRows[i].Up, Down: baselineRows[i].Down}
+		nodeBaselines[baselineRows[i].Email] = runtime.NodeTrafficCounter{Up: baselineRows[i].Up, Down: baselineRows[i].Down}
 	}
 
 	var existingEmailsList []string
@@ -440,8 +437,20 @@ func (s *InboundService) setRemoteTrafficLocked(nodeID int, snap *runtime.Traffi
 			snapEmails[cs.Email] = struct{}{}
 
 			base, seen := nodeBaselines[cs.Email]
+
+			if snap.PushedBaselines != nil {
+				if pushed, ok := snap.PushedBaselines[cs.Email]; ok {
+					if pushed.Up > base.Up {
+						base.Up = pushed.Up
+					}
+					if pushed.Down > base.Down {
+						base.Down = pushed.Down
+					}
+				}
+			}
+
 			var deltaUp, deltaDown int64
-			if seen {
+			if seen || snap.PushedBaselines != nil {
 				if deltaUp = cs.Up - base.Up; deltaUp < 0 {
 					deltaUp = cs.Up
 				}
@@ -476,7 +485,7 @@ func (s *InboundService) setRemoteTrafficLocked(nodeID int, snap *runtime.Traffi
 				if err := s.upsertNodeBaseline(tx, nodeID, cs.Email, cs.Up, cs.Down); err != nil {
 					return false, err
 				}
-				nodeBaselines[cs.Email] = nodeTrafficCounter{Up: cs.Up, Down: cs.Down}
+				nodeBaselines[cs.Email] = runtime.NodeTrafficCounter{Up: cs.Up, Down: cs.Down}
 				continue
 			}
 
@@ -506,7 +515,7 @@ func (s *InboundService) setRemoteTrafficLocked(nodeID int, snap *runtime.Traffi
 			if err := s.upsertNodeBaseline(tx, nodeID, cs.Email, cs.Up, cs.Down); err != nil {
 				return false, err
 			}
-			nodeBaselines[cs.Email] = nodeTrafficCounter{Up: cs.Up, Down: cs.Down}
+			nodeBaselines[cs.Email] = runtime.NodeTrafficCounter{Up: cs.Up, Down: cs.Down}
 		}
 
 		for k, existing := range centralCS {

--- a/internal/web/service/inbound_traffic_global.go
+++ b/internal/web/service/inbound_traffic_global.go
@@ -1,0 +1,60 @@
+package service
+
+import (
+	"github.com/mhsanaei/3x-ui/v3/internal/database"
+	"github.com/mhsanaei/3x-ui/v3/internal/database/model"
+	"github.com/mhsanaei/3x-ui/v3/internal/xray"
+	"github.com/mhsanaei/3x-ui/v3/internal/web/runtime"
+	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
+)
+
+func (s *InboundService) AcceptGlobalTraffic(traffics []*xray.ClientTraffic) error {
+	db := database.GetDB()
+	return submitTrafficWrite(func() error {
+		tx := db.Begin()
+		defer func() {
+			if r := recover(); r != nil {
+				tx.Rollback()
+			}
+		}()
+
+		for _, t := range traffics {
+			if t == nil || t.Email == "" {
+				continue
+			}
+
+			if err := tx.Model(xray.ClientTraffic{}).Where("email = ?", t.Email).
+				Updates(map[string]any{
+					"up":   gorm.Expr(database.GreatestExpr("up", "?"), t.Up),
+					"down": gorm.Expr(database.GreatestExpr("down", "?"), t.Down),
+				}).Error; err != nil {
+				tx.Rollback()
+				return err
+			}
+
+			err := tx.Clauses(clause.OnConflict{
+				Columns:   []clause.Column{{Name: "node_id"}, {Name: "email"}},
+				DoUpdates: clause.AssignmentColumns([]string{"up", "down"}),
+			}).Create(&model.NodeClientTraffic{NodeId: 0, Email: t.Email, Up: t.Up, Down: t.Down}).Error
+			if err != nil {
+				tx.Rollback()
+				return err
+			}
+		}
+		return tx.Commit().Error
+	})
+}
+
+func (s *InboundService) GetPushedBaselines() (map[string]runtime.NodeTrafficCounter, error) {
+	db := database.GetDB()
+	var rows []model.NodeClientTraffic
+	if err := db.Where("node_id = ?", 0).Find(&rows).Error; err != nil {
+		return nil, err
+	}
+	res := make(map[string]runtime.NodeTrafficCounter, len(rows))
+	for _, r := range rows {
+		res[r.Email] = runtime.NodeTrafficCounter{Up: r.Up, Down: r.Down}
+	}
+	return res, nil
+}


### PR DESCRIPTION
**The Issue:**
Currently, remote nodes only track local client traffic. If a client is attached to multiple nodes, their global traffic may exceed their limit (e.g. 5GB total, but only 2GB on Node A). The Master correctly disables the user and sends a config update (\enable=false\) to the node. However, Xray's hot-reload does not kill existing connections. Because the node's local traffic (\2GB\) is less than the limit (\5GB\), the node's \XrayTrafficJob\ never triggers a local \RestartXray()\. This allows the user to stay connected and use hundreds of GBs unchecked. Additionally, the Node's UI inaccurately shows only local usage instead of global usage.

**The Solution:**
This PR introduces bidirectional traffic syncing.
1. Added \PushAllClientTraffics\ to broadcast the Master's global traffic aggregations back to all active nodes during the \NodeTrafficSyncJob\.
2. Added \AcceptGlobalTraffic\ on the node to ingest this data and update the node's local \client_traffics\ so the Node UI reflects the true global usage.
3. Node acknowledges the pushed traffic using the \PushedBaselines\ map in \TrafficSnapshot\. The Master uses this to adjust its delta baselines, preventing double-counting.
4. Because the node now has the global usage, the node's local \XrayTrafficJob\ correctly detects when a user depletes their global allowance and correctly forces a local \RestartXray(true)\ to disconnect the user immediately.