### PR TITLE
fix(inbound): preserve custom share strategy on edit

### DIFF
--- a/frontend/src/pages/inbounds/form/InboundFormModal.tsx
+++ b/frontend/src/pages/inbounds/form/InboundFormModal.tsx
@@ -381,7 +381,8 @@ export default function InboundFormModal({
   // protocol reset drops a nodeId that no longer applies.
   useEffect(() => {
     if (!open) return;
-    if (!nodeShareOptionAvailable && shareAddrStrategy === 'node') {
+    const current = form.getFieldValue('shareAddrStrategy') as InboundFormValues['shareAddrStrategy'] | undefined;
+    if (!nodeShareOptionAvailable && (current ?? 'node') === 'node') {
       form.setFieldValue('shareAddrStrategy', 'listen');
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/frontend/src/test/inbound-form-modal.test.tsx
+++ b/frontend/src/test/inbound-form-modal.test.tsx
@@ -1,6 +1,8 @@
 import { describe, it, expect } from 'vitest';
+import { screen } from '@testing-library/react';
 
 import InboundFormModal from '@/pages/inbounds/form/InboundFormModal';
+import { DBInbound } from '@/models/dbinbound';
 import {
   renderWithProviders,
   fieldLabels,
@@ -37,5 +39,40 @@ describe('InboundFormModal', () => {
       chooseSelectOption('protocol', proto);
       expect(fieldLabels()).toMatchSnapshot(proto);
     }
+  });
+
+  it('preserves custom share address strategy when editing a local inbound', async () => {
+    renderWithProviders(
+      <InboundFormModal
+        open
+        mode="edit"
+        dbInbound={new DBInbound({
+          id: 1,
+          port: 12345,
+          listen: '',
+          protocol: 'shadowsocks',
+          remark: 'edge',
+          enable: true,
+          settings: {
+            method: '2022-blake3-aes-128-gcm',
+            password: 'server-password',
+            network: 'tcp,udp',
+            clients: [],
+          },
+          streamSettings: { network: 'tcp', security: 'none', tcpSettings: {} },
+          sniffing: { enabled: false },
+          nodeId: null,
+          shareAddrStrategy: 'custom',
+          shareAddr: 'edge.example.test',
+        })}
+        dbInbounds={[]}
+        availableNodes={[]}
+        onClose={() => {}}
+        onSaved={() => {}}
+      />,
+    );
+
+    const shareAddrInput = await screen.findByDisplayValue('edge.example.test');
+    expect((shareAddrInput as HTMLInputElement).value).toBe('edge.example.test');
   });
 });


### PR DESCRIPTION
## Summary

Preserve an inbound's saved custom share address strategy when reopening the edit form for a local inbound where the node share option is unavailable.

## Why

Fixes #5224.

The edit modal initialized the saved inbound values, but a later effect used a stale watched `shareAddrStrategy` value from the previous render. For local inbounds without an available node share option, that stale default could overwrite a saved `custom` strategy with `listen`, so saving the form would lose the custom share address selection.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactoring (no behavior change)
- [ ] Documentation
- [ ] Tests only
- [ ] Build / CI / tooling
- [ ] Other

## Areas affected

- [x] Frontend (UI / panel pages)
- [ ] Backend (API endpoints, login, settings)
- [ ] Xray config generation
- [ ] Subscription (share links / Clash / JSON)
- [ ] Statistics / traffic counters
- [ ] Database / migrations
- [ ] Install / upgrade script
- [ ] Docker image
- [x] Multi-node (sub-nodes)
- [ ] Telegram bot

## How was this tested?

Added a regression test for editing a local inbound with `shareAddrStrategy: "custom"` and `shareAddr: "edge.example.test"`; before the form-state fix, the custom share address field was not rendered because the strategy was overwritten to `listen`.

Validated locally with:

- `cd frontend && npm run test -- src/test/inbound-form-modal.test.tsx src/test/inbound-link.test.ts src/test/inbound-form-adapter.test.ts`
- `cd frontend && npm run test`
- `cd frontend && npm run typecheck`
- `cd frontend && npm run lint`
- `cd frontend && npm run build`
- `go build ./...`
- `go test ./...`
- `git diff --check origin/main...HEAD`

A real multi-node panel deployment was not run; this change is covered by a focused form-state regression test plus the existing link/form adapter suites.

## Screenshots / recordings

N/A. This fixes form state preservation without changing the visual layout.

## Breaking changes

None.

## Checklist

- [x] I tested the change locally and confirmed the described behavior.
- [x] I added or updated tests for the new behavior (when applicable).
- [x] `go build ./...` and the test suite pass locally.
- [x] For frontend changes: `npm run lint`, `npm run typecheck`, and `npm run build` pass.
- [ ] I updated the Wiki / README / API docs if user-facing behavior changed.
- [x] My commits follow the project's existing message style.
- [x] I have no unrelated changes mixed into this PR.