### PR TITLE
perf(db): index group_name and client_traffics hot columns

### DIFF
--- a/internal/database/index_tags_test.go
+++ b/internal/database/index_tags_test.go
@@ -1,0 +1,41 @@
+package database
+
+import (
+	"testing"
+
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+	"gorm.io/gorm/logger"
+
+	"github.com/mhsanaei/3x-ui/v3/internal/database/model"
+	"github.com/mhsanaei/3x-ui/v3/internal/xray"
+)
+
+// AutoMigrate must create the hot-path indexes added for client group filters
+// and client_traffics inbound/last_online lookups. gorm creates missing indexes
+// on migrate, so this also protects existing DBs after upgrade.
+func TestAutoMigrateCreatesHotPathIndexes(t *testing.T) {
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{
+		Logger: logger.Default.LogMode(logger.Silent),
+	})
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	if err := db.AutoMigrate(&model.ClientRecord{}, &xray.ClientTraffic{}); err != nil {
+		t.Fatalf("automigrate: %v", err)
+	}
+
+	cases := []struct {
+		model any
+		index string
+	}{
+		{&model.ClientRecord{}, "idx_client_record_group"},
+		{&xray.ClientTraffic{}, "idx_client_traffics_inbound"},
+		{&xray.ClientTraffic{}, "idx_client_traffics_last_online"},
+	}
+	for _, c := range cases {
+		if !db.Migrator().HasIndex(c.model, c.index) {
+			t.Errorf("expected index %q to exist after AutoMigrate", c.index)
+		}
+	}
+}

--- a/internal/database/model/model.go
+++ b/internal/database/model/model.go
@@ -571,7 +571,7 @@ type ClientRecord struct {
 	ExpiryTime int64  `json:"expiryTime" gorm:"column:expiry_time"`
 	Enable     bool   `json:"enable" gorm:"default:true"`
 	TgID       int64  `json:"tgId" gorm:"column:tg_id"`
-	Group      string `json:"group" gorm:"column:group_name;default:''"`
+	Group      string `json:"group" gorm:"column:group_name;default:'';index:idx_client_record_group"`
 	Comment    string `json:"comment"`
 	Reset      int    `json:"reset" gorm:"default:0"`
 	CreatedAt  int64  `json:"createdAt" gorm:"autoCreateTime:milli"`

--- a/internal/xray/client_traffic.go
+++ b/internal/xray/client_traffic.go
@@ -4,7 +4,7 @@ package xray
 // It tracks upload/download usage, expiry times, and online status for inbound clients.
 type ClientTraffic struct {
 	Id         int    `json:"id" form:"id" gorm:"primaryKey;autoIncrement" example:"14825"`
-	InboundId  int    `json:"inboundId" form:"inboundId" example:"1"`
+	InboundId  int    `json:"inboundId" form:"inboundId" gorm:"index:idx_client_traffics_inbound" example:"1"`
 	Enable     bool   `json:"enable" form:"enable" example:"true"`
 	Email      string `json:"email" form:"email" gorm:"unique" example:"user1"`
 	UUID       string `json:"uuid" form:"uuid" gorm:"-" example:"e18c9a96-71bf-48d4-933f-8b9a46d4290c"`
@@ -14,5 +14,5 @@ type ClientTraffic struct {
 	ExpiryTime int64  `json:"expiryTime" form:"expiryTime" example:"1735689600000"`
 	Total      int64  `json:"total" form:"total" example:"10737418240"`
 	Reset      int    `json:"reset" form:"reset" gorm:"default:0" example:"0"`
-	LastOnline int64  `json:"lastOnline" form:"lastOnline" gorm:"default:0" example:"1735680000000"`
+	LastOnline int64  `json:"lastOnline" form:"lastOnline" gorm:"default:0;index:idx_client_traffics_last_online" example:"1735680000000"`
 }


### PR DESCRIPTION
## Summary

This PR adds the missing hot-path database indexes for:

- `client_records.group_name`
- `client_traffics.inbound_id`
- `client_traffics.last_online`

These columns are used frequently in filtering, grouping, and traffic-related reads, but were not indexed.

## Why

On larger datasets, these lookups become unnecessarily expensive and increase query latency for common panel operations.

This change keeps the schema behavior the same while improving read performance on existing and future databases.

## Scope

- adds index tags for the three hot columns
- relies on the existing migration / AutoMigrate flow
- no behavioral change

## Validation

- added/updated tests to assert the indexes exist after migration
- validated with database tests

## Risk

Low. This is a schema/index improvement only and does not change application logic.
