### PR TITLE
feat(web): cap request body size on state-changing routes

### DIFF
--- a/internal/web/middleware/bodylimit.go
+++ b/internal/web/middleware/bodylimit.go
@@ -1,0 +1,30 @@
+package middleware
+
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+)
+
+// MaxBodyBytes caps the request body size for state-changing requests. It wraps
+// the body in an http.MaxBytesReader so that any handler reading it (gin's
+// ShouldBind, manual io.ReadAll, etc.) receives an error once the limit is
+// exceeded, which the existing bind-failure path reports as a 400 rather than
+// allocating an unbounded buffer or starting a long DB transaction.
+//
+// Methods without a body (GET/HEAD/OPTIONS/TRACE) and a non-positive limit are
+// passed through untouched.
+func MaxBodyBytes(limit int64) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		if limit > 0 {
+			switch c.Request.Method {
+			case http.MethodGet, http.MethodHead, http.MethodOptions, http.MethodTrace:
+			default:
+				if c.Request.Body != nil {
+					c.Request.Body = http.MaxBytesReader(c.Writer, c.Request.Body, limit)
+				}
+			}
+		}
+		c.Next()
+	}
+}

--- a/internal/web/middleware/bodylimit_test.go
+++ b/internal/web/middleware/bodylimit_test.go
@@ -1,0 +1,49 @@
+package middleware
+
+import (
+	"bytes"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+)
+
+func TestMaxBodyBytes(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	const limit = 16
+
+	r := gin.New()
+	r.Use(MaxBodyBytes(limit))
+	r.POST("/x", func(c *gin.Context) {
+		if _, err := io.ReadAll(c.Request.Body); err != nil {
+			c.String(http.StatusRequestEntityTooLarge, "too big")
+			return
+		}
+		c.String(http.StatusOK, "ok")
+	})
+	r.GET("/x", func(c *gin.Context) { c.String(http.StatusOK, "ok") })
+
+	// Body within the limit is read normally.
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest(http.MethodPost, "/x", strings.NewReader("0123456789")))
+	if w.Code != http.StatusOK {
+		t.Errorf("under-limit POST: got %d, want 200", w.Code)
+	}
+
+	// Body over the limit makes the handler's read fail (no unbounded buffer).
+	w = httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest(http.MethodPost, "/x", bytes.NewReader(make([]byte, limit*4))))
+	if w.Code == http.StatusOK {
+		t.Errorf("over-limit POST should not succeed, got 200")
+	}
+
+	// Bodyless methods pass through untouched.
+	w = httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/x", nil))
+	if w.Code != http.StatusOK {
+		t.Errorf("GET should pass through, got %d", w.Code)
+	}
+}

--- a/internal/web/web.go
+++ b/internal/web/web.go
@@ -153,6 +153,13 @@ func (s *Server) initRouter() (*gin.Engine, error) {
 	sendHSTS := directHTTPS && !config.IsSkipHSTS()
 	engine.Use(middleware.SecurityHeadersMiddleware(sendHSTS))
 
+	// Cap request bodies on state-changing requests so a stolen session/API
+	// token or a buggy client can't force large allocations or long DB
+	// transactions via bulk create/attach/import endpoints. GET/HEAD/OPTIONS
+	// carry no body and are left untouched. Follow-up: make the limit a setting.
+	const maxRequestBodyBytes = 10 << 20 // 10 MiB
+	engine.Use(middleware.MaxBodyBytes(maxRequestBodyBytes))
+
 	webDomain, err := s.settingService.GetWebDomain()
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
## Summary

This PR adds a request body size limit for state-changing routes.

It uses `http.MaxBytesReader` to reject oversized request bodies before they cause unnecessary memory allocation or long processing on mutation endpoints.

## Why

Even with authentication in place, large request bodies on create/update/import-style routes are an avoidable resource risk. A reasonable cap improves resilience against buggy clients and accidental oversized submissions.

## Scope

- adds body-size limiting middleware
- applies it to state-changing requests
- does not affect normal read-only requests

## Validation

- added tests for:
  - under-limit request bodies
  - over-limit request bodies
  - routes without request bodies

## Risk

Low. This is defensive hardening and does not alter normal successful request flows.
