### PR TITLE
fix(runtime): honor per-node TLS verify and pin mode in node sync

### DIFF
--- a/internal/web/runtime/remote.go
+++ b/internal/web/runtime/remote.go
@@ -3,6 +3,11 @@ package runtime
 import (
 	"bytes"
 	"context"
+	"crypto/sha256"
+	"crypto/subtle"
+	"crypto/tls"
+	"encoding/base64"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -39,7 +44,8 @@ type envelope struct {
 }
 
 type Remote struct {
-	node *model.Node
+	node   *model.Node
+	client *http.Client
 
 	mu            sync.RWMutex
 	remoteIDByTag map[string]int
@@ -55,8 +61,75 @@ type RemoteInboundOption struct {
 func NewRemote(n *model.Node) *Remote {
 	return &Remote{
 		node:          n,
+		client:        tlsClientForNode(n),
 		remoteIDByTag: make(map[string]int),
 	}
+}
+
+// tlsClientForNode mirrors web/service.nodeHTTPClientFor so that runtime node
+// sync honors the same per-node TLS trust model as the management UI: "verify"
+// (or any http node) uses the shared SSRF-guarded client with default chain
+// validation; "skip" disables validation; "pin" disables the default chain
+// check but verifies the leaf certificate SHA-256 against the stored pin. A
+// malformed pin falls back to the default verifying client (fail safe, never
+// silently skip) and is logged.
+//
+// NOTE (follow-up): de-duplicate by extracting a shared model.Node TLS config
+// helper used by both web/service and web/runtime.
+func tlsClientForNode(n *model.Node) *http.Client {
+	mode := n.TlsVerifyMode
+	if mode == "" {
+		mode = "verify"
+	}
+	if mode == "verify" || n.Scheme == "http" {
+		return remoteHTTPClient
+	}
+	tlsCfg := &tls.Config{InsecureSkipVerify: true} // lgtm[go/disabled-certificate-check]
+	if mode == "pin" {
+		want, err := decodeCertPin(n.PinnedCertSha256)
+		if err != nil {
+			logger.Warningf("node %s has TlsVerifyMode=pin but an invalid pin (%v); falling back to default certificate verification", n.Name, err)
+			return remoteHTTPClient
+		}
+		tlsCfg.VerifyConnection = func(cs tls.ConnectionState) error {
+			if len(cs.PeerCertificates) == 0 {
+				return errors.New("node presented no certificate")
+			}
+			sum := sha256.Sum256(cs.PeerCertificates[0].Raw)
+			if subtle.ConstantTimeCompare(sum[:], want) != 1 {
+				return errors.New("node certificate does not match pinned SHA-256")
+			}
+			return nil
+		}
+	}
+	return &http.Client{
+		Transport: &http.Transport{
+			MaxIdleConns:        64,
+			MaxIdleConnsPerHost: 4,
+			IdleConnTimeout:     60 * time.Second,
+			DialContext:         netsafe.SSRFGuardedDialContext,
+			TLSClientConfig:     tlsCfg,
+		},
+	}
+}
+
+// decodeCertPin accepts a SHA-256 certificate hash as base64 (Xray's
+// pinnedPeerCertSha256 format) or hex with optional colons and returns the raw
+// 32 bytes.
+func decodeCertPin(s string) ([]byte, error) {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return nil, errors.New("certificate pin is empty")
+	}
+	if b, err := hex.DecodeString(strings.ReplaceAll(s, ":", "")); err == nil && len(b) == sha256.Size {
+		return b, nil
+	}
+	for _, enc := range []*base64.Encoding{base64.StdEncoding, base64.RawStdEncoding, base64.URLEncoding, base64.RawURLEncoding} {
+		if b, err := enc.DecodeString(s); err == nil && len(b) == sha256.Size {
+			return b, nil
+		}
+	}
+	return nil, errors.New("certificate pin must be a SHA-256 hash (base64 or hex)")
 }
 
 func (r *Remote) Name() string { return "node:" + r.node.Name }
@@ -129,7 +202,7 @@ func (r *Remote) do(ctx context.Context, method, path string, body any) (*envelo
 		req.Header.Set("Content-Type", contentType)
 	}
 
-	resp, err := remoteHTTPClient.Do(req)
+	resp, err := r.client.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("%s %s: %w", method, path, err)
 	}

--- a/internal/web/runtime/remote_tlspin_test.go
+++ b/internal/web/runtime/remote_tlspin_test.go
@@ -1,0 +1,157 @@
+package runtime
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/sha256"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/base64"
+	"math/big"
+	"net/http"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/mhsanaei/3x-ui/v3/internal/database/model"
+	xuilogger "github.com/mhsanaei/3x-ui/v3/internal/logger"
+	"github.com/op/go-logging"
+)
+
+// tlsClientForNode logs a warning on the bad-pin fail-safe path, which panics if
+// the global logger backend is nil. Initialize it once for the package's tests.
+func TestMain(m *testing.M) {
+	xuilogger.InitLogger(logging.ERROR)
+	os.Exit(m.Run())
+}
+
+func selfSignedLeaf(t *testing.T) *x509.Certificate {
+	t.Helper()
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("genkey: %v", err)
+	}
+	tmpl := &x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject:      pkix.Name{CommonName: "node.test"},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(time.Hour),
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
+	if err != nil {
+		t.Fatalf("createcert: %v", err)
+	}
+	cert, err := x509.ParseCertificate(der)
+	if err != nil {
+		t.Fatalf("parsecert: %v", err)
+	}
+	return cert
+}
+
+func tlsConfigOf(t *testing.T, c *http.Client) *tls.Config {
+	t.Helper()
+	tr, ok := c.Transport.(*http.Transport)
+	if !ok {
+		t.Fatalf("transport is not *http.Transport")
+	}
+	return tr.TLSClientConfig
+}
+
+// "verify" mode and http nodes must reuse the shared SSRF-guarded client with
+// default certificate validation (no custom TLS config).
+func TestTLSClientForNode_VerifyAndHTTPReuseShared(t *testing.T) {
+	if got := tlsClientForNode(&model.Node{Name: "v", Scheme: "https", TlsVerifyMode: "verify"}); got != remoteHTTPClient {
+		t.Errorf("verify mode should reuse the shared client")
+	}
+	if got := tlsClientForNode(&model.Node{Name: "h", Scheme: "http", TlsVerifyMode: "pin"}); got != remoteHTTPClient {
+		t.Errorf("http node should reuse the shared client regardless of mode")
+	}
+	if got := tlsClientForNode(&model.Node{Name: "d", Scheme: "https"}); got != remoteHTTPClient {
+		t.Errorf("empty mode defaults to verify -> shared client")
+	}
+}
+
+// "skip" mode must disable verification on a dedicated client.
+func TestTLSClientForNode_Skip(t *testing.T) {
+	c := tlsClientForNode(&model.Node{Name: "s", Scheme: "https", TlsVerifyMode: "skip"})
+	if c == remoteHTTPClient {
+		t.Fatalf("skip mode must not reuse the shared verifying client")
+	}
+	cfg := tlsConfigOf(t, c)
+	if cfg == nil || !cfg.InsecureSkipVerify {
+		t.Errorf("skip mode must set InsecureSkipVerify=true")
+	}
+	if cfg.VerifyConnection != nil {
+		t.Errorf("skip mode must not set a pin VerifyConnection")
+	}
+}
+
+// "pin" mode must accept the matching leaf and reject a different cert, while
+// still bypassing the default chain (InsecureSkipVerify).
+func TestTLSClientForNode_PinAcceptsAndRejects(t *testing.T) {
+	leaf := selfSignedLeaf(t)
+	sum := sha256.Sum256(leaf.Raw)
+	pin := base64.StdEncoding.EncodeToString(sum[:])
+
+	c := tlsClientForNode(&model.Node{Name: "p", Scheme: "https", TlsVerifyMode: "pin", PinnedCertSha256: pin})
+	cfg := tlsConfigOf(t, c)
+	if cfg == nil || !cfg.InsecureSkipVerify || cfg.VerifyConnection == nil {
+		t.Fatalf("pin mode must skip default chain and set VerifyConnection")
+	}
+	if err := cfg.VerifyConnection(tls.ConnectionState{PeerCertificates: []*x509.Certificate{leaf}}); err != nil {
+		t.Errorf("pin should accept the matching leaf: %v", err)
+	}
+	other := selfSignedLeaf(t)
+	if err := cfg.VerifyConnection(tls.ConnectionState{PeerCertificates: []*x509.Certificate{other}}); err == nil {
+		t.Errorf("pin must reject a non-matching leaf")
+	}
+	if err := cfg.VerifyConnection(tls.ConnectionState{}); err == nil {
+		t.Errorf("pin must reject an empty certificate chain")
+	}
+}
+
+// A malformed pin must fail safe to the default verifying client, never to skip.
+func TestTLSClientForNode_BadPinFailsSafe(t *testing.T) {
+	c := tlsClientForNode(&model.Node{Name: "bad", Scheme: "https", TlsVerifyMode: "pin", PinnedCertSha256: "not-a-real-hash"})
+	if c != remoteHTTPClient {
+		t.Errorf("invalid pin must fall back to the shared verifying client, not skip")
+	}
+}
+
+func TestDecodeCertPin_HexAndBase64(t *testing.T) {
+	raw := sha256.Sum256([]byte("x"))
+	for _, s := range []string{
+		base64.StdEncoding.EncodeToString(raw[:]),
+		base64.RawStdEncoding.EncodeToString(raw[:]),
+		hexColons(raw[:]),
+	} {
+		got, err := decodeCertPin(s)
+		if err != nil {
+			t.Errorf("decode %q: %v", s, err)
+			continue
+		}
+		if string(got) != string(raw[:]) {
+			t.Errorf("decode %q: wrong bytes", s)
+		}
+	}
+	if _, err := decodeCertPin("zzzz"); err == nil {
+		t.Errorf("garbage pin must error")
+	}
+	if _, err := decodeCertPin(""); err == nil {
+		t.Errorf("empty pin must error")
+	}
+}
+
+func hexColons(b []byte) string {
+	const hexdig = "0123456789abcdef"
+	out := make([]byte, 0, len(b)*3)
+	for i, c := range b {
+		if i > 0 {
+			out = append(out, ':')
+		}
+		out = append(out, hexdig[c>>4], hexdig[c&0x0f])
+	}
+	return string(out)
+}


### PR DESCRIPTION
## Summary

This PR makes node-sync runtime HTTP calls honor the same per-node TLS verification / pinning settings already respected in the management path.

## Why

Node sync is a high-trust Bearer-token path. If node management supports verification / skip / pin modes, runtime synchronization should use the same trust model instead of silently falling back to a different one.

## Scope

- aligns runtime remote HTTP client behavior with node TLS settings
- keeps the existing SSRF-safe dialing behavior
- preserves fail-safe behavior when pin parsing is invalid

## Validation

- added tests for:
  - normal verification
  - insecure/skip mode
  - certificate pin success/failure
  - malformed pin fallback behavior

## Risk

Low to medium. This improves security on node-to-node communication but touches remote runtime behavior, so it is test-backed and intentionally scoped.
