### PR TITLE
fix(ui): center align the blinking online dot inside Tag components

### DIFF
--- a/frontend/src/pages/clients/ClientsPage.tsx
+++ b/frontend/src/pages/clients/ClientsPage.tsx
@@ -649,7 +649,7 @@ export default function ClientsPage() {
           </Tooltip>
         );
         if (record.enable && isOnline(record.email)) return (
-          <Tag color="green"><span className="online-dot" />{t('pages.clients.online')}</Tag>
+          <Tag color="green" style={{ display: 'inline-flex', alignItems: 'center', gap: '4px'}}><span className="online-dot" />{t('pages.clients.online')}</Tag>
         );
         if (!record.enable) return <Tag>{t('disabled')}</Tag>;
         if (bucket === 'expiring') return <Tag color="orange">{t('depletingSoon')}</Tag>;


### PR DESCRIPTION
## Summary

Swapped the Tag container layout to inline-flex to correct a slight vertical layout offset of the .online-dot on the Clients page.


<!-- What does this PR do? One or two sentences. -->

## Why

Closes #5238 

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactoring (no behavior change)
- [ ] Documentation
- [ ] Tests only
- [ ] Build / CI / tooling
- [ ] Other

## Areas affected

- [x] Frontend (UI / panel pages)
- [ ] Backend (API endpoints, login, settings)
- [ ] Xray config generation
- [ ] Subscription (share links / Clash / JSON)
- [ ] Statistics / traffic counters
- [ ] Database / migrations
- [ ] Install / upgrade script
- [ ] Docker image
- [ ] Multi-node (sub-nodes)
- [ ] Telegram bot

## How was this tested?

1. Set a client to an active/online state.
2. Navigate to the **Clients**  page.
3. Observe that the blinking green dot is now mathematically centered with the adjacent "Online" text string.

## Screenshots / recordings

<img width="244" height="87" alt="Screenshot from 2026-06-13 12-17-33" src="https://github.com/user-attachments/assets/83c43fa1-13b6-42df-a744-26bce27cd7f3" />

<!-- Required for UI changes. Drag images or GIFs here. Remove if N/A. -->

## Breaking changes

"None"

## Checklist

- [x] I tested the change locally and confirmed the described behavior.
- [ ] I added or updated tests for the new behavior (when applicable).
- [ ] `go build ./...` and the test suite pass locally.
- [x] For frontend changes: `npm run lint`, `npm run typecheck`, and `npm run build` pass.
- [ ] I updated the Wiki / README / API docs if user-facing behavior changed.
- [x] My commits follow the project's existing message style.
- [x] I have no unrelated changes mixed into this PR.
