### PR TITLE
fix(reality): load `dest` as `target` alias so existing inbounds aren't wiped

### DIFF
--- a/frontend/src/schemas/protocols/security/reality.ts
+++ b/frontend/src/schemas/protocols/security/reality.ts
@@ -14,28 +14,51 @@ export const RealityClientSettingsSchema = z.object({
 });
 export type RealityClientSettings = z.infer<typeof RealityClientSettingsSchema>;
 
+// xray-core accepts both `target` and `dest` as the REALITY destination —
+// they are aliases (infra/conf/transport_internet.go: REALITYConfig has
+// `json:"target"` and `json:"dest"`). The panel writes `target`, but configs
+// produced by older panel builds, external tools, or the panel's own
+// `/panel/api/inbounds` API commonly use `dest`. Map `dest` -> `target` on
+// parse when `target` is absent/empty: otherwise such an inbound loads with
+// an empty (required) Target field even though it runs fine, and re-saving
+// it serializes the blank `target` and drops the working `dest` — silently
+// breaking REALITY on the next xray restart.
+const aliasRealityDest = (value: unknown): unknown => {
+  if (value && typeof value === 'object' && !Array.isArray(value)) {
+    const obj = value as Record<string, unknown>;
+    const hasTarget = typeof obj.target === 'string' && obj.target !== '';
+    if (!hasTarget && typeof obj.dest === 'string' && obj.dest !== '') {
+      return { ...obj, target: obj.dest };
+    }
+  }
+  return value;
+};
+
 // Reality stream payload. `serverNames` and `shortIds` are stored as
 // comma-joined strings in the panel class but ship as string[] on the wire
 // — fixtures round-trip through the array form. `target` is the dest host
 // Reality piggybacks on; the panel auto-generates random target+SNI when
 // blank.
-export const RealityStreamSettingsSchema = z.object({
-  show: z.boolean().default(false),
-  xver: z.number().int().min(0).default(0),
-  target: z.string().default(''),
-  serverNames: z.array(z.string()).default([]),
-  privateKey: z.string().default(''),
-  minClientVer: z.string().default(''),
-  maxClientVer: z.string().default(''),
-  maxTimediff: z.number().int().min(0).default(0),
-  shortIds: z.array(z.string()).default([]),
-  mldsa65Seed: z.string().default(''),
-  settings: RealityClientSettingsSchema.default({
-    publicKey: '',
-    fingerprint: 'chrome',
-    serverName: '',
-    spiderX: '/',
-    mldsa65Verify: '',
+export const RealityStreamSettingsSchema = z.preprocess(
+  aliasRealityDest,
+  z.object({
+    show: z.boolean().default(false),
+    xver: z.number().int().min(0).default(0),
+    target: z.string().default(''),
+    serverNames: z.array(z.string()).default([]),
+    privateKey: z.string().default(''),
+    minClientVer: z.string().default(''),
+    maxClientVer: z.string().default(''),
+    maxTimediff: z.number().int().min(0).default(0),
+    shortIds: z.array(z.string()).default([]),
+    mldsa65Seed: z.string().default(''),
+    settings: RealityClientSettingsSchema.default({
+      publicKey: '',
+      fingerprint: 'chrome',
+      serverName: '',
+      spiderX: '/',
+      mldsa65Verify: '',
+    }),
   }),
-});
+);
 export type RealityStreamSettings = z.infer<typeof RealityStreamSettingsSchema>;

--- a/frontend/src/test/security.test.ts
+++ b/frontend/src/test/security.test.ts
@@ -2,6 +2,7 @@
 import { describe, expect, it } from 'vitest';
 
 import { SecuritySettingsSchema } from '@/schemas/protocols';
+import { RealityStreamSettingsSchema } from '@/schemas/protocols/security/reality';
 
 const securityFixtures = import.meta.glob<unknown>(
   './golden/fixtures/security/*.json',
@@ -23,4 +24,39 @@ describe('SecuritySettingsSchema fixtures', () => {
       expect(parsed).toMatchSnapshot();
     });
   }
+});
+
+describe('RealityStreamSettingsSchema dest -> target alias', () => {
+  it('maps legacy `dest` to `target` when `target` is absent', () => {
+    const parsed = RealityStreamSettingsSchema.parse({
+      dest: 'example.com:443',
+      serverNames: ['example.com'],
+    });
+    expect(parsed.target).toBe('example.com:443');
+  });
+
+  it('keeps `target` when both keys are present', () => {
+    const parsed = RealityStreamSettingsSchema.parse({
+      target: 'example.com:443',
+      dest: 'other.com:443',
+    });
+    expect(parsed.target).toBe('example.com:443');
+  });
+
+  it('does not let an empty `target` shadow a present `dest`', () => {
+    const parsed = RealityStreamSettingsSchema.parse({
+      target: '',
+      dest: 'example.com:443',
+    });
+    expect(parsed.target).toBe('example.com:443');
+  });
+
+  it('migrates `dest` through the security discriminated union', () => {
+    const parsed = SecuritySettingsSchema.parse({
+      security: 'reality',
+      realitySettings: { dest: 'caddy:443', serverNames: ['volov.online'] },
+    });
+    if (parsed.security !== 'reality') throw new Error('expected reality branch');
+    expect(parsed.realitySettings.target).toBe('caddy:443');
+  });
 });


### PR DESCRIPTION
## Summary

REALITY inbounds whose `realitySettings` use the `dest` key load with an empty **Target** field in the edit form, and re-saving silently drops the destination. Normalize `dest` → `target` on parse so these configs load (and round-trip) correctly.

## Why

xray-core accepts both `target` and `dest` as the REALITY destination — they are aliases:

```go
// XTLS/Xray-core infra/conf/transport_internet.go — REALITYConfig
Target json.RawMessage `json:"target"`
Dest   json.RawMessage `json:"dest"`
```

The frontend reads/writes only `target`:

- `frontend/src/schemas/protocols/security/reality.ts` — `RealityStreamSettingsSchema` defines `target` only.
- `frontend/src/pages/inbounds/form/security/reality.tsx` — the field binds to `['streamSettings','realitySettings','target']`.

So an inbound created by an older panel build, an external tool, or the panel's own `/panel/api/inbounds` API (which commonly write `dest`) loads with `target: ''` — Zod ignores the unknown `dest`. The Target field shows empty with the "required" warning even though xray is running fine.

Worse, re-saving such an inbound serializes the blank `target` and drops the working `dest`, so the REALITY inbound has no destination on the next xray restart — a silent break from just opening and saving the edit form.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactoring (no behavior change)
- [ ] Documentation
- [ ] Tests only
- [ ] Build / CI / tooling
- [ ] Other

## Areas affected

- [x] Frontend (UI / panel pages)
- [ ] Backend (API endpoints, login, settings)
- [ ] Xray config generation
- [ ] Subscription (share links / Clash / JSON)
- [ ] Statistics / traffic counters
- [ ] Database / migrations
- [ ] Install / upgrade script
- [ ] Docker image
- [ ] Multi-node (sub-nodes)
- [ ] Telegram bot

## How was this tested?

Manual repro:

1. Create a VLESS+REALITY inbound whose `realitySettings` use `dest`, e.g. `{ "dest": "example.com:443", "serverNames": ["example.com"], ... }` (via the API, or restore an older config).
2. Open the inbound → Security tab. Before: Target is empty (placeholder `example.com:443`) with the "required" warning, despite xray running. After: Target loads as `example.com:443`.

Added unit tests in `frontend/src/test/security.test.ts` covering the alias on the schema directly (target absent, both keys present, empty `target` + present `dest`) and through `SecuritySettingsSchema`.

Validated locally:

- `cd frontend && npm run test` → 513 passed (31 files), no snapshot changes
- `cd frontend && npm run typecheck`
- `cd frontend && npm run lint`
- `cd frontend && npm run build`
- `git diff --check origin/main...HEAD`

## Screenshots / recordings

No visual/layout change — this is a form-state fix. Symptom: the **Target** field renders empty (placeholder `example.com:443`) for a `dest`-based REALITY inbound; after the fix it loads the configured destination.

## Breaking changes

None.

## Checklist

- [x] I tested the change locally and confirmed the described behavior.
- [x] I added or updated tests for the new behavior (when applicable).
- [ ] `go build ./...` and the test suite pass locally. — frontend-only change; ran the frontend suite (above).
- [x] For frontend changes: `npm run lint`, `npm run typecheck`, and `npm run build` pass.
- [ ] I updated the Wiki / README / API docs if user-facing behavior changed. — no docs change needed.
- [x] My commits follow the project's existing message style.
- [x] I have no unrelated changes mixed into this PR.
