### PR TITLE
perf(db): add an index on settings.key

### DIFF
--- a/internal/database/model/model.go
+++ b/internal/database/model/model.go
@@ -486,7 +486,7 @@ func HealMtprotoSecret(settings string) (string, bool) {
 // Setting stores key-value configuration settings for the 3x-ui panel.
 type Setting struct {
 	Id    int    `json:"id" form:"id" gorm:"primaryKey;autoIncrement"`
-	Key   string `json:"key" form:"key"`
+	Key   string `json:"key" form:"key" gorm:"index:idx_settings_key"`
 	Value string `json:"value" form:"value"`
 }
 

--- a/internal/database/settings_index_test.go
+++ b/internal/database/settings_index_test.go
@@ -1,0 +1,30 @@
+package database
+
+import (
+	"testing"
+
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+	"gorm.io/gorm/logger"
+
+	"github.com/mhsanaei/3x-ui/v3/internal/database/model"
+)
+
+// settings.key is read on nearly every request and job tick (getSetting
+// WHERE key=?); AutoMigrate must create the index so those lookups don't
+// full-scan the settings table past the large xrayTemplateConfig blob. gorm
+// creates missing indexes on migrate, so this also covers existing DBs.
+func TestAutoMigrateCreatesSettingsKeyIndex(t *testing.T) {
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{
+		Logger: logger.Default.LogMode(logger.Silent),
+	})
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	if err := db.AutoMigrate(&model.Setting{}); err != nil {
+		t.Fatalf("automigrate: %v", err)
+	}
+	if !db.Migrator().HasIndex(&model.Setting{}, "idx_settings_key") {
+		t.Errorf("expected idx_settings_key to exist after AutoMigrate")
+	}
+}


### PR DESCRIPTION
## Summary

Adds a database index on `settings.key` so the hottest config lookup no longer full-scans the table.

## Why

`getSetting` (`WHERE key = ?`) runs on nearly every subscription request and job tick. `settings.key` had no index, so each lookup full-scans the `settings` table — including past the large `xrayTemplateConfig` blob.

## Scope

- adds index `idx_settings_key` on `settings.key`
- `AutoMigrate` creates it on existing databases on upgrade
- no behavior change

## Validation

- `HasIndex` unit test after `AutoMigrate`
- `database` package tests pass

## Risk

Low. Index-only addition, no schema or behavior change, idempotent migration.
