### PR TITLE
fix(sub): set read/write/idle timeouts on the subscription server

### DIFF
--- a/internal/sub/sub.go
+++ b/internal/sub/sub.go
@@ -302,6 +302,13 @@ func (s *Server) Start() (err error) {
 
 	s.httpServer = &http.Server{
 		Handler: engine,
+		// The subscription server is the most exposed (public) listener; without
+		// these a few slow-header connections exhaust it (Slowloris). Mirrors the
+		// panel server timeouts in internal/web/web.go.
+		ReadHeaderTimeout: 5 * time.Second,
+		ReadTimeout:       30 * time.Second,
+		WriteTimeout:      30 * time.Second,
+		IdleTimeout:       120 * time.Second,
 	}
 
 	go func() {


### PR DESCRIPTION
## Summary

Sets read/write/idle timeouts on the public subscription HTTP server.

## Why

The subscription server is the most exposed (public) listener and was created with no timeouts, leaving it open to slow-header / Slowloris exhaustion. The panel server already sets these.

## Scope

- adds `ReadHeaderTimeout` / `ReadTimeout` / `WriteTimeout` / `IdleTimeout`
- values mirror the panel server in `internal/web/web.go`
- no behavior change for normal clients

## Validation

- `go build` / `go vet` clean
- values match the already-shipped panel server configuration

## Risk

Low. Conservative timeouts mirroring an already-shipped server on the same codebase.
