### PR TITLE
fix(web): recover panicking cron jobs instead of crashing the panel

### DIFF
--- a/internal/web/web.go
+++ b/internal/web/web.go
@@ -49,6 +49,12 @@ var distFS embed.FS
 
 var startTime = time.Now()
 
+// cronPanicLogger adapts the package logger to cron's Printf-style logger so a
+// panicking scheduled job is recovered and logged instead of crashing the panel.
+type cronPanicLogger struct{}
+
+func (cronPanicLogger) Printf(format string, args ...any) { logger.Errorf(format, args...) }
+
 // wrapDistFS adapts the embedded `dist/` directory so it can be mounted
 // as the panel's `/assets/` static route. Vite emits its bundled JS/CSS
 // under `dist/assets/`; serving the FS rooted at `dist/assets` makes
@@ -402,7 +408,9 @@ func (s *Server) start(restartXray bool, startTgBot bool) (err error) {
 	}
 	service.StartTrafficWriter()
 
-	s.cron = cron.New(cron.WithLocation(loc), cron.WithSeconds())
+	// cron.Recover wraps every job so a panic is logged and the scheduler keeps
+	// running, instead of the panic taking down the whole panel process.
+	s.cron = cron.New(cron.WithLocation(loc), cron.WithSeconds(), cron.WithChain(cron.Recover(cron.PrintfLogger(cronPanicLogger{}))))
 	s.cron.Start()
 
 	// Wire the inbound-runtime manager once so InboundService can route


### PR DESCRIPTION
## Summary

Wraps scheduled jobs with `cron.Recover` so a panicking job no longer crashes the panel.

## Why

The scheduler was created without a panic-recovery wrapper, so a panic in any scheduled job (traffic write, IP check, etc.) propagated up and could take down the whole panel process.

## Scope

- adds `cron.WithChain(cron.Recover(...))` with a small logger adapter
- a panicking job is now logged and the scheduler keeps running
- no change to job logic or scheduling

## Validation

- `go build` / `go vet` clean

## Risk

Low. Adds resilience only; no functional change to jobs.
