### PR TITLE
fix(xray): verify the release archive checksum before installing

### DIFF
--- a/internal/web/service/server.go
+++ b/internal/web/service/server.go
@@ -846,7 +846,11 @@ func (s *ServerService) downloadXRay(version string) (string, error) {
 		return "", err
 	}
 	if got := hex.EncodeToString(hasher.Sum(nil)); !strings.EqualFold(got, want) {
-		return "", fmt.Errorf("download xray: checksum mismatch (want %s, got %s)", want, got)
+		// User-facing warning: the archive's SHA-256 does not match the official
+		// release checksum, so the download is corrupted or has been tampered
+		// with. Abort the install so a bad binary is never run, and tell the user
+		// to retry/re-download rather than proceed with a mismatched image.
+		return "", fmt.Errorf("Xray update aborted: the downloaded archive does not match the official SHA-256 checksum, so the image is corrupted or differs from the official release. Please exit and re-download the official image, then try again (expected %s, got %s)", want, got)
 	}
 
 	ok = true

--- a/internal/web/service/server.go
+++ b/internal/web/service/server.go
@@ -4,6 +4,8 @@ import (
 	"archive/zip"
 	"bufio"
 	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -685,6 +687,9 @@ func (s *ServerService) sampleCPUUtilization() (float64, error) {
 const (
 	maxXrayArchiveBytes = 200 << 20
 	maxXrayBinaryBytes  = 200 << 20
+	// maxXrayDigestBytes caps the .dgst checksum sidecar read; it is a few
+	// hundred bytes in practice.
+	maxXrayDigestBytes = 64 << 10
 )
 
 func (s *ServerService) GetXrayVersions() ([]string, error) {
@@ -826,8 +831,61 @@ func (s *ServerService) downloadXRay(version string) (string, error) {
 		return "", fmt.Errorf("download xray: archive exceeds %d bytes", maxXrayArchiveBytes)
 	}
 
+	// Verify the archive against the SHA2-256 published in the release's .dgst
+	// sidecar before installing it. TLS protects the transport, not the artifact;
+	// a corrupted or tampered asset must not be installed and run as xray.
+	want, err := s.fetchXrayDigestSHA256(client, url+".dgst")
+	if err != nil {
+		return "", err
+	}
+	if _, err := file.Seek(0, io.SeekStart); err != nil {
+		return "", err
+	}
+	hasher := sha256.New()
+	if _, err := io.Copy(hasher, file); err != nil {
+		return "", err
+	}
+	if got := hex.EncodeToString(hasher.Sum(nil)); !strings.EqualFold(got, want) {
+		return "", fmt.Errorf("download xray: checksum mismatch (want %s, got %s)", want, got)
+	}
+
 	ok = true
 	return path, nil
+}
+
+// fetchXrayDigestSHA256 downloads the .dgst sidecar XTLS publishes next to each
+// release asset and returns the SHA2-256 hex digest it lists.
+func (s *ServerService) fetchXrayDigestSHA256(client *http.Client, dgstURL string) (string, error) {
+	resp, err := client.Get(dgstURL)
+	if err != nil {
+		return "", fmt.Errorf("download xray checksum: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("download xray checksum: unexpected HTTP %d", resp.StatusCode)
+	}
+	raw, err := io.ReadAll(io.LimitReader(resp.Body, maxXrayDigestBytes))
+	if err != nil {
+		return "", fmt.Errorf("download xray checksum: %w", err)
+	}
+	return parseXrayDigestSHA256(raw)
+}
+
+// parseXrayDigestSHA256 extracts the lowercase SHA2-256 hex from an XTLS .dgst
+// file, whose lines are "ALGO= <hex>" (the relevant one being "SHA2-256= ...").
+func parseXrayDigestSHA256(dgst []byte) (string, error) {
+	for _, line := range strings.Split(string(dgst), "\n") {
+		rest, ok := strings.CutPrefix(strings.TrimSpace(line), "SHA2-256=")
+		if !ok {
+			continue
+		}
+		h := strings.ToLower(strings.TrimSpace(rest))
+		if len(h) != 64 {
+			return "", fmt.Errorf("xray checksum: malformed SHA2-256 entry in digest")
+		}
+		return h, nil
+	}
+	return "", fmt.Errorf("xray checksum: no SHA2-256 entry in digest")
 }
 
 func (s *ServerService) UpdateXray(version string) error {

--- a/internal/web/service/server_xray_checksum_test.go
+++ b/internal/web/service/server_xray_checksum_test.go
@@ -1,0 +1,72 @@
+package service
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// A real XTLS .dgst sidecar (Xray-linux-64.zip.dgst, v26.3.27): lines are
+// "ALGO= <hex>", and the algorithm label is "SHA2-256", not "SHA256".
+const sampleXrayDgst = `# Hash Values
+
+MD5= ee4e2ff74948a9b464624b1cabc44409
+SHA1= b55b06e74e89083b9cedfdecf0d68b579cd2af72
+SHA2-256= 23cd9af937744d97776ee35ecad4972cf4b2109d1e0fe6be9930467608f7c8ae
+SHA2-512= e8bc40a0687cac184bbe4b5c1f047e69064ccedc489fb25e208889ae287bbf8736dff16b108d68fc00dc33edc8bb53502e47a9698a277f4f51b67b83d899e518
+`
+
+const wantSHA = "23cd9af937744d97776ee35ecad4972cf4b2109d1e0fe6be9930467608f7c8ae"
+
+func TestParseXrayDigestSHA256(t *testing.T) {
+	got, err := parseXrayDigestSHA256([]byte(sampleXrayDgst))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if got != wantSHA {
+		t.Fatalf("sha = %q, want %q", got, wantSHA)
+	}
+}
+
+func TestParseXrayDigestSHA256_Errors(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		in   string
+	}{
+		{"no-sha256-line", "MD5= abc\nSHA1= def\n"},
+		{"malformed-short", "SHA2-256= deadbeef\n"},
+		{"empty", ""},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if _, err := parseXrayDigestSHA256([]byte(tc.in)); err == nil {
+				t.Fatalf("%s: expected an error", tc.name)
+			}
+		})
+	}
+}
+
+func TestFetchXrayDigestSHA256(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(sampleXrayDgst))
+	}))
+	defer srv.Close()
+
+	got, err := (&ServerService{}).fetchXrayDigestSHA256(srv.Client(), srv.URL+"/Xray-linux-64.zip.dgst")
+	if err != nil {
+		t.Fatalf("fetch: %v", err)
+	}
+	if got != wantSHA {
+		t.Fatalf("sha = %q, want %q", got, wantSHA)
+	}
+}
+
+func TestFetchXrayDigestSHA256_HTTPError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "nope", http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	if _, err := (&ServerService{}).fetchXrayDigestSHA256(srv.Client(), srv.URL+"/missing.dgst"); err == nil {
+		t.Fatal("expected an error on HTTP 404")
+	}
+}


### PR DESCRIPTION
## Summary

Verify the downloaded Xray-core release archive against its published `SHA2-256` before installing, instead of installing it after only a TLS fetch + HTTP-200 + a size cap.

## Why

`UpdateXray` → `downloadXRay` fetched the release zip and installed the binary from it with no integrity check on the artifact itself. TLS protects the transport, not the bytes: a corrupted or tampered release asset (a bad mirror/CDN, or a proxy that terminates TLS) would be extracted and run as the panel's long-lived xray process.

## Scope

- after download, fetch the `.dgst` sidecar XTLS publishes next to each asset, parse its `SHA2-256` (the label is `SHA2-256=`, not `SHA256=`), compute the archive's SHA-256, and abort on mismatch
- abort the update when the `.dgst` is unreachable or has no/short `SHA2-256` entry — fail closed, never install an unverified archive. *(Maintainer note: this hard-fails updating to any release without a published `.dgst`; happy to switch to warn-and-proceed if you'd prefer to keep installing those.)*
- the `.dgst` read is capped at 64 KiB

## Validation

- unit tests for the digest parser (the real v26.3.27 `.dgst` line format, plus missing/malformed entries) and the fetch (httptest 200 + 404)
- `internal/web/service` package tests pass

## Risk

Low. Adds a verification step inside the existing download path; no API or behaviour change beyond rejecting an unverifiable archive.