### PR TITLE
feat(sub): full XHTTP field mapping for Clash/Mihomo subscriptions

### DIFF
--- a/frontend/src/lib/xray/stream-wire-normalize.ts
+++ b/frontend/src/lib/xray/stream-wire-normalize.ts
@@ -150,7 +150,12 @@ export function normalizeXhttpForWire(
 
   if (side === 'inbound') {
     if (!enableXmux) delete out.xmux;
-    delete out.scMinPostsIntervalMs;
+    // scMinPostsIntervalMs is a client-only tuning knob that subscriptions
+    // must propagate to clients. Only strip the xray-core default ("30")
+    // or empty values — the literal "30" is a known DPI fingerprint (#5141).
+    if (out.scMinPostsIntervalMs === '' || out.scMinPostsIntervalMs === '30') {
+      delete out.scMinPostsIntervalMs;
+    }
     delete out.uplinkChunkSize;
   }
 

--- a/frontend/src/pages/inbounds/form/transport/xhttp.tsx
+++ b/frontend/src/pages/inbounds/form/transport/xhttp.tsx
@@ -54,6 +54,12 @@ export default function XhttpForm({ form }: { form: FormInstance<InboundFormValu
           >
             <Input />
           </Form.Item>
+          <Form.Item
+            name={['streamSettings', 'xhttpSettings', 'scMinPostsIntervalMs']}
+            label={t('pages.xray.outboundForm.minUploadInterval')}
+          >
+            <Input placeholder="e.g. 50-150" />
+          </Form.Item>
         </>
       )}
       {xhttpMode === 'stream-up' && (

--- a/frontend/src/pages/inbounds/form/transport/xhttp.tsx
+++ b/frontend/src/pages/inbounds/form/transport/xhttp.tsx
@@ -40,7 +40,7 @@ export default function XhttpForm({ form }: { form: FormInstance<InboundFormValu
           }))}
         />
       </Form.Item>
-      {xhttpMode === 'packet-up' && (
+      {(xhttpMode === 'packet-up' || xhttpMode === 'auto') && (
         <>
           <Form.Item
             name={['streamSettings', 'xhttpSettings', 'scMaxBufferedPosts']}

--- a/frontend/src/schemas/protocols/stream/xhttp.ts
+++ b/frontend/src/schemas/protocols/stream/xhttp.ts
@@ -51,9 +51,12 @@ export const XHttpStreamSettingsSchema = z.object({
   serverMaxHeaderBytes: z.number().int().min(0).default(0),
   uplinkHTTPMethod: z.string().default(''),
   headers: WsHeaderMapSchema.default({}),
-  // Outbound-only fields. Server (inbound) listener ignores these. The
-  // panel embeds them in share-link `extra` blobs so the same xhttp
-  // config can roundtrip on both sides.
+  // Client-side fields stored on inbound for subscription propagation.
+  // The server listener ignores them at runtime, but the panel embeds
+  // them in share-link `extra` blobs so the same xhttp config can
+  // round-trip on both sides.
+  // - scMinPostsIntervalMs: preserved when non-default (stripped at '' or '30')
+  // - uplinkChunkSize & noGRPCHeader: outbound-only; stripped from inbound wire
   scMinPostsIntervalMs: z.string().default(''),
   uplinkChunkSize: z.number().int().min(0).default(0),
   noGRPCHeader: z.boolean().default(false),

--- a/frontend/src/test/stream-wire-normalize.test.ts
+++ b/frontend/src/test/stream-wire-normalize.test.ts
@@ -362,6 +362,102 @@ describe('inbound formValuesToWirePayload integration', () => {
     const settings = tls.settings as Record<string, unknown>;
     expect(settings).not.toHaveProperty('fingerprint');
   });
+
+  it('preserves non-default scMinPostsIntervalMs in packet-up inbound wire payload for subscriptions', () => {
+    const values = {
+      remark: 't',
+      enable: true,
+      port: 443,
+      listen: '0.0.0.0',
+      tag: 'in-443',
+      expiryTime: 0,
+      sniffing: { enabled: false },
+      up: 0,
+      down: 0,
+      total: 0,
+      trafficReset: 'never',
+      lastTrafficResetTime: 0,
+      nodeId: null,
+      protocol: 'vless',
+      settings: { clients: [{ id: '7eeb09ed-ae97-400d-a1ce-2485fb904407', email: 'n' }], decryption: 'none' },
+      streamSettings: {
+        network: 'xhttp',
+        security: 'reality',
+        realitySettings: {
+          target: 'play.google.com:443',
+          privateKey: 'priv',
+          serverNames: ['play.google.com'],
+          shortIds: ['44003d86dc1e'],
+          settings: { publicKey: 'pub', fingerprint: 'chrome', spiderX: '/' },
+        },
+        xhttpSettings: {
+          path: '/app',
+          host: 'play.google.com',
+          mode: 'packet-up',
+          scMinPostsIntervalMs: '50-150',
+        },
+        sockopt: {},
+      },
+    };
+
+    const parsed = InboundFormSchema.safeParse(values);
+    expect(parsed.success).toBe(true);
+    if (!parsed.success) throw parsed.error;
+
+    const payload = formValuesToWirePayload(parsed.data);
+    const stream = JSON.parse(payload.streamSettings) as Record<string, unknown>;
+    const xhttp = stream.xhttpSettings as Record<string, unknown>;
+
+    expect(xhttp.scMinPostsIntervalMs).toBe('50-150');
+  });
+
+  it('strips default scMinPostsIntervalMs=30 from inbound wire payload', () => {
+    const values = {
+      remark: 't',
+      enable: true,
+      port: 443,
+      listen: '0.0.0.0',
+      tag: 'in-443',
+      expiryTime: 0,
+      sniffing: { enabled: false },
+      up: 0,
+      down: 0,
+      total: 0,
+      trafficReset: 'never',
+      lastTrafficResetTime: 0,
+      nodeId: null,
+      protocol: 'vless',
+      settings: { clients: [{ id: '7eeb09ed-ae97-400d-a1ce-2485fb904407', email: 'n' }], decryption: 'none' },
+      streamSettings: {
+        network: 'xhttp',
+        security: 'reality',
+        realitySettings: {
+          target: 'play.google.com:443',
+          privateKey: 'priv',
+          serverNames: ['play.google.com'],
+          shortIds: ['44003d86dc1e'],
+          settings: { publicKey: 'pub', fingerprint: 'chrome', spiderX: '/' },
+        },
+        xhttpSettings: {
+          path: '/app',
+          host: 'play.google.com',
+          mode: 'packet-up',
+          scMinPostsIntervalMs: '30',
+        },
+        sockopt: {},
+      },
+    };
+
+    const parsed = InboundFormSchema.safeParse(values);
+    expect(parsed.success).toBe(true);
+    if (!parsed.success) throw parsed.error;
+
+    const payload = formValuesToWirePayload(parsed.data);
+    const stream = JSON.parse(payload.streamSettings) as Record<string, unknown>;
+    const xhttp = stream.xhttpSettings as Record<string, unknown>;
+
+    expect(xhttp).not.toHaveProperty('scMinPostsIntervalMs');
+  });
 });
 
 describe('freedom outbound sockopt wire payload', () => {

--- a/frontend/src/test/stream-wire-normalize.test.ts
+++ b/frontend/src/test/stream-wire-normalize.test.ts
@@ -53,6 +53,28 @@ describe('normalizeXhttpForWire stream-one', () => {
     expect(out).not.toHaveProperty('headers');
   });
 
+  it('preserves non-default scMinPostsIntervalMs on inbound for subscriptions', () => {
+    const out = normalizeXhttpForWire({
+      path: '/app',
+      mode: 'packet-up',
+      scMinPostsIntervalMs: '50-150',
+      enableXmux: false,
+    }, 'inbound');
+
+    expect(out.scMinPostsIntervalMs).toBe('50-150');
+  });
+
+  it('strips empty scMinPostsIntervalMs on inbound', () => {
+    const out = normalizeXhttpForWire({
+      path: '/app',
+      mode: 'packet-up',
+      scMinPostsIntervalMs: '',
+      enableXmux: false,
+    }, 'inbound');
+
+    expect(out).not.toHaveProperty('scMinPostsIntervalMs');
+  });
+
   it('keeps xmux on outbound stream-one', () => {
     const out = normalizeXhttpForWire({
       path: '/app',

--- a/internal/sub/clash_service.go
+++ b/internal/sub/clash_service.go
@@ -350,6 +350,128 @@ func (s *SubClashService) buildHysteriaProxy(subReq *SubService, inbound *model.
 	return proxy
 }
 
+// buildXhttpClashOpts converts xhttpSettings from 3x-ui's camelCase JSON
+// storage into the kebab-case map that Mihomo expects under xhttp-opts.
+//
+// Only client-relevant fields are included (allowlist approach).
+// Server-only fields (noSSEHeader, scMaxBufferedPosts, scStreamUpServerSecs,
+// serverMaxHeaderBytes) are automatically excluded because they are not in
+// the mapping. This is intentional — when Mihomo adds new fields, the mapping
+// must be updated explicitly rather than leaking unverified fields to clients.
+//
+// Returns nil if no non-trivial fields are present.
+func buildXhttpClashOpts(xhttp map[string]any) map[string]any {
+	if xhttp == nil {
+		return nil
+	}
+	opts := map[string]any{}
+
+	// Direct fields: path, mode
+	if v, ok := xhttp["path"].(string); ok && v != "" {
+		opts["path"] = v
+	}
+	if v, ok := xhttp["mode"].(string); ok && v != "" {
+		opts["mode"] = v
+	}
+
+	// Host: explicit host field wins, then fall back to headers.Host
+	host := ""
+	if v, ok := xhttp["host"].(string); ok && v != "" {
+		host = v
+	} else if headers, ok := xhttp["headers"].(map[string]any); ok {
+		host = searchHost(headers)
+	}
+	if host != "" {
+		opts["host"] = host
+	}
+
+	type xhttpStringField struct{ src, dst, skipValue string }
+
+	stringFields := []xhttpStringField{
+		{"xPaddingBytes", "x-padding-bytes", ""},
+		{"uplinkHTTPMethod", "uplink-http-method", ""},
+		{"sessionPlacement", "session-placement", ""},
+		{"sessionKey", "session-key", ""},
+		{"seqPlacement", "seq-placement", ""},
+		{"seqKey", "seq-key", ""},
+		{"uplinkDataPlacement", "uplink-data-placement", ""},
+		{"uplinkDataKey", "uplink-data-key", ""},
+		{"scMaxEachPostBytes", "sc-max-each-post-bytes", "1000000"},
+		{"scMinPostsIntervalMs", "sc-min-posts-interval-ms", "30"},
+	}
+
+	for _, f := range stringFields {
+		if v, ok := xhttp[f.src].(string); ok && v != "" && v != f.skipValue {
+			opts[f.dst] = v
+		}
+	}
+
+	// Bool fields (truthy only)
+	if v, ok := xhttp["noGRPCHeader"].(bool); ok && v {
+		opts["no-grpc-header"] = true
+	}
+	if v, ok := xhttp["xPaddingObfsMode"].(bool); ok && v {
+		opts["x-padding-obfs-mode"] = true
+		// Padding obfs gated fields
+		for _, field := range []struct{ src, dst string }{
+			{"xPaddingKey", "x-padding-key"},
+			{"xPaddingHeader", "x-padding-header"},
+			{"xPaddingPlacement", "x-padding-placement"},
+			{"xPaddingMethod", "x-padding-method"},
+		} {
+			if v, ok := xhttp[field.src].(string); ok && v != "" {
+				opts[field.dst] = v
+			}
+		}
+	}
+
+	// Non-zero value fields
+	if v, ok := nonZeroShareValue(xhttp["uplinkChunkSize"]); ok {
+		opts["uplink-chunk-size"] = v
+	}
+
+	// Nested object: xmux → reuse-settings
+	if xmux, ok := xhttp["xmux"].(map[string]any); ok && len(xmux) > 0 {
+		reuse := map[string]any{}
+		for _, f := range []struct{ src, dst string }{
+			{"maxConcurrency", "max-concurrency"},
+			{"maxConnections", "max-connections"},
+			{"cMaxReuseTimes", "c-max-reuse-times"},
+			{"hMaxRequestTimes", "h-max-request-times"},
+			{"hMaxReusableSecs", "h-max-reusable-secs"},
+		} {
+			if v, ok := xmux[f.src].(string); ok && v != "" {
+				reuse[f.dst] = v
+			}
+		}
+		if v, ok := nonZeroShareValue(xmux["hKeepAlivePeriod"]); ok {
+			reuse["h-keep-alive-period"] = v
+		}
+		if len(reuse) > 0 {
+			opts["reuse-settings"] = reuse
+		}
+	}
+
+	// Headers (drop Host key)
+	if rawHeaders, ok := xhttp["headers"].(map[string]any); ok && len(rawHeaders) > 0 {
+		out := map[string]any{}
+		for k, v := range rawHeaders {
+			if strings.EqualFold(k, "host") {
+				continue
+			}
+			out[k] = v
+		}
+		if len(out) > 0 {
+			opts["headers"] = out
+		}
+	}
+
+	if len(opts) == 0 {
+		return nil
+	}
+	return opts
+}
+
 func (s *SubClashService) applyTransport(proxy map[string]any, network string, stream map[string]any) bool {
 	switch network {
 	case "", "tcp":
@@ -425,25 +547,8 @@ func (s *SubClashService) applyTransport(proxy map[string]any, network string, s
 	case "xhttp":
 		proxy["network"] = "xhttp"
 		xhttp, _ := stream["xhttpSettings"].(map[string]any)
-		opts := map[string]any{}
-		if xhttp != nil {
-			if path, ok := xhttp["path"].(string); ok && path != "" {
-				opts["path"] = path
-			}
-			host := ""
-			if v, ok := xhttp["host"].(string); ok && v != "" {
-				host = v
-			} else if headers, ok := xhttp["headers"].(map[string]any); ok {
-				host = searchHost(headers)
-			}
-			if host != "" {
-				opts["host"] = host
-			}
-			if mode, ok := xhttp["mode"].(string); ok && mode != "" {
-				opts["mode"] = mode
-			}
-		}
-		if len(opts) > 0 {
+		opts := buildXhttpClashOpts(xhttp)
+		if opts != nil {
 			proxy["xhttp-opts"] = opts
 		}
 		return true

--- a/internal/sub/clash_service_test.go
+++ b/internal/sub/clash_service_test.go
@@ -301,3 +301,457 @@ func TestBuildProxy_VLESSNoneEncryptionOmittedForClash(t *testing.T) {
 		t.Fatalf("uuid = %v, want %v", proxy["uuid"], client.ID)
 	}
 }
+
+func TestBuildXhttpClashOpts_FullFieldMapping(t *testing.T) {
+	xhttp := map[string]any{
+		"path":    "/api/v1",
+		"mode":    "stream-up",
+		"host":    "example.com",
+		"xPaddingBytes":    "100-1000",
+		"xPaddingObfsMode": true,
+		"xPaddingKey":       "mykey",
+		"xPaddingHeader":    "X-Trace-ID",
+		"xPaddingPlacement": "queryInHeader",
+		"xPaddingMethod":    "tokenish",
+		"uplinkHTTPMethod":  "POST",
+		"sessionPlacement":  "query",
+		"sessionKey":        "sess",
+		"seqPlacement":      "header",
+		"seqKey":            "seq",
+		"uplinkDataPlacement": "body",
+		"uplinkDataKey":      "udata",
+		"uplinkChunkSize":    "64-256",
+		"noGRPCHeader":       true,
+		"scMaxEachPostBytes": "500000",
+		"scMinPostsIntervalMs": "50",
+		"xmux": map[string]any{
+			"maxConcurrency":   "16-32",
+			"maxConnections":   "4",
+			"cMaxReuseTimes":   "8",
+			"hMaxRequestTimes":  "600-900",
+			"hMaxReusableSecs":  "1800-3000",
+			"hKeepAlivePeriod":  float64(60),
+		},
+		"headers": map[string]any{
+			"User-Agent": "chrome",
+			"Host":       "should-be-dropped.com",
+		},
+	}
+
+	opts := buildXhttpClashOpts(xhttp)
+	if opts == nil {
+		t.Fatal("expected non-nil opts for full field mapping")
+	}
+
+	// Direct fields
+	if opts["path"] != "/api/v1" {
+		t.Errorf("path = %v, want /api/v1", opts["path"])
+	}
+	if opts["mode"] != "stream-up" {
+		t.Errorf("mode = %v, want stream-up", opts["mode"])
+	}
+	if opts["host"] != "example.com" {
+		t.Errorf("host = %v, want example.com", opts["host"])
+	}
+
+	// String fields
+	if opts["x-padding-bytes"] != "100-1000" {
+		t.Errorf("x-padding-bytes = %v", opts["x-padding-bytes"])
+	}
+	if opts["uplink-http-method"] != "POST" {
+		t.Errorf("uplink-http-method = %v", opts["uplink-http-method"])
+	}
+	if opts["session-placement"] != "query" {
+		t.Errorf("session-placement = %v", opts["session-placement"])
+	}
+	if opts["session-key"] != "sess" {
+		t.Errorf("session-key = %v", opts["session-key"])
+	}
+	if opts["seq-placement"] != "header" {
+		t.Errorf("seq-placement = %v", opts["seq-placement"])
+	}
+	if opts["seq-key"] != "seq" {
+		t.Errorf("seq-key = %v", opts["seq-key"])
+	}
+	if opts["uplink-data-placement"] != "body" {
+		t.Errorf("uplink-data-placement = %v", opts["uplink-data-placement"])
+	}
+	if opts["uplink-data-key"] != "udata" {
+		t.Errorf("uplink-data-key = %v", opts["uplink-data-key"])
+	}
+
+	// DPI-filtered fields (non-default values should pass)
+	if opts["sc-max-each-post-bytes"] != "500000" {
+		t.Errorf("sc-max-each-post-bytes = %v", opts["sc-max-each-post-bytes"])
+	}
+	if opts["sc-min-posts-interval-ms"] != "50" {
+		t.Errorf("sc-min-posts-interval-ms = %v", opts["sc-min-posts-interval-ms"])
+	}
+
+	// Bool fields
+	if opts["no-grpc-header"] != true {
+		t.Errorf("no-grpc-header = %v, want true", opts["no-grpc-header"])
+	}
+	if opts["x-padding-obfs-mode"] != true {
+		t.Errorf("x-padding-obfs-mode = %v, want true", opts["x-padding-obfs-mode"])
+	}
+
+	// Padding obfs gated fields
+	if opts["x-padding-key"] != "mykey" {
+		t.Errorf("x-padding-key = %v", opts["x-padding-key"])
+	}
+	if opts["x-padding-header"] != "X-Trace-ID" {
+		t.Errorf("x-padding-header = %v", opts["x-padding-header"])
+	}
+	if opts["x-padding-placement"] != "queryInHeader" {
+		t.Errorf("x-padding-placement = %v", opts["x-padding-placement"])
+	}
+	if opts["x-padding-method"] != "tokenish" {
+		t.Errorf("x-padding-method = %v", opts["x-padding-method"])
+	}
+
+	// Non-zero value fields
+	if opts["uplink-chunk-size"] != "64-256" {
+		t.Errorf("uplink-chunk-size = %v", opts["uplink-chunk-size"])
+	}
+
+	// Reuse-settings (xmux)
+	reuse, ok := opts["reuse-settings"].(map[string]any)
+	if !ok {
+		t.Fatalf("reuse-settings missing or wrong type: %#v", opts["reuse-settings"])
+	}
+	if reuse["max-concurrency"] != "16-32" {
+		t.Errorf("max-concurrency = %v", reuse["max-concurrency"])
+	}
+	if reuse["max-connections"] != "4" {
+		t.Errorf("max-connections = %v", reuse["max-connections"])
+	}
+	if reuse["c-max-reuse-times"] != "8" {
+		t.Errorf("c-max-reuse-times = %v", reuse["c-max-reuse-times"])
+	}
+	if reuse["h-max-request-times"] != "600-900" {
+		t.Errorf("h-max-request-times = %v", reuse["h-max-request-times"])
+	}
+	if reuse["h-max-reusable-secs"] != "1800-3000" {
+		t.Errorf("h-max-reusable-secs = %v", reuse["h-max-reusable-secs"])
+	}
+	if reuse["h-keep-alive-period"] != float64(60) {
+		t.Errorf("h-keep-alive-period = %v, want 60", reuse["h-keep-alive-period"])
+	}
+
+	// Headers (Host should be dropped)
+	headers, ok := opts["headers"].(map[string]any)
+	if !ok {
+		t.Fatalf("headers missing or wrong type: %#v", opts["headers"])
+	}
+	if headers["User-Agent"] != "chrome" {
+		t.Errorf("headers[User-Agent] = %v", headers["User-Agent"])
+	}
+	if _, has := headers["Host"]; has {
+		t.Error("headers should not contain Host key")
+	}
+	if _, has := headers["host"]; has {
+		t.Error("headers should not contain host key (case-insensitive)")
+	}
+}
+
+func TestBuildXhttpClashOpts_DPIDefaultsFiltered(t *testing.T) {
+	xhttp := map[string]any{
+		"path":                "/",
+		"mode":                "stream-up",
+		"scMaxEachPostBytes":   "1000000",
+		"scMinPostsIntervalMs": "30",
+	}
+	opts := buildXhttpClashOpts(xhttp)
+	if opts == nil {
+		t.Fatal("expected non-nil opts (path and mode should be present)")
+	}
+	if _, has := opts["sc-max-each-post-bytes"]; has {
+		t.Error("sc-max-each-post-bytes should be filtered when value is 1000000")
+	}
+	if _, has := opts["sc-min-posts-interval-ms"]; has {
+		t.Error("sc-min-posts-interval-ms should be filtered when value is 30")
+	}
+}
+
+func TestBuildXhttpClashOpts_PaddingObfsGate(t *testing.T) {
+	// Sub-test 1: obfs mode false — gated fields should not appear
+	t.Run("ObfsModeFalse", func(t *testing.T) {
+		xhttp := map[string]any{
+			"path":            "/",
+			"xPaddingObfsMode": false,
+			"xPaddingKey":     "should-not-appear",
+		}
+		opts := buildXhttpClashOpts(xhttp)
+		if opts == nil {
+			t.Fatal("expected non-nil opts")
+		}
+		if _, has := opts["x-padding-obfs-mode"]; has {
+			t.Error("x-padding-obfs-mode should not appear when false")
+		}
+		if _, has := opts["x-padding-key"]; has {
+			t.Error("x-padding-key should not appear when obfs mode is false")
+		}
+	})
+
+	// Sub-test 2: obfs mode absent — gated fields should not appear
+	t.Run("ObfsModeAbsent", func(t *testing.T) {
+		xhttp := map[string]any{
+			"path":        "/",
+			"xPaddingKey": "should-not-appear",
+		}
+		opts := buildXhttpClashOpts(xhttp)
+		if opts == nil {
+			t.Fatal("expected non-nil opts")
+		}
+		if _, has := opts["x-padding-key"]; has {
+			t.Error("x-padding-key should not appear when obfs mode is absent")
+		}
+	})
+
+	// Sub-test 3: obfs mode true with no gated fields — only x-padding-obfs-mode appears
+	t.Run("ObfsModeTrueNoGatedFields", func(t *testing.T) {
+		xhttp := map[string]any{
+			"path":             "/",
+			"xPaddingObfsMode": true,
+		}
+		opts := buildXhttpClashOpts(xhttp)
+		if opts == nil {
+			t.Fatal("expected non-nil opts")
+		}
+		if opts["x-padding-obfs-mode"] != true {
+			t.Errorf("x-padding-obfs-mode = %v, want true", opts["x-padding-obfs-mode"])
+		}
+		if _, has := opts["x-padding-key"]; has {
+			t.Error("x-padding-key should not appear when not set")
+		}
+	})
+}
+
+func TestBuildXhttpClashOpts_XmuxMapsToReuseSettings(t *testing.T) {
+	// Sub-test 1: full xmux mapping
+	t.Run("FullXmux", func(t *testing.T) {
+		xhttp := map[string]any{
+			"path": "/",
+			"xmux": map[string]any{
+				"maxConcurrency":   "16-32",
+				"maxConnections":   "4",
+				"cMaxReuseTimes":   "8",
+				"hMaxRequestTimes":  "600-900",
+				"hMaxReusableSecs":  "1800-3000",
+				"hKeepAlivePeriod":  float64(60),
+			},
+		}
+		opts := buildXhttpClashOpts(xhttp)
+		if opts == nil {
+			t.Fatal("expected non-nil opts")
+		}
+		reuse, ok := opts["reuse-settings"].(map[string]any)
+		if !ok {
+			t.Fatalf("reuse-settings missing or wrong type: %#v", opts["reuse-settings"])
+		}
+		if reuse["max-concurrency"] != "16-32" {
+			t.Errorf("max-concurrency = %v", reuse["max-concurrency"])
+		}
+		if reuse["max-connections"] != "4" {
+			t.Errorf("max-connections = %v", reuse["max-connections"])
+		}
+		if reuse["c-max-reuse-times"] != "8" {
+			t.Errorf("c-max-reuse-times = %v", reuse["c-max-reuse-times"])
+		}
+		if reuse["h-max-request-times"] != "600-900" {
+			t.Errorf("h-max-request-times = %v", reuse["h-max-request-times"])
+		}
+		if reuse["h-max-reusable-secs"] != "1800-3000" {
+			t.Errorf("h-max-reusable-secs = %v", reuse["h-max-reusable-secs"])
+		}
+		if reuse["h-keep-alive-period"] != float64(60) {
+			t.Errorf("h-keep-alive-period = %v, want 60", reuse["h-keep-alive-period"])
+		}
+	})
+
+	// Sub-test 2: empty xmux map — no reuse-settings key
+	t.Run("EmptyXmux", func(t *testing.T) {
+		xhttp := map[string]any{
+			"path": "/",
+			"xmux": map[string]any{},
+		}
+		opts := buildXhttpClashOpts(xhttp)
+		if opts == nil {
+			t.Fatal("expected non-nil opts (path is present)")
+		}
+		if _, has := opts["reuse-settings"]; has {
+			t.Error("reuse-settings should not appear for empty xmux")
+		}
+	})
+
+	// Sub-test 3: hKeepAlivePeriod as int (not float64)
+	t.Run("IntKeepAlivePeriod", func(t *testing.T) {
+		xhttp := map[string]any{
+			"path": "/",
+			"xmux": map[string]any{
+				"hKeepAlivePeriod": int(60),
+			},
+		}
+		opts := buildXhttpClashOpts(xhttp)
+		if opts == nil {
+			t.Fatal("expected non-nil opts")
+		}
+		reuse, ok := opts["reuse-settings"].(map[string]any)
+		if !ok {
+			t.Fatalf("reuse-settings missing: %#v", opts["reuse-settings"])
+		}
+		if reuse["h-keep-alive-period"] != int(60) {
+			t.Errorf("h-keep-alive-period = %v (%T), want 60 (int)", reuse["h-keep-alive-period"], reuse["h-keep-alive-period"])
+		}
+	})
+
+	// Sub-test 4: hKeepAlivePeriod=0 should be filtered
+	t.Run("ZeroKeepAlivePeriod", func(t *testing.T) {
+		xhttp := map[string]any{
+			"path": "/",
+			"xmux": map[string]any{
+				"hKeepAlivePeriod": float64(0),
+			},
+		}
+		opts := buildXhttpClashOpts(xhttp)
+		if opts == nil {
+			t.Fatal("expected non-nil opts")
+		}
+		if _, has := opts["reuse-settings"]; has {
+			t.Error("reuse-settings should not appear when only hKeepAlivePeriod=0")
+		}
+	})
+}
+
+func TestBuildXhttpClashOpts_ServerOnlyFieldsExcluded(t *testing.T) {
+	xhttp := map[string]any{
+		"path":                 "/",
+		"noSSEHeader":          true,
+		"scMaxBufferedPosts":   "100",
+		"scStreamUpServerSecs": "5",
+		"serverMaxHeaderBytes": "4096",
+	}
+	opts := buildXhttpClashOpts(xhttp)
+	if opts == nil {
+		t.Fatal("expected non-nil opts (path is present)")
+	}
+	if _, has := opts["no-sse-header"]; has {
+		t.Error("noSSEHeader should not appear in Clash output (server-only)")
+	}
+	if _, has := opts["sc-max-buffered-posts"]; has {
+		t.Error("scMaxBufferedPosts should not appear in Clash output (server-only)")
+	}
+	if _, has := opts["sc-stream-up-server-secs"]; has {
+		t.Error("scStreamUpServerSecs should not appear in Clash output (server-only)")
+	}
+	if _, has := opts["server-max-header-bytes"]; has {
+		t.Error("serverMaxHeaderBytes should not appear in Clash output (not in Mihomo)")
+	}
+}
+
+func TestBuildXhttpClashOpts_NilInput(t *testing.T) {
+	opts := buildXhttpClashOpts(nil)
+	if opts != nil {
+		t.Fatalf("expected nil for nil input, got %#v", opts)
+	}
+}
+
+func TestBuildXhttpClashOpts_EmptyInput(t *testing.T) {
+	opts := buildXhttpClashOpts(map[string]any{})
+	if opts != nil {
+		t.Fatalf("expected nil for empty input, got %#v", opts)
+	}
+}
+
+func TestBuildXhttpClashOpts_HostFallbackFromHeaders(t *testing.T) {
+	// Sub-test 1: host from headers.Host
+	t.Run("HostFromHeaders", func(t *testing.T) {
+		xhttp := map[string]any{
+			"path":    "/",
+			"headers": map[string]any{"Host": "via-header.example.com"},
+		}
+		opts := buildXhttpClashOpts(xhttp)
+		if opts == nil {
+			t.Fatal("expected non-nil opts")
+		}
+		if opts["host"] != "via-header.example.com" {
+			t.Errorf("host = %v, want via-header.example.com", opts["host"])
+		}
+	})
+
+	// Sub-test 2: headers only contains Host — no headers key in output
+	t.Run("HeadersOnlyHost", func(t *testing.T) {
+		xhttp := map[string]any{
+			"path":    "/",
+			"headers": map[string]any{"Host": "only-host.example.com"},
+		}
+		opts := buildXhttpClashOpts(xhttp)
+		if opts == nil {
+			t.Fatal("expected non-nil opts")
+		}
+		if _, has := opts["headers"]; has {
+			t.Error("headers key should not appear when only Host is present (Host is extracted to top-level)")
+		}
+	})
+
+	// Sub-test 3: case-insensitive Host drop
+	t.Run("CaseInsensitiveHostDrop", func(t *testing.T) {
+		xhttp := map[string]any{
+			"path": "/",
+			"host": "explicit.example.com",
+			"headers": map[string]any{
+				"host":     "lowercase-host.example.com",
+				"X-Custom": "value",
+			},
+		}
+		opts := buildXhttpClashOpts(xhttp)
+		if opts == nil {
+			t.Fatal("expected non-nil opts")
+		}
+		if opts["host"] != "explicit.example.com" {
+			t.Errorf("host = %v, want explicit.example.com (explicit host wins)", opts["host"])
+		}
+		headers, ok := opts["headers"].(map[string]any)
+		if !ok {
+			t.Fatal("headers should be present (X-Custom remains)")
+		}
+		if _, has := headers["host"]; has {
+			t.Error("lowercase 'host' should be dropped from headers")
+		}
+		if headers["X-Custom"] != "value" {
+			t.Errorf("X-Custom = %v, want value", headers["X-Custom"])
+		}
+	})
+}
+
+func TestBuildXhttpClashOpts_NoGRPCHeaderFalsey(t *testing.T) {
+	// Sub-test 1: noGRPCHeader: false
+	t.Run("ExplicitFalse", func(t *testing.T) {
+		xhttp := map[string]any{
+			"path":         "/",
+			"noGRPCHeader": false,
+		}
+		opts := buildXhttpClashOpts(xhttp)
+		if opts == nil {
+			t.Fatal("expected non-nil opts (path is present)")
+		}
+		if _, has := opts["no-grpc-header"]; has {
+			t.Error("no-grpc-header should not appear when noGRPCHeader is false")
+		}
+	})
+
+	// Sub-test 2: noGRPCHeader absent
+	t.Run("Absent", func(t *testing.T) {
+		xhttp := map[string]any{
+			"path": "/",
+		}
+		opts := buildXhttpClashOpts(xhttp)
+		if opts == nil {
+			t.Fatal("expected non-nil opts")
+		}
+		if _, has := opts["no-grpc-header"]; has {
+			t.Error("no-grpc-header should not appear when absent")
+		}
+	})
+}

--- a/internal/sub/json_service.go
+++ b/internal/sub/json_service.go
@@ -146,6 +146,16 @@ func (s *SubJsonService) getConfig(subReq *SubService, inbound *model.Inbound, c
 		defaultDest = host
 	}
 
+	// Per-inbound xmux takes precedence over the global subJsonMux.
+	// When xmux is present inside xhttpSettings, XHTTP multiplexing
+	// is handled by xmux — don't also set the legacy outbound.Mux.
+	mux := s.mux
+	if xhttp, ok := stream["xhttpSettings"].(map[string]any); ok {
+		if _, hasXmux := xhttp["xmux"]; hasXmux {
+			mux = ""
+		}
+	}
+
 	externalProxies, ok := stream["externalProxy"].([]any)
 	hasExternalProxy := ok && len(externalProxies) > 0
 	if !hasExternalProxy {
@@ -188,13 +198,13 @@ func (s *SubJsonService) getConfig(subReq *SubService, inbound *model.Inbound, c
 
 		switch inbound.Protocol {
 		case "vmess":
-			newOutbounds = append(newOutbounds, s.genVnext(inbound, streamSettings, client))
+			newOutbounds = append(newOutbounds, s.genVnext(inbound, streamSettings, client, mux))
 		case "vless":
-			newOutbounds = append(newOutbounds, s.genVless(inbound, streamSettings, client))
+			newOutbounds = append(newOutbounds, s.genVless(inbound, streamSettings, client, mux))
 		case "trojan", "shadowsocks":
-			newOutbounds = append(newOutbounds, s.genServer(inbound, streamSettings, client))
+			newOutbounds = append(newOutbounds, s.genServer(inbound, streamSettings, client, mux))
 		case "hysteria":
-			newOutbounds = append(newOutbounds, s.genHy(inbound, newStream, client))
+			newOutbounds = append(newOutbounds, s.genHy(inbound, newStream, client, mux))
 		}
 
 		newOutbounds = append(newOutbounds, s.defaultOutbounds...)
@@ -321,13 +331,13 @@ func (s *SubJsonService) realityData(rData map[string]any) map[string]any {
 	return rltyData
 }
 
-func (s *SubJsonService) genVnext(inbound *model.Inbound, streamSettings json_util.RawMessage, client model.Client) json_util.RawMessage {
+func (s *SubJsonService) genVnext(inbound *model.Inbound, streamSettings json_util.RawMessage, client model.Client, mux string) json_util.RawMessage {
 	outbound := Outbound{}
 
 	outbound.Protocol = string(inbound.Protocol)
 	outbound.Tag = "proxy"
-	if s.mux != "" {
-		outbound.Mux = json_util.RawMessage(s.mux)
+	if mux != "" {
+		outbound.Mux = json_util.RawMessage(mux)
 	}
 	outbound.StreamSettings = streamSettings
 
@@ -347,12 +357,12 @@ func (s *SubJsonService) genVnext(inbound *model.Inbound, streamSettings json_ut
 	return result
 }
 
-func (s *SubJsonService) genVless(inbound *model.Inbound, streamSettings json_util.RawMessage, client model.Client) json_util.RawMessage {
+func (s *SubJsonService) genVless(inbound *model.Inbound, streamSettings json_util.RawMessage, client model.Client, mux string) json_util.RawMessage {
 	outbound := Outbound{}
 	outbound.Protocol = string(inbound.Protocol)
 	outbound.Tag = "proxy"
-	if s.mux != "" {
-		outbound.Mux = json_util.RawMessage(s.mux)
+	if mux != "" {
+		outbound.Mux = json_util.RawMessage(mux)
 	}
 	outbound.StreamSettings = streamSettings
 
@@ -376,7 +386,7 @@ func (s *SubJsonService) genVless(inbound *model.Inbound, streamSettings json_ut
 	return result
 }
 
-func (s *SubJsonService) genServer(inbound *model.Inbound, streamSettings json_util.RawMessage, client model.Client) json_util.RawMessage {
+func (s *SubJsonService) genServer(inbound *model.Inbound, streamSettings json_util.RawMessage, client model.Client, mux string) json_util.RawMessage {
 	outbound := Outbound{}
 
 	serverData := make([]ServerSetting, 1)
@@ -403,8 +413,8 @@ func (s *SubJsonService) genServer(inbound *model.Inbound, streamSettings json_u
 
 	outbound.Protocol = string(inbound.Protocol)
 	outbound.Tag = "proxy"
-	if s.mux != "" {
-		outbound.Mux = json_util.RawMessage(s.mux)
+	if mux != "" {
+		outbound.Mux = json_util.RawMessage(mux)
 	}
 	outbound.StreamSettings = streamSettings
 
@@ -423,14 +433,14 @@ func (s *SubJsonService) genServer(inbound *model.Inbound, streamSettings json_u
 	return result
 }
 
-func (s *SubJsonService) genHy(inbound *model.Inbound, newStream map[string]any, client model.Client) json_util.RawMessage {
+func (s *SubJsonService) genHy(inbound *model.Inbound, newStream map[string]any, client model.Client, mux string) json_util.RawMessage {
 	outbound := Outbound{}
 
 	outbound.Protocol = string(inbound.Protocol)
 	outbound.Tag = "proxy"
 
-	if s.mux != "" {
-		outbound.Mux = json_util.RawMessage(s.mux)
+	if mux != "" {
+		outbound.Mux = json_util.RawMessage(mux)
 	}
 
 	var settings, stream map[string]any

--- a/internal/sub/json_service_test.go
+++ b/internal/sub/json_service_test.go
@@ -106,7 +106,7 @@ func TestSubJsonServiceVlessFlattened(t *testing.T) {
 	inbound := &model.Inbound{Listen: "1.2.3.4", Port: 443, Protocol: model.VLESS, Settings: `{"encryption":"none"}`}
 	client := model.Client{ID: "uuid-1", Flow: "xtls-rprx-vision"}
 
-	settings := outboundSettings(t, NewSubJsonService("", "", "", nil).genVless(inbound, nil, client))
+	settings := outboundSettings(t, NewSubJsonService("", "", "", nil).genVless(inbound, nil, client, ""))
 	if _, ok := settings["vnext"]; ok {
 		t.Fatal("vless outbound must not use vnext")
 	}
@@ -119,7 +119,7 @@ func TestSubJsonServiceVmessFlattened(t *testing.T) {
 	inbound := &model.Inbound{Listen: "1.2.3.4", Port: 443, Protocol: model.VMESS, Settings: `{}`}
 	client := model.Client{ID: "uuid-2"}
 
-	settings := outboundSettings(t, NewSubJsonService("", "", "", nil).genVnext(inbound, nil, client))
+	settings := outboundSettings(t, NewSubJsonService("", "", "", nil).genVnext(inbound, nil, client, ""))
 	if _, ok := settings["vnext"]; ok {
 		t.Fatal("vmess outbound must not use vnext")
 	}
@@ -132,7 +132,7 @@ func TestSubJsonServiceServerFlattened(t *testing.T) {
 	trojan := &model.Inbound{Listen: "1.2.3.4", Port: 443, Protocol: model.Trojan, Settings: `{}`}
 	client := model.Client{Password: "p4ss"}
 
-	settings := outboundSettings(t, NewSubJsonService("", "", "", nil).genServer(trojan, nil, client))
+	settings := outboundSettings(t, NewSubJsonService("", "", "", nil).genServer(trojan, nil, client, ""))
 	if _, ok := settings["servers"]; ok {
 		t.Fatal("trojan outbound must not use servers array")
 	}
@@ -141,8 +141,89 @@ func TestSubJsonServiceServerFlattened(t *testing.T) {
 	}
 
 	ss := &model.Inbound{Listen: "1.2.3.4", Port: 443, Protocol: model.Shadowsocks, Settings: `{"method":"aes-256-gcm"}`}
-	ssSettings := outboundSettings(t, NewSubJsonService("", "", "", nil).genServer(ss, nil, client))
+	ssSettings := outboundSettings(t, NewSubJsonService("", "", "", nil).genServer(ss, nil, client, ""))
 	if ssSettings["method"] != "aes-256-gcm" {
 		t.Fatalf("flat shadowsocks must carry method: %#v", ssSettings)
+	}
+}
+
+func TestSubJsonServiceXmuxSuppressesGlobalMux(t *testing.T) {
+	globalMux := `{"enabled":true,"concurrency":8}`
+	svc := NewSubJsonService(globalMux, "", "", nil)
+
+	// When xmux is present in xhttpSettings, the per-inbound xmux handles
+	// multiplexing and the legacy outbound.Mux must NOT be set.
+	stream := `{"network":"xhttp","security":"tls","tlsSettings":{"serverName":"example.com"},"xhttpSettings":{"path":"/api","mode":"packet-up","xmux":{"maxConcurrency":"16-32"}}}`
+	parsed := svc.streamData(stream)
+
+	mux := globalMux
+	if xhttp, ok := parsed["xhttpSettings"].(map[string]any); ok {
+		if _, hasXmux := xhttp["xmux"]; hasXmux {
+			mux = ""
+		}
+	}
+
+	streamSettings, _ := json.Marshal(parsed)
+	inbound := &model.Inbound{Listen: "1.2.3.4", Port: 443, Protocol: model.VLESS, Settings: `{"encryption":"none"}`}
+	client := model.Client{ID: "uuid-1"}
+
+	raw := svc.genVless(inbound, streamSettings, client, mux)
+	var ob map[string]any
+	if err := json.Unmarshal(raw, &ob); err != nil {
+		t.Fatalf("unmarshal outbound: %v", err)
+	}
+	if _, has := ob["mux"]; has {
+		t.Fatal("outbound.Mux must NOT be set when per-inbound xmux is present")
+	}
+
+	// Verify xmux is still inside xhttpSettings in streamSettings.
+	ss, _ := ob["streamSettings"].(map[string]any)
+	if ss == nil {
+		t.Fatal("streamSettings missing from outbound")
+	}
+	xhttp, _ := ss["xhttpSettings"].(map[string]any)
+	if xhttp == nil {
+		t.Fatal("xhttpSettings missing from streamSettings")
+	}
+	xmux, _ := xhttp["xmux"].(map[string]any)
+	if xmux == nil {
+		t.Fatal("xmux missing from xhttpSettings — per-inbound xmux must survive streamData()")
+	}
+	if xmux["maxConcurrency"] != "16-32" {
+		t.Fatalf("xmux.maxConcurrency = %v, want 16-32", xmux["maxConcurrency"])
+	}
+}
+
+func TestSubJsonServiceGlobalMuxWhenNoXmux(t *testing.T) {
+	globalMux := `{"enabled":true,"concurrency":8}`
+	svc := NewSubJsonService(globalMux, "", "", nil)
+
+	// When no xmux is present, the global subJsonMux should be used.
+	stream := `{"network":"xhttp","security":"tls","tlsSettings":{"serverName":"example.com"},"xhttpSettings":{"path":"/api","mode":"packet-up"}}`
+	parsed := svc.streamData(stream)
+
+	mux := globalMux
+	if xhttp, ok := parsed["xhttpSettings"].(map[string]any); ok {
+		if _, hasXmux := xhttp["xmux"]; hasXmux {
+			mux = ""
+		}
+	}
+
+	streamSettings, _ := json.Marshal(parsed)
+	inbound := &model.Inbound{Listen: "1.2.3.4", Port: 443, Protocol: model.VLESS, Settings: `{"encryption":"none"}`}
+	client := model.Client{ID: "uuid-1"}
+
+	raw := svc.genVless(inbound, streamSettings, client, mux)
+	var ob map[string]any
+	if err := json.Unmarshal(raw, &ob); err != nil {
+		t.Fatalf("unmarshal outbound: %v", err)
+	}
+	m, has := ob["mux"]
+	if !has {
+		t.Fatal("outbound.Mux must be set when global subJsonMux is configured and no per-inbound xmux")
+	}
+	mm, _ := m.(map[string]any)
+	if mm["enabled"] != true || mm["concurrency"] != float64(8) {
+		t.Fatalf("mux payload wrong: %#v", m)
 	}
 }

--- a/internal/sub/mutation_audit_test.go
+++ b/internal/sub/mutation_audit_test.go
@@ -66,12 +66,12 @@ func TestSubJsonService_MuxAttachedWhenConfigured(t *testing.T) {
 		wantMux  bool
 		protocol model.Protocol
 	}{
-		{"vmess mux", NewSubJsonService(mux, "", "", nil).genVnext(&model.Inbound{Protocol: model.VMESS, Settings: `{}`}, nil, client), true, model.VMESS},
-		{"vless mux", NewSubJsonService(mux, "", "", nil).genVless(&model.Inbound{Protocol: model.VLESS, Settings: `{}`}, nil, client), true, model.VLESS},
-		{"server mux", NewSubJsonService(mux, "", "", nil).genServer(&model.Inbound{Protocol: model.Trojan, Settings: `{}`}, nil, client), true, model.Trojan},
-		{"vmess no mux", NewSubJsonService("", "", "", nil).genVnext(&model.Inbound{Protocol: model.VMESS, Settings: `{}`}, nil, client), false, model.VMESS},
-		{"vless no mux", NewSubJsonService("", "", "", nil).genVless(&model.Inbound{Protocol: model.VLESS, Settings: `{}`}, nil, client), false, model.VLESS},
-		{"server no mux", NewSubJsonService("", "", "", nil).genServer(&model.Inbound{Protocol: model.Trojan, Settings: `{}`}, nil, client), false, model.Trojan},
+		{"vmess mux", NewSubJsonService(mux, "", "", nil).genVnext(&model.Inbound{Protocol: model.VMESS, Settings: `{}`}, nil, client, mux), true, model.VMESS},
+		{"vless mux", NewSubJsonService(mux, "", "", nil).genVless(&model.Inbound{Protocol: model.VLESS, Settings: `{}`}, nil, client, mux), true, model.VLESS},
+		{"server mux", NewSubJsonService(mux, "", "", nil).genServer(&model.Inbound{Protocol: model.Trojan, Settings: `{}`}, nil, client, mux), true, model.Trojan},
+		{"vmess no mux", NewSubJsonService("", "", "", nil).genVnext(&model.Inbound{Protocol: model.VMESS, Settings: `{}`}, nil, client, ""), false, model.VMESS},
+		{"vless no mux", NewSubJsonService("", "", "", nil).genVless(&model.Inbound{Protocol: model.VLESS, Settings: `{}`}, nil, client, ""), false, model.VLESS},
+		{"server no mux", NewSubJsonService("", "", "", nil).genServer(&model.Inbound{Protocol: model.Trojan, Settings: `{}`}, nil, client, ""), false, model.Trojan},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {


### PR DESCRIPTION
## Summary

The Clash subscription generator (`clash_service.go`) only emitted `path`, `host`, `mode` in `xhttp-opts`. Mihomo supports ALL XHTTP parameters including padding, xmux (as `reuse-settings`), session/seq placement, and more.

This PR adds `buildXhttpClashOpts()` — an allowlist-based function that maps all client-relevant XHTTP fields from 3x-ui's camelCase JSON storage to Mihomo's kebab-case YAML format.

## Changes

### `internal/sub/clash_service.go`
- **New function `buildXhttpClashOpts()`** (lines 363-473): Converts `xhttpSettings` map to Mihomo-compatible `xhttp-opts` map
  - String field mapping with DPI default filtering (`scMaxEachPostBytes="1000000"`, `scMinPostsIntervalMs="30"`)
  - Bool fields (truthy only): `noGRPCHeader`, `xPaddingObfsMode`
  - Padding obfs gated fields: only emitted when `xPaddingObfsMode=true`
  - Nested `xmux` → `reuse-settings` with kebab-case sub-field mapping
  - Headers with case-insensitive Host key drop
  - Returns `nil` for empty opts (consistent with `buildXhttpExtra`)
- **Updated `applyTransport` xhttp case** (lines 547-554): Delegates to `buildXhttpClashOpts`

### `internal/sub/clash_service_test.go`
- **9 new test functions** (454 lines) covering:
  - `TestBuildXhttpClashOpts_FullFieldMapping` — every kebab-case key verified
  - `TestBuildXhttpClashOpts_DPIDefaultsFiltered` — DPI fingerprint defaults filtered
  - `TestBuildXhttpClashOpts_PaddingObfsGate` — false/absent/true-with-no-gated-fields
  - `TestBuildXhttpClashOpts_XmuxMapsToReuseSettings` — full mapping, empty, int/float64/zero hKeepAlivePeriod
  - `TestBuildXhttpClashOpts_ServerOnlyFieldsExcluded` — noSSEHeader, scMaxBufferedPosts, etc.
  - `TestBuildXhttpClashOpts_NilInput` / `_EmptyInput` — return nil
  - `TestBuildXhttpClashOpts_HostFallbackFromHeaders` — headers.Host, only-Host, case-insensitive drop
  - `TestBuildXhttpClashOpts_NoGRPCHeaderFalsey` — false and absent both produce no key

## Field Mapping (source-verified against Mihomo `adapter/outbound/vless.go`)

| 3x-ui (camelCase) | Mihomo (kebab-case) | Type | Filter |
|---|---|---|---|
| `path` | `path` | string | direct |
| `host` | `host` | string | direct + headers fallback |
| `mode` | `mode` | string | direct |
| `headers` | `headers` | map | drop Host key |
| `noGRPCHeader` | `no-grpc-header` | bool | truthy only |
| `xPaddingBytes` | `x-padding-bytes` | string | non-empty |
| `xPaddingObfsMode` | `x-padding-obfs-mode` | bool | truthy only |
| `xPaddingKey` | `x-padding-key` | string | non-empty, gated by obfs mode |
| `xPaddingHeader` | `x-padding-header` | string | non-empty, gated by obfs mode |
| `xPaddingPlacement` | `x-padding-placement` | string | non-empty, gated by obfs mode |
| `xPaddingMethod` | `x-padding-method` | string | non-empty, gated by obfs mode |
| `uplinkHTTPMethod` | `uplink-http-method` | string | non-empty |
| `sessionPlacement` | `session-placement` | string | non-empty |
| `sessionKey` | `session-key` | string | non-empty |
| `seqPlacement` | `seq-placement` | string | non-empty |
| `seqKey` | `seq-key` | string | non-empty |
| `uplinkDataPlacement` | `uplink-data-placement` | string | non-empty |
| `uplinkDataKey` | `uplink-data-key` | string | non-empty |
| `uplinkChunkSize` | `uplink-chunk-size` | string | non-zero |
| `scMaxEachPostBytes` | `sc-max-each-post-bytes` | string | non-empty, filter "1000000" |
| `scMinPostsIntervalMs` | `sc-min-posts-interval-ms` | string | non-empty, filter "30" |
| `xmux` | `reuse-settings` | nested | non-empty object |

### XMUX → reuse-settings sub-fields
| `maxConcurrency` | `max-concurrency` | string | non-empty |
| `maxConnections` | `max-connections` | string | non-empty |
| `cMaxReuseTimes` | `c-max-reuse-times` | string | non-empty |
| `hMaxRequestTimes` | `h-max-request-times` | string | non-empty |
| `hMaxReusableSecs` | `h-max-reusable-secs` | string | non-empty |
| `hKeepAlivePeriod` | `h-keep-alive-period` | int | non-zero |

### Server-only fields (EXCLUDED — not in allowlist)
- `noSSEHeader`, `scMaxBufferedPosts`, `scStreamUpServerSecs`, `serverMaxHeaderBytes`

### Deferred to follow-up PR
- `downloadSettings` → `download-settings` (complex nested structure)

## Testing

- All 15 test cases pass (9 functions with sub-tests)
- Existing `TestApplyTransport_XHTTP` and `TestApplyTransport_XHTTP_HostFromHeaders` still pass
- Tested locally with Mihomo v1.19.27 — connection successful, all XHTTP fields accepted

## Related

- Builds on #5393 (JSON subscription XHTTP client fields fix)
- Mihomo XHTTP field names verified against source code (`adapter/outbound/vless.go` struct tags)