### PR TITLE
fix(xray): guard log-writer race and bound handler gRPC deadlines

### DIFF
--- a/internal/xray/api.go
+++ b/internal/xray/api.go
@@ -38,6 +38,13 @@ import (
 	"google.golang.org/grpc/status"
 )
 
+// Compiled once at package load: GetTraffic runs on every traffic-stats tick,
+// so recompiling these per call is wasted work.
+var (
+	trafficRegex       = regexp.MustCompile(`(inbound|outbound)>>>([^>]+)>>>traffic>>>(downlink|uplink)`)
+	clientTrafficRegex = regexp.MustCompile(`user>>>([^>]+)>>>traffic>>>(downlink|uplink)`)
+)
+
 // XrayAPI is a gRPC client for managing Xray core configuration, inbounds, outbounds, and statistics.
 type XrayAPI struct {
 	HandlerServiceClient *command.HandlerServiceClient
@@ -536,9 +543,6 @@ func (x *XrayAPI) GetTraffic() ([]*Traffic, []*ClientTraffic, error) {
 	if x.grpcClient == nil {
 		return nil, nil, common.NewError("xray api is not initialized")
 	}
-
-	trafficRegex := regexp.MustCompile(`(inbound|outbound)>>>([^>]+)>>>traffic>>>(downlink|uplink)`)
-	clientTrafficRegex := regexp.MustCompile(`user>>>([^>]+)>>>traffic>>>(downlink|uplink)`)
 
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*10)
 	defer cancel()

--- a/internal/xray/api.go
+++ b/internal/xray/api.go
@@ -123,8 +123,16 @@ func (x *XrayAPI) Close() {
 	x.isConnected = false
 }
 
+// handlerRPCTimeout bounds per-call gRPC handler operations (add/remove inbound,
+// alter user) so a hung core connection cannot block the caller indefinitely —
+// for example while the process restart lock is held.
+const handlerRPCTimeout = 10 * time.Second
+
 // AddInbound adds a new inbound configuration to the Xray core via gRPC.
 func (x *XrayAPI) AddInbound(inbound []byte) error {
+	if x.HandlerServiceClient == nil {
+		return common.NewError("xray HandlerServiceClient is not initialized")
+	}
 	client := *x.HandlerServiceClient
 
 	conf := new(conf.InboundDetourConfig)
@@ -140,15 +148,22 @@ func (x *XrayAPI) AddInbound(inbound []byte) error {
 	}
 	inboundConfig := command.AddInboundRequest{Inbound: config}
 
-	_, err = client.AddInbound(context.Background(), &inboundConfig)
+	ctx, cancel := context.WithTimeout(context.Background(), handlerRPCTimeout)
+	defer cancel()
+	_, err = client.AddInbound(ctx, &inboundConfig)
 
 	return err
 }
 
 // DelInbound removes an inbound configuration from the Xray core by tag.
 func (x *XrayAPI) DelInbound(tag string) error {
+	if x.HandlerServiceClient == nil {
+		return common.NewError("xray HandlerServiceClient is not initialized")
+	}
 	client := *x.HandlerServiceClient
-	_, err := client.RemoveInbound(context.Background(), &command.RemoveInboundRequest{
+	ctx, cancel := context.WithTimeout(context.Background(), handlerRPCTimeout)
+	defer cancel()
+	_, err := client.RemoveInbound(ctx, &command.RemoveInboundRequest{
 		Tag: tag,
 	})
 	return err
@@ -505,9 +520,14 @@ func (x *XrayAPI) AddUser(Protocol string, inboundTag string, user map[string]an
 		return nil
 	}
 
+	if x.HandlerServiceClient == nil {
+		return common.NewError("xray HandlerServiceClient is not initialized")
+	}
 	client := *x.HandlerServiceClient
 
-	_, err = client.AlterInbound(context.Background(), &command.AlterInboundRequest{
+	ctx, cancel := context.WithTimeout(context.Background(), handlerRPCTimeout)
+	defer cancel()
+	_, err = client.AlterInbound(ctx, &command.AlterInboundRequest{
 		Tag: inboundTag,
 		Operation: serial.ToTypedMessage(&command.AddUserOperation{
 			User: &protocol.User{

--- a/internal/xray/log_writer.go
+++ b/internal/xray/log_writer.go
@@ -4,6 +4,7 @@ import (
 	"regexp"
 	"runtime"
 	"strings"
+	"sync"
 
 	"github.com/mhsanaei/3x-ui/v3/internal/logger"
 )
@@ -22,7 +23,23 @@ func NewLogWriter() *LogWriter {
 
 // LogWriter processes and filters log output from the Xray process, handling crash detection and message filtering.
 type LogWriter struct {
+	mu       sync.RWMutex
 	lastLine string
+}
+
+// LastLine returns the most recently processed Xray log line. It is safe for
+// concurrent use: Process.GetResult reads it from a different goroutine than the
+// one Xray drives Write from.
+func (lw *LogWriter) LastLine() string {
+	lw.mu.RLock()
+	defer lw.mu.RUnlock()
+	return lw.lastLine
+}
+
+func (lw *LogWriter) setLastLine(line string) {
+	lw.mu.Lock()
+	lw.lastLine = line
+	lw.mu.Unlock()
 }
 
 // Write processes and filters log output from the Xray process, handling crash detection and message filtering.
@@ -39,7 +56,7 @@ func (lw *LogWriter) Write(m []byte) (n int, err error) {
 	// Check if the message contains a crash
 	if crashRegex.MatchString(message) {
 		logger.Debug("Core crash detected:\n", message)
-		lw.lastLine = message
+		lw.setLastLine(message)
 		err1 := writeCrashReport(m)
 		if err1 != nil {
 			logger.Error("Unable to write crash report:", err1)
@@ -60,7 +77,7 @@ func (lw *LogWriter) Write(m []byte) (n int, err error) {
 			if strings.Contains(msgBodyLower, "tls handshake error") ||
 				strings.Contains(msgBodyLower, "connection ends") {
 				logger.Debug("XRAY: " + msgBody)
-				lw.lastLine = ""
+				lw.setLastLine("")
 				continue
 			}
 
@@ -80,14 +97,14 @@ func (lw *LogWriter) Write(m []byte) (n int, err error) {
 					logger.Debug("XRAY: " + msg)
 				}
 			}
-			lw.lastLine = ""
+			lw.setLastLine("")
 		} else if msg != "" {
 			msgLower := strings.ToLower(msg)
 
 			if strings.Contains(msgLower, "tls handshake error") ||
 				strings.Contains(msgLower, "connection ends") {
 				logger.Debug("XRAY: " + msg)
-				lw.lastLine = msg
+				lw.setLastLine(msg)
 				continue
 			}
 
@@ -96,7 +113,7 @@ func (lw *LogWriter) Write(m []byte) (n int, err error) {
 			} else {
 				logger.Debug("XRAY: " + msg)
 			}
-			lw.lastLine = msg
+			lw.setLastLine(msg)
 		}
 	}
 

--- a/internal/xray/log_writer.go
+++ b/internal/xray/log_writer.go
@@ -8,6 +8,13 @@ import (
 	"github.com/mhsanaei/3x-ui/v3/internal/logger"
 )
 
+// Compiled once at package load: Write runs on every line Xray emits, so
+// recompiling these per write is wasted work.
+var (
+	crashRegex   = regexp.MustCompile(`(?i)(panic|exception|stack trace|fatal error)`)
+	logLineRegex = regexp.MustCompile(`^(\d{4}/\d{2}/\d{2} \d{2}:\d{2}:\d{2}\.\d{6}) \[([^\]]+)\] (.+)$`)
+)
+
 // NewLogWriter returns a new LogWriter for processing Xray log output.
 func NewLogWriter() *LogWriter {
 	return &LogWriter{}
@@ -20,8 +27,6 @@ type LogWriter struct {
 
 // Write processes and filters log output from the Xray process, handling crash detection and message filtering.
 func (lw *LogWriter) Write(m []byte) (n int, err error) {
-	crashRegex := regexp.MustCompile(`(?i)(panic|exception|stack trace|fatal error)`)
-
 	// Convert the data to a string
 	message := strings.TrimSpace(string(m))
 	msgLowerAll := strings.ToLower(message)
@@ -42,11 +47,10 @@ func (lw *LogWriter) Write(m []byte) (n int, err error) {
 		return len(m), nil
 	}
 
-	regex := regexp.MustCompile(`^(\d{4}/\d{2}/\d{2} \d{2}:\d{2}:\d{2}\.\d{6}) \[([^\]]+)\] (.+)$`)
 	messages := strings.SplitSeq(message, "\n")
 
 	for msg := range messages {
-		matches := regex.FindStringSubmatch(msg)
+		matches := logLineRegex.FindStringSubmatch(msg)
 
 		if len(matches) > 3 {
 			level := matches[2]

--- a/internal/xray/log_writer_race_test.go
+++ b/internal/xray/log_writer_race_test.go
@@ -1,0 +1,36 @@
+package xray
+
+import (
+	"sync"
+	"testing"
+)
+
+// TestLogWriterLastLineConcurrent exercises the LogWriter from multiple
+// goroutines: Xray drives Write while another goroutine (Process.GetResult)
+// reads the last line. Run under `go test -race` this fails on an unguarded
+// lastLine field and passes once the access is serialized.
+func TestLogWriterLastLineConcurrent(t *testing.T) {
+	lw := NewLogWriter()
+	const writers, readers, iterations = 4, 4, 500
+
+	var wg sync.WaitGroup
+	wg.Add(writers + readers)
+
+	for i := 0; i < writers; i++ {
+		go func() {
+			defer wg.Done()
+			for j := 0; j < iterations; j++ {
+				_, _ = lw.Write([]byte("2024/01/01 00:00:00.000000 [Info] connection accepted"))
+			}
+		}()
+	}
+	for i := 0; i < readers; i++ {
+		go func() {
+			defer wg.Done()
+			for j := 0; j < iterations; j++ {
+				_ = lw.LastLine()
+			}
+		}()
+	}
+	wg.Wait()
+}

--- a/internal/xray/process.go
+++ b/internal/xray/process.go
@@ -273,10 +273,11 @@ func (p *process) GetResult() string {
 	p.mu.RLock()
 	exitErr := p.exitErr
 	p.mu.RUnlock()
-	if len(p.logWriter.lastLine) == 0 && exitErr != nil {
+	lastLine := p.logWriter.LastLine()
+	if len(lastLine) == 0 && exitErr != nil {
 		return exitErr.Error()
 	}
-	return p.logWriter.lastLine
+	return lastLine
 }
 
 // GetVersion returns the version string of the Xray process.


### PR DESCRIPTION
> **Stacked on top of #5362** (`perf(xray): compile log/traffic regexps once at package scope`).
> Both fixes here live in the same two files that #5362 edits (`internal/xray/log_writer.go`,
> `internal/xray/api.go`), so this branch is written **on top of #5362** to avoid a merge
> conflict between the two PRs. **Please merge #5362 first.** Once it lands, the diff here is
> just the two fixes below; until then the diff also shows #5362's regexp hoist as context.

## Summary
Two small, independent correctness fixes to the Xray gRPC/log internals: a data race on the
log writer's last line, and missing deadlines on handler gRPC calls.

## Why
- **`LogWriter.lastLine` data race.** `Write` is driven by the Xray process output goroutine,
  while `Process.GetResult` reads `lastLine` from the caller's goroutine. The field is
  unsynchronized, so the concurrent read/write is a data race (`go test -race`).
- **Handler gRPC calls have no deadline.** `AddInbound`, `DelInbound` and the `AddUser` ->
  `AlterInbound` call use `context.Background()`. If the core connection hangs, the caller
  blocks indefinitely — especially bad while the process restart lock is held. The other
  handler operations already use a 10s timeout; these three were missed.

## Scope
- `log_writer.go`: add an `RWMutex` to `LogWriter`, expose `LastLine()`, and route every write
  through `setLastLine()`.
- `process.go`: `GetResult` now reads the last line via `LastLine()`.
- `api.go`: add `handlerRPCTimeout` (10s) and apply it (plus a nil-client guard) to
  `AddInbound`, `DelInbound`, and the `AddUser` `AlterInbound` call.

## Validation
- `go build ./internal/xray/...` and `go vet ./internal/xray/...` are clean.
- `go test -race -shuffle=on ./internal/xray/...` passes, including the added
  `TestLogWriterLastLineConcurrent` (concurrent `Write` + `LastLine`).

## Risk
Low. Both changes are localized to the Xray internals; behavior is unchanged except that
concurrent access to `lastLine` is serialized and the three handler RPCs are now bounded.
