### PR TITLE
feat(wireguard): manage WireGuard peers as clients on the Clients tab

### DIFF
--- a/frontend/public/openapi.json
+++ b/frontend/public/openapi.json
@@ -3255,6 +3255,198 @@
         }
       }
     },
+    "/panel/api/inbounds/{id}/addWgClient": {
+      "post": {
+        "tags": [
+          "Inbounds"
+        ],
+        "summary": "Add a WireGuard peer to an existing WireGuard inbound. Creates a client record, attaches it to the inbound, and hot-reloads the inbound in xray.",
+        "operationId": "post_panel_api_inbounds_id_addWgClient",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "description": "WireGuard inbound ID.",
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object"
+              },
+              "example": {
+                "email": "peer1",
+                "password": "<private-key>",
+                "wgSettings": {
+                  "publicKey": "<public-key>",
+                  "allowedIPs": [
+                    "10.0.0.2/32"
+                  ],
+                  "preSharedKey": "",
+                  "keepAlive": 0
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean"
+                    },
+                    "msg": {
+                      "type": "string"
+                    },
+                    "obj": {}
+                  }
+                },
+                "example": {
+                  "success": true
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/panel/api/inbounds/{id}/updateWgClient": {
+      "post": {
+        "tags": [
+          "Inbounds"
+        ],
+        "summary": "Update a WireGuard peer on an existing WireGuard inbound. Identifies the peer by email, updates its record and wg_settings, and hot-reloads the inbound in xray.",
+        "operationId": "post_panel_api_inbounds_id_updateWgClient",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "description": "WireGuard inbound ID.",
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "name": "email",
+            "in": "query",
+            "required": true,
+            "description": "Current email (name) of the peer to update.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object"
+              },
+              "example": {
+                "email": "peer1-renamed",
+                "enable": true,
+                "wgSettings": {
+                  "publicKey": "<public-key>",
+                  "allowedIPs": [
+                    "10.0.0.2/32"
+                  ]
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean"
+                    },
+                    "msg": {
+                      "type": "string"
+                    },
+                    "obj": {}
+                  }
+                },
+                "example": {
+                  "success": true
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/panel/api/inbounds/{id}/delWgClient": {
+      "post": {
+        "tags": [
+          "Inbounds"
+        ],
+        "summary": "Remove a WireGuard peer from an inbound by email. Deletes the client record, removes the peer from settings.peers[], and hot-reloads the inbound in xray.",
+        "operationId": "post_panel_api_inbounds_id_delWgClient",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "description": "WireGuard inbound ID.",
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "name": "email",
+            "in": "query",
+            "required": true,
+            "description": "Email (name) of the peer to delete.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean"
+                    },
+                    "msg": {
+                      "type": "string"
+                    },
+                    "obj": {}
+                  }
+                },
+                "example": {
+                  "success": true
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/panel/api/server/status": {
       "get": {
         "tags": [

--- a/frontend/public/openapi.json
+++ b/frontend/public/openapi.json
@@ -1077,7 +1077,7 @@
             "type": "integer"
           },
           "password": {
-            "description": "Client password",
+            "description": "Client password (WireGuard: private key)",
             "type": "string"
           },
           "reset": {
@@ -1112,6 +1112,15 @@
           "updated_at": {
             "description": "Last update timestamp",
             "type": "integer"
+          },
+          "wgPeer": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/WgPeerSettings"
+              }
+            ],
+            "description": "WireGuard peer settings (nil for non-WG clients)",
+            "nullable": true
           }
         },
         "required": [
@@ -1760,6 +1769,10 @@
           "tlsFlowCapable": {
             "example": true,
             "type": "boolean"
+          },
+          "wgPublicKey": {
+            "description": "WireGuard server public key; only set for wireguard inbounds.",
+            "type": "string"
           }
         },
         "required": [
@@ -2125,6 +2138,31 @@
           "id",
           "password",
           "username"
+        ],
+        "type": "object"
+      },
+      "WgPeerSettings": {
+        "description": "WgPeerSettings holds WireGuard-specific peer configuration stored as JSON in the clients table.",
+        "properties": {
+          "allowedIPs": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "keepAlive": {
+            "type": "integer"
+          },
+          "preSharedKey": {
+            "type": "string"
+          },
+          "publicKey": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "allowedIPs",
+          "publicKey"
         ],
         "type": "object"
       }
@@ -2549,7 +2587,8 @@
                       "remark": "VLESS-443",
                       "ssMethod": "",
                       "tag": "in-443-tcp",
-                      "tlsFlowCapable": true
+                      "tlsFlowCapable": true,
+                      "wgPublicKey": ""
                     }
                   ]
                 }

--- a/frontend/src/generated/examples.ts
+++ b/frontend/src/generated/examples.ts
@@ -221,7 +221,8 @@ export const EXAMPLES: Record<string, unknown> = {
     "subId": "",
     "tgId": 0,
     "totalGB": 0,
-    "updated_at": 0
+    "updated_at": 0,
+    "wgPeer": null
   },
   "ClientInbound": {
     "clientId": 0,
@@ -384,7 +385,8 @@ export const EXAMPLES: Record<string, unknown> = {
     "remark": "VLESS-443",
     "ssMethod": "",
     "tag": "in-443-tcp",
-    "tlsFlowCapable": true
+    "tlsFlowCapable": true,
+    "wgPublicKey": ""
   },
   "Msg": {
     "msg": "",
@@ -462,5 +464,13 @@ export const EXAMPLES: Record<string, unknown> = {
     "id": 0,
     "password": "",
     "username": ""
+  },
+  "WgPeerSettings": {
+    "allowedIPs": [
+      ""
+    ],
+    "keepAlive": 0,
+    "preSharedKey": "",
+    "publicKey": ""
   }
 };

--- a/frontend/src/generated/schemas.ts
+++ b/frontend/src/generated/schemas.ts
@@ -1051,7 +1051,7 @@ export const SCHEMAS: Record<string, unknown> = {
         "type": "integer"
       },
       "password": {
-        "description": "Client password",
+        "description": "Client password (WireGuard: private key)",
         "type": "string"
       },
       "reset": {
@@ -1086,6 +1086,15 @@ export const SCHEMAS: Record<string, unknown> = {
       "updated_at": {
         "description": "Last update timestamp",
         "type": "integer"
+      },
+      "wgPeer": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/WgPeerSettings"
+          }
+        ],
+        "description": "WireGuard peer settings (nil for non-WG clients)",
+        "nullable": true
       }
     },
     "required": [
@@ -1734,6 +1743,10 @@ export const SCHEMAS: Record<string, unknown> = {
       "tlsFlowCapable": {
         "example": true,
         "type": "boolean"
+      },
+      "wgPublicKey": {
+        "description": "WireGuard server public key; only set for wireguard inbounds.",
+        "type": "string"
       }
     },
     "required": [
@@ -2099,6 +2112,31 @@ export const SCHEMAS: Record<string, unknown> = {
       "id",
       "password",
       "username"
+    ],
+    "type": "object"
+  },
+  "WgPeerSettings": {
+    "description": "WgPeerSettings holds WireGuard-specific peer configuration stored as JSON in the clients table.",
+    "properties": {
+      "allowedIPs": {
+        "items": {
+          "type": "string"
+        },
+        "type": "array"
+      },
+      "keepAlive": {
+        "type": "integer"
+      },
+      "preSharedKey": {
+        "type": "string"
+      },
+      "publicKey": {
+        "type": "string"
+      }
+    },
+    "required": [
+      "allowedIPs",
+      "publicKey"
     ],
     "type": "object"
   }

--- a/frontend/src/generated/types.ts
+++ b/frontend/src/generated/types.ts
@@ -232,6 +232,7 @@ export interface Client {
   tgId: number;
   totalGB: number;
   updated_at?: number;
+  wgPeer?: WgPeerSettings | null;
 }
 
 export interface ClientInbound {
@@ -381,6 +382,7 @@ export interface InboundOption {
   ssMethod: string;
   tag: string;
   tlsFlowCapable: boolean;
+  wgPublicKey?: string;
 }
 
 export interface Msg {
@@ -462,5 +464,12 @@ export interface User {
   id: number;
   password: string;
   username: string;
+}
+
+export interface WgPeerSettings {
+  allowedIPs: string[];
+  keepAlive?: number;
+  preSharedKey?: string;
+  publicKey: string;
 }
 

--- a/frontend/src/generated/zod.ts
+++ b/frontend/src/generated/zod.ts
@@ -248,6 +248,7 @@ export const ClientSchema = z.object({
   tgId: z.number().int(),
   totalGB: z.number().int(),
   updated_at: z.number().int().optional(),
+  wgPeer: z.lazy(() => WgPeerSettingsSchema).nullable().optional(),
 });
 export type Client = z.infer<typeof ClientSchema>;
 
@@ -408,6 +409,7 @@ export const InboundOptionSchema = z.object({
   ssMethod: z.string(),
   tag: z.string(),
   tlsFlowCapable: z.boolean(),
+  wgPublicKey: z.string().optional(),
 });
 export type InboundOption = z.infer<typeof InboundOptionSchema>;
 
@@ -497,4 +499,12 @@ export const UserSchema = z.object({
   username: z.string(),
 });
 export type User = z.infer<typeof UserSchema>;
+
+export const WgPeerSettingsSchema = z.object({
+  allowedIPs: z.array(z.string()),
+  keepAlive: z.number().int().optional(),
+  preSharedKey: z.string().optional(),
+  publicKey: z.string(),
+});
+export type WgPeerSettings = z.infer<typeof WgPeerSettingsSchema>;
 

--- a/frontend/src/hooks/useClients.ts
+++ b/frontend/src/hooks/useClients.ts
@@ -485,6 +485,9 @@ export function useClients() {
     if (base.reverse?.tag) {
       payload.reverse = { tag: base.reverse.tag };
     }
+    if (base.wgPeer) {
+      payload.wgPeer = base.wgPeer;
+    }
     return update(client.email, payload);
   }, [hydrate, update]);
 

--- a/frontend/src/pages/api-docs/endpoints.ts
+++ b/frontend/src/pages/api-docs/endpoints.ts
@@ -237,6 +237,37 @@ export const sections: readonly Section[] = [
         body: '{\n  "fallbacks": [\n    { "childId": 11, "path": "/vlws", "xver": 2 },\n    { "childId": 12, "alpn": "h2", "dest": "8443" }\n  ]\n}',
         response: '{\n  "success": true,\n  "msg": "Inbound updated"\n}',
       },
+      {
+        method: 'POST',
+        path: '/panel/api/inbounds/:id/addWgClient',
+        summary: 'Add a WireGuard peer to an existing WireGuard inbound. Creates a client record, attaches it to the inbound, and hot-reloads the inbound in xray.',
+        params: [
+          { name: 'id', in: 'path', type: 'number', desc: 'WireGuard inbound ID.' },
+        ],
+        body: '{\n  "email": "peer1",\n  "password": "<private-key>",\n  "wgSettings": {\n    "publicKey": "<public-key>",\n    "allowedIPs": ["10.0.0.2/32"],\n    "preSharedKey": "",\n    "keepAlive": 0\n  }\n}',
+        response: '{\n  "success": true\n}',
+      },
+      {
+        method: 'POST',
+        path: '/panel/api/inbounds/:id/updateWgClient',
+        summary: 'Update a WireGuard peer on an existing WireGuard inbound. Identifies the peer by email, updates its record and wg_settings, and hot-reloads the inbound in xray.',
+        params: [
+          { name: 'id', in: 'path', type: 'number', desc: 'WireGuard inbound ID.' },
+          { name: 'email', in: 'query', type: 'string', desc: 'Current email (name) of the peer to update.' },
+        ],
+        body: '{\n  "email": "peer1-renamed",\n  "enable": true,\n  "wgSettings": {\n    "publicKey": "<public-key>",\n    "allowedIPs": ["10.0.0.2/32"]\n  }\n}',
+        response: '{\n  "success": true\n}',
+      },
+      {
+        method: 'POST',
+        path: '/panel/api/inbounds/:id/delWgClient',
+        summary: 'Remove a WireGuard peer from an inbound by email. Deletes the client record, removes the peer from settings.peers[], and hot-reloads the inbound in xray.',
+        params: [
+          { name: 'id', in: 'path', type: 'number', desc: 'WireGuard inbound ID.' },
+          { name: 'email', in: 'query', type: 'string', desc: 'Email (name) of the peer to delete.' },
+        ],
+        response: '{\n  "success": true\n}',
+      },
     ],
   },
 

--- a/frontend/src/pages/clients/ClientFormModal.tsx
+++ b/frontend/src/pages/clients/ClientFormModal.tsx
@@ -913,7 +913,7 @@ export default function ClientFormModal({
                   </div>
                 ),
               }] : []),
-              {
+              ...(!showWireGuard ? [{
                 key: 'links',
                 label: t('pages.clients.tabLinks'),
                 children: (
@@ -963,7 +963,7 @@ export default function ClientFormModal({
                     </div>
                   </>
                 ),
-              },
+              }] : []),
             ]}
           />
         </Form>

--- a/frontend/src/pages/clients/ClientFormModal.tsx
+++ b/frontend/src/pages/clients/ClientFormModal.tsx
@@ -19,10 +19,10 @@ import {
   Typography,
   message,
 } from 'antd';
-import { DeleteOutlined, EyeOutlined, PlusOutlined, ReloadOutlined, RetweetOutlined } from '@ant-design/icons';
+import { CopyOutlined, DeleteOutlined, DownloadOutlined, EyeOutlined, PlusOutlined, ReloadOutlined, RetweetOutlined } from '@ant-design/icons';
 import dayjs from 'dayjs';
 import type { Dayjs } from 'dayjs';
-import { HttpUtil, RandomUtil, Wireguard } from '@/utils';
+import { ClipboardManager, FileManager, HttpUtil, RandomUtil, Wireguard } from '@/utils';
 import { formatInboundLabel } from '@/lib/inbounds/label';
 import { normalizeClientIps, type ClientIpInfo } from '@/lib/clients/ip-log';
 import { DateTimePicker, SelectAllClearButtons } from '@/components/form';
@@ -346,6 +346,32 @@ export default function ClientFormModal({
     () => (form.inboundIds || []).find((id) => wgIds.has(id)) ?? null,
     [form.inboundIds, wgIds],
   );
+
+  const wgInbound = useMemo(
+    () => firstWgInboundId != null ? inbounds.find((ib) => ib.id === firstWgInboundId) : undefined,
+    [firstWgInboundId, inbounds],
+  );
+
+  const wgConfigText = useMemo(() => {
+    if (!showWireGuard) return '';
+    const serverPubKey = wgInbound?.wgPublicKey || '';
+    const endpoint = `${window.location.hostname}:${wgInbound?.port || ''}`;
+    const address = (form.wgPeer.allowedIPs || []).filter(Boolean).join(', ') || '10.0.0.2/32';
+    const lines = [
+      '[Interface]',
+      `PrivateKey = ${form.wgPeer.privateKey || ''}`,
+      `Address = ${address}`,
+      'DNS = 8.8.8.8',
+      '',
+      '[Peer]',
+      `PublicKey = ${serverPubKey}`,
+      'AllowedIPs = 0.0.0.0/0, ::/0',
+      `Endpoint = ${endpoint}`,
+    ];
+    if (form.wgPeer.preSharedKey) lines.push(`PresharedKey = ${form.wgPeer.preSharedKey}`);
+    if (form.wgPeer.keepAlive > 0) lines.push(`PersistentKeepalive = ${form.wgPeer.keepAlive}`);
+    return lines.join('\n');
+  }, [showWireGuard, wgInbound, form.wgPeer]);
 
   // When a WG inbound is selected in add mode, suggest the next available IP.
   useEffect(() => {
@@ -858,6 +884,35 @@ export default function ClientFormModal({
                   </>
                 ),
               },
+              ...(showWireGuard ? [{
+                key: 'wgconf',
+                label: 'Config',
+                children: (
+                  <div>
+                    <div style={{ display: 'flex', justifyContent: 'flex-end', gap: 8, marginBottom: 8 }}>
+                      <Tooltip title={t('copy')}>
+                        <Button size="small" icon={<CopyOutlined />} onClick={() => ClipboardManager.copyText(wgConfigText)} />
+                      </Tooltip>
+                      <Tooltip title={t('download')}>
+                        <Button size="small" icon={<DownloadOutlined />} onClick={() => FileManager.downloadTextFile(wgConfigText, `${form.email}.conf`)} />
+                      </Tooltip>
+                    </div>
+                    <pre style={{
+                      background: 'var(--ant-color-fill-quaternary, #f5f5f5)',
+                      borderRadius: 6,
+                      padding: '10px 14px',
+                      margin: 0,
+                      fontSize: 13,
+                      lineHeight: 1.6,
+                      overflowX: 'auto',
+                      whiteSpace: 'pre',
+                      userSelect: 'all',
+                    }}>
+                      {wgConfigText}
+                    </pre>
+                  </div>
+                ),
+              }] : []),
               {
                 key: 'links',
                 label: t('pages.clients.tabLinks'),

--- a/frontend/src/pages/clients/ClientFormModal.tsx
+++ b/frontend/src/pages/clients/ClientFormModal.tsx
@@ -83,6 +83,7 @@ interface ClientFormModalProps {
   attachedIds?: number[];
   tgBotEnable?: boolean;
   groups?: string[];
+  getNextWgAllowedIp?: (inboundId: number) => string;
   save: (
     payload: Record<string, unknown> | SaveCreatePayload,
     meta: SaveMetaEdit | SaveMetaCreate,
@@ -181,6 +182,7 @@ export default function ClientFormModal({
   attachedIds = [],
   tgBotEnable = false,
   groups = [],
+  getNextWgAllowedIp,
   save,
   resetTraffic,
   onOpenChange,
@@ -339,6 +341,19 @@ export default function ClientFormModal({
     () => (form.inboundIds || []).some((id) => wgIds.has(id)),
     [form.inboundIds, wgIds],
   );
+
+  const firstWgInboundId = useMemo(
+    () => (form.inboundIds || []).find((id) => wgIds.has(id)) ?? null,
+    [form.inboundIds, wgIds],
+  );
+
+  // When a WG inbound is selected in add mode, suggest the next available IP.
+  useEffect(() => {
+    if (isEdit || !showWireGuard || firstWgInboundId === null || !getNextWgAllowedIp) return;
+    const nextIp = getNextWgAllowedIp(firstWgInboundId);
+    setForm((prev) => ({ ...prev, wgPeer: { ...prev.wgPeer, allowedIPs: [nextIp] } }));
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [showWireGuard, firstWgInboundId]);
 
   const showFlow = useMemo(
     () => (form.inboundIds || []).some((id) => flowCapableIds.has(id)),

--- a/frontend/src/pages/clients/ClientFormModal.tsx
+++ b/frontend/src/pages/clients/ClientFormModal.tsx
@@ -22,7 +22,7 @@ import {
 import { DeleteOutlined, EyeOutlined, PlusOutlined, ReloadOutlined, RetweetOutlined } from '@ant-design/icons';
 import dayjs from 'dayjs';
 import type { Dayjs } from 'dayjs';
-import { HttpUtil, RandomUtil } from '@/utils';
+import { HttpUtil, RandomUtil, Wireguard } from '@/utils';
 import { formatInboundLabel } from '@/lib/inbounds/label';
 import { normalizeClientIps, type ClientIpInfo } from '@/lib/clients/ip-log';
 import { DateTimePicker, SelectAllClearButtons } from '@/components/form';
@@ -34,7 +34,7 @@ const FLOW_OPTIONS = Object.values(TLS_FLOW_CONTROL);
 const VMESS_SECURITY_OPTIONS = ['auto', 'aes-128-gcm', 'chacha20-poly1305', 'none', 'zero'] as const;
 
 const MULTI_CLIENT_PROTOCOLS = new Set([
-  'shadowsocks', 'vless', 'vmess', 'trojan', 'hysteria',
+  'shadowsocks', 'vless', 'vmess', 'trojan', 'hysteria', 'wireguard',
 ]);
 
 const CLIENT_FORM_MODAL_Z_INDEX = 1000;
@@ -91,6 +91,14 @@ interface ClientFormModalProps {
   onOpenChange: (open: boolean) => void;
 }
 
+interface WgPeerForm {
+  publicKey: string;
+  privateKey: string;
+  preSharedKey: string;
+  allowedIPs: string[];
+  keepAlive: number;
+}
+
 interface FormState {
   email: string;
   subId: string;
@@ -112,6 +120,11 @@ interface FormState {
   enable: boolean;
   inboundIds: number[];
   externalLinks: ExternalLinkRow[];
+  wgPeer: WgPeerForm;
+}
+
+function emptyWgPeer(): WgPeerForm {
+  return { publicKey: '', privateKey: '', preSharedKey: '', allowedIPs: ['10.0.0.2/32'], keepAlive: 0 };
 }
 
 function emptyForm(): FormState {
@@ -136,6 +149,7 @@ function emptyForm(): FormState {
     enable: true,
     inboundIds: [],
     externalLinks: [],
+    wgPeer: emptyWgPeer(),
   };
 }
 
@@ -214,6 +228,7 @@ export default function ClientFormModal({
 
     if (isEdit && client) {
       const et = Number(client.expiryTime) || 0;
+      const wg = client.wgPeer;
       const next: FormState = {
         ...emptyForm(),
         email: client.email || '',
@@ -233,6 +248,9 @@ export default function ClientFormModal({
         enable: !!client.enable,
         inboundIds: Array.isArray(attachedIds) ? [...attachedIds] : [],
         externalLinks: toExternalLinkRows(attachedExternalLinks),
+        wgPeer: wg
+          ? { publicKey: wg.publicKey || '', privateKey: client.password || '', preSharedKey: wg.preSharedKey || '', allowedIPs: wg.allowedIPs ?? ['10.0.0.2/32'], keepAlive: wg.keepAlive ?? 0 }
+          : emptyWgPeer(),
       };
       if (et < 0) {
         next.delayedStart = true;
@@ -246,6 +264,7 @@ export default function ClientFormModal({
       setForm(next);
       void loadIps();
     } else {
+      const kp = Wireguard.generateKeypair();
       setForm({
         ...emptyForm(),
         email: RandomUtil.randomLowerAndNum(10),
@@ -253,6 +272,7 @@ export default function ClientFormModal({
         subId: RandomUtil.randomLowerAndNum(16),
         password: RandomUtil.randomLowerAndNum(16),
         auth: RandomUtil.randomLowerAndNum(16),
+        wgPeer: { publicKey: kp.publicKey, privateKey: kp.privateKey, preSharedKey: '', allowedIPs: ['10.0.0.2/32'], keepAlive: 0 },
       });
     }
 
@@ -283,6 +303,14 @@ export default function ClientFormModal({
     return ids;
   }, [inbounds]);
 
+  const wgIds = useMemo(() => {
+    const ids = new Set<number>();
+    for (const row of inbounds || []) {
+      if (row && row.protocol === 'wireguard') ids.add(row.id);
+    }
+    return ids;
+  }, [inbounds]);
+
   const ss2022Method = useMemo(() => {
     for (const id of form.inboundIds || []) {
       const ib = (inbounds || []).find((row) => row.id === id);
@@ -297,6 +325,20 @@ export default function ClientFormModal({
       ? RandomUtil.randomShadowsocksPassword(ss2022Method)
       : RandomUtil.randomLowerAndNum(16));
   }
+
+  function regenerateWgKeypair() {
+    const kp = Wireguard.generateKeypair();
+    setForm((prev) => ({ ...prev, wgPeer: { ...prev.wgPeer, privateKey: kp.privateKey, publicKey: kp.publicKey } }));
+  }
+
+  function updateWgPeer<K extends keyof WgPeerForm>(key: K, value: WgPeerForm[K]) {
+    setForm((prev) => ({ ...prev, wgPeer: { ...prev.wgPeer, [key]: value } }));
+  }
+
+  const showWireGuard = useMemo(
+    () => (form.inboundIds || []).some((id) => wgIds.has(id)),
+    [form.inboundIds, wgIds],
+  );
 
   const showFlow = useMemo(
     () => (form.inboundIds || []).some((id) => flowCapableIds.has(id)),
@@ -431,19 +473,27 @@ export default function ClientFormModal({
       email: form.email.trim(),
       subId: form.subId,
       id: form.uuid,
-      password: form.password,
+      password: showWireGuard ? form.wgPeer.privateKey : form.password,
       auth: form.auth,
       flow: showFlow ? (form.flow || '') : '',
       security: showSecurity ? (form.security || 'auto') : 'auto',
-      totalGB: gbToBytes(form.totalGB),
-      expiryTime,
+      totalGB: showWireGuard ? 0 : gbToBytes(form.totalGB),
+      expiryTime: showWireGuard ? 0 : expiryTime,
       reset: Number(form.reset) || 0,
-      limitIp: Number(form.limitIp) || 0,
+      limitIp: showWireGuard ? 0 : Number(form.limitIp) || 0,
       tgId: Number(form.tgId) || 0,
       group: form.group,
       comment: form.comment,
       enable: !!form.enable,
     };
+    if (showWireGuard) {
+      clientPayload.wgPeer = {
+        publicKey: form.wgPeer.publicKey,
+        preSharedKey: form.wgPeer.preSharedKey || undefined,
+        allowedIPs: form.wgPeer.allowedIPs.filter(Boolean),
+        keepAlive: form.wgPeer.keepAlive || undefined,
+      };
+    }
     const reverseTag = showReverseTag ? (form.reverseTag || '').trim() : '';
     if (reverseTag) {
       clientPayload.reverse = { tag: reverseTag };
@@ -542,67 +592,73 @@ export default function ClientFormModal({
                           </Space.Compact>
                         </Form.Item>
                       </Col>
-                      <Col xs={24} md={6}>
-                        <Form.Item label={t('pages.clients.totalGB')} tooltip={t('pages.clients.totalGBDesc')}>
-                          <InputNumber value={form.totalGB} min={0} step={1} style={{ width: '100%' }}
-                            onChange={(v) => update('totalGB', Number(v) || 0)} />
-                        </Form.Item>
-                      </Col>
-                      <Col xs={24} md={6}>
-                        <Form.Item label={t('pages.clients.limitIp')} tooltip={t('pages.clients.limitIpDesc')}>
-                          <Space.Compact style={{ display: 'flex' }}>
-                            <InputNumber value={form.limitIp} min={0} style={{ flex: 1 }}
-                              onChange={(v) => update('limitIp', Number(v) || 0)} />
-                            {isEdit && (
-                              <Tooltip title={t('pages.clients.ipLog')}>
-                                <Button icon={<EyeOutlined />} loading={ipsLoading} onClick={openIpsModal}>
-                                  {clientIps.length > 0 ? clientIps.length : ''}
-                                </Button>
-                              </Tooltip>
-                            )}
-                          </Space.Compact>
-                        </Form.Item>
-                      </Col>
+                      {!showWireGuard && (
+                        <Col xs={24} md={6}>
+                          <Form.Item label={t('pages.clients.totalGB')} tooltip={t('pages.clients.totalGBDesc')}>
+                            <InputNumber value={form.totalGB} min={0} step={1} style={{ width: '100%' }}
+                              onChange={(v) => update('totalGB', Number(v) || 0)} />
+                          </Form.Item>
+                        </Col>
+                      )}
+                      {!showWireGuard && (
+                        <Col xs={24} md={6}>
+                          <Form.Item label={t('pages.clients.limitIp')} tooltip={t('pages.clients.limitIpDesc')}>
+                            <Space.Compact style={{ display: 'flex' }}>
+                              <InputNumber value={form.limitIp} min={0} style={{ flex: 1 }}
+                                onChange={(v) => update('limitIp', Number(v) || 0)} />
+                              {isEdit && (
+                                <Tooltip title={t('pages.clients.ipLog')}>
+                                  <Button icon={<EyeOutlined />} loading={ipsLoading} onClick={openIpsModal}>
+                                    {clientIps.length > 0 ? clientIps.length : ''}
+                                  </Button>
+                                </Tooltip>
+                              )}
+                            </Space.Compact>
+                          </Form.Item>
+                        </Col>
+                      )}
                     </Row>
 
-                    <Row gutter={16}>
-                      <Col xs={24} md={12}>
-                        {form.delayedStart ? (
-                          <Form.Item label={t('pages.clients.expireDays')}>
-                            <InputNumber value={form.delayedDays} min={0} style={{ width: '100%' }}
-                              onChange={(v) => update('delayedDays', Number(v) || 0)} />
-                          </Form.Item>
-                        ) : (
-                          <Form.Item label={t('pages.clients.expiryTime')}>
-                            <DateTimePicker
-                              value={form.expiryDate}
-                              onChange={(d) => update('expiryDate', d || null)}
+                    {!showWireGuard && (
+                      <Row gutter={16}>
+                        <Col xs={24} md={12}>
+                          {form.delayedStart ? (
+                            <Form.Item label={t('pages.clients.expireDays')}>
+                              <InputNumber value={form.delayedDays} min={0} style={{ width: '100%' }}
+                                onChange={(v) => update('delayedDays', Number(v) || 0)} />
+                            </Form.Item>
+                          ) : (
+                            <Form.Item label={t('pages.clients.expiryTime')}>
+                              <DateTimePicker
+                                value={form.expiryDate}
+                                onChange={(d) => update('expiryDate', d || null)}
+                              />
+                            </Form.Item>
+                          )}
+                        </Col>
+                        <Col xs={12} md={6}>
+                          <Form.Item label={t('pages.clients.delayedStart')}>
+                            <Switch
+                              checked={form.delayedStart}
+                              onChange={(v) => {
+                                update('delayedStart', v);
+                                if (v) update('expiryDate', null);
+                                else update('delayedDays', 0);
+                              }}
                             />
                           </Form.Item>
-                        )}
-                      </Col>
-                      <Col xs={12} md={6}>
-                        <Form.Item label={t('pages.clients.delayedStart')}>
-                          <Switch
-                            checked={form.delayedStart}
-                            onChange={(v) => {
-                              update('delayedStart', v);
-                              if (v) update('expiryDate', null);
-                              else update('delayedDays', 0);
-                            }}
-                          />
-                        </Form.Item>
-                      </Col>
-                      <Col xs={12} md={6}>
-                        <Form.Item
-                          label={t('pages.clients.renewDays')}
-                          tooltip={t('pages.clients.renewDesc')}
-                        >
-                          <InputNumber value={form.reset} min={0} style={{ width: '100%' }}
-                            onChange={(v) => update('reset', Number(v) || 0)} />
-                        </Form.Item>
-                      </Col>
-                    </Row>
+                        </Col>
+                        <Col xs={12} md={6}>
+                          <Form.Item
+                            label={t('pages.clients.renewDays')}
+                            tooltip={t('pages.clients.renewDesc')}
+                          >
+                            <InputNumber value={form.reset} min={0} style={{ width: '100%' }}
+                              onChange={(v) => update('reset', Number(v) || 0)} />
+                          </Form.Item>
+                        </Col>
+                      </Row>
+                    )}
 
                     <Row gutter={16}>
                       <Col xs={24} md={12}>
@@ -678,54 +734,111 @@ export default function ClientFormModal({
                 label: t('pages.clients.tabCredentials'),
                 children: (
                   <>
-                    <Form.Item label={t('pages.clients.uuid')}>
-                      <Space.Compact style={{ display: 'flex' }}>
-                        <Input value={form.uuid} style={{ flex: 1 }} onChange={(e) => update('uuid', e.target.value)} />
-                        <Button icon={<ReloadOutlined />} onClick={() => update('uuid', RandomUtil.randomUUID())} />
-                      </Space.Compact>
-                    </Form.Item>
+                    {showWireGuard ? (
+                      <>
+                        <Form.Item label={t('pages.clients.wg.privateKey')}>
+                          <Space.Compact style={{ display: 'flex' }}>
+                            <Input value={form.wgPeer.privateKey} style={{ flex: 1 }}
+                              onChange={(e) => updateWgPeer('privateKey', e.target.value)} />
+                            <Tooltip title={t('pages.clients.wg.regenerateKeypair')}>
+                              <Button icon={<ReloadOutlined />} onClick={regenerateWgKeypair} />
+                            </Tooltip>
+                          </Space.Compact>
+                        </Form.Item>
 
-                    <Form.Item label={t('pages.clients.password')}>
-                      <Space.Compact style={{ display: 'flex' }}>
-                        <Input value={form.password} style={{ flex: 1 }} onChange={(e) => update('password', e.target.value)} />
-                        <Button icon={<ReloadOutlined />} onClick={regeneratePassword} />
-                      </Space.Compact>
-                    </Form.Item>
+                        <Form.Item label={t('pages.clients.wg.publicKey')}>
+                          <Input value={form.wgPeer.publicKey} readOnly />
+                        </Form.Item>
 
-                    <Form.Item label={t('pages.clients.subId')}>
-                      <Space.Compact style={{ display: 'flex' }}>
-                        <Input value={form.subId} style={{ flex: 1 }} onChange={(e) => update('subId', e.target.value)} />
-                        <Button icon={<ReloadOutlined />} onClick={() => update('subId', RandomUtil.randomLowerAndNum(16))} />
-                      </Space.Compact>
-                    </Form.Item>
+                        <Form.Item label={t('pages.clients.wg.preSharedKey')}>
+                          <Space.Compact style={{ display: 'flex' }}>
+                            <Input value={form.wgPeer.preSharedKey} style={{ flex: 1 }}
+                              onChange={(e) => updateWgPeer('preSharedKey', e.target.value)} />
+                            <Tooltip title={t('pages.clients.wg.generatePsk')}>
+                              <Button icon={<ReloadOutlined />}
+                                onClick={() => updateWgPeer('preSharedKey', RandomUtil.randomBase64(32))} />
+                            </Tooltip>
+                          </Space.Compact>
+                        </Form.Item>
 
-                    <Form.Item label={t('pages.clients.hysteriaAuth')}>
-                      <Space.Compact style={{ display: 'flex' }}>
-                        <Input value={form.auth} style={{ flex: 1 }} onChange={(e) => update('auth', e.target.value)} />
-                        <Button icon={<ReloadOutlined />} onClick={() => update('auth', RandomUtil.randomLowerAndNum(16))} />
-                      </Space.Compact>
-                    </Form.Item>
+                        <Form.Item label={t('pages.clients.wg.allowedIPs')}>
+                          {(form.wgPeer.allowedIPs || []).map((ip, idx) => (
+                            <Space.Compact key={idx} style={{ display: 'flex', marginBottom: 4 }}>
+                              <Input value={ip} style={{ flex: 1 }}
+                                onChange={(e) => {
+                                  const next = [...form.wgPeer.allowedIPs];
+                                  next[idx] = e.target.value;
+                                  updateWgPeer('allowedIPs', next);
+                                }} />
+                              <Tooltip title={t('delete')}>
+                                <Button danger icon={<DeleteOutlined />}
+                                  onClick={() => updateWgPeer('allowedIPs', form.wgPeer.allowedIPs.filter((_, i) => i !== idx))} />
+                              </Tooltip>
+                            </Space.Compact>
+                          ))}
+                          <Button icon={<PlusOutlined />} size="small" style={{ marginTop: 4 }}
+                            onClick={() => updateWgPeer('allowedIPs', [...(form.wgPeer.allowedIPs || []), ''])}>
+                            {t('pages.clients.wg.addAllowedIP')}
+                          </Button>
+                        </Form.Item>
 
-                    {showFlow && (
-                      <Form.Item label={t('pages.clients.flow')}>
-                        <Select
-                          value={form.flow}
-                          onChange={(v) => update('flow', v)}
-                          options={[
-                            { value: '', label: t('none') },
-                            ...FLOW_OPTIONS.map((k) => ({ value: k, label: k })),
-                          ]}
-                        />
-                      </Form.Item>
-                    )}
-                    {showSecurity && (
-                      <Form.Item label={t('pages.clients.vmessSecurity')}>
-                        <Select
-                          value={form.security}
-                          onChange={(v) => update('security', v)}
-                          options={VMESS_SECURITY_OPTIONS.map((k) => ({ value: k, label: k }))}
-                        />
-                      </Form.Item>
+                        <Form.Item label={t('pages.clients.wg.keepAlive')}>
+                          <InputNumber value={form.wgPeer.keepAlive} min={0} style={{ width: '100%' }}
+                            onChange={(v) => updateWgPeer('keepAlive', Number(v) || 0)} />
+                        </Form.Item>
+                      </>
+                    ) : (
+                      <>
+                        <Form.Item label={t('pages.clients.uuid')}>
+                          <Space.Compact style={{ display: 'flex' }}>
+                            <Input value={form.uuid} style={{ flex: 1 }} onChange={(e) => update('uuid', e.target.value)} />
+                            <Button icon={<ReloadOutlined />} onClick={() => update('uuid', RandomUtil.randomUUID())} />
+                          </Space.Compact>
+                        </Form.Item>
+
+                        <Form.Item label={t('pages.clients.password')}>
+                          <Space.Compact style={{ display: 'flex' }}>
+                            <Input value={form.password} style={{ flex: 1 }} onChange={(e) => update('password', e.target.value)} />
+                            <Button icon={<ReloadOutlined />} onClick={regeneratePassword} />
+                          </Space.Compact>
+                        </Form.Item>
+
+                        <Form.Item label={t('pages.clients.subId')}>
+                          <Space.Compact style={{ display: 'flex' }}>
+                            <Input value={form.subId} style={{ flex: 1 }} onChange={(e) => update('subId', e.target.value)} />
+                            <Button icon={<ReloadOutlined />} onClick={() => update('subId', RandomUtil.randomLowerAndNum(16))} />
+                          </Space.Compact>
+                        </Form.Item>
+
+                        <Form.Item label={t('pages.clients.hysteriaAuth')}>
+                          <Space.Compact style={{ display: 'flex' }}>
+                            <Input value={form.auth} style={{ flex: 1 }} onChange={(e) => update('auth', e.target.value)} />
+                            <Button icon={<ReloadOutlined />} onClick={() => update('auth', RandomUtil.randomLowerAndNum(16))} />
+                          </Space.Compact>
+                        </Form.Item>
+
+                        {showFlow && (
+                          <Form.Item label={t('pages.clients.flow')}>
+                            <Select
+                              value={form.flow}
+                              onChange={(v) => update('flow', v)}
+                              options={[
+                                { value: '', label: t('none') },
+                                ...FLOW_OPTIONS.map((k) => ({ value: k, label: k })),
+                              ]}
+                            />
+                          </Form.Item>
+                        )}
+                        {showSecurity && (
+                          <Form.Item label={t('pages.clients.vmessSecurity')}>
+                            <Select
+                              value={form.security}
+                              onChange={(v) => update('security', v)}
+                              options={VMESS_SECURITY_OPTIONS.map((k) => ({ value: k, label: k }))}
+                            />
+                          </Form.Item>
+                        )}
+                      </>
                     )}
                   </>
                 ),

--- a/frontend/src/pages/clients/ClientInfoModal.tsx
+++ b/frontend/src/pages/clients/ClientInfoModal.tsx
@@ -1,9 +1,9 @@
 import { useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Button, Divider, Modal, Popover, Tag, Tooltip, message } from 'antd';
-import { CopyOutlined, EyeOutlined, QrcodeOutlined, ReloadOutlined } from '@ant-design/icons';
+import { CopyOutlined, DownloadOutlined, EyeOutlined, QrcodeOutlined, ReloadOutlined } from '@ant-design/icons';
 
-import { ClipboardManager, HttpUtil, IntlUtil, SizeFormatter } from '@/utils';
+import { ClipboardManager, FileManager, HttpUtil, IntlUtil, SizeFormatter } from '@/utils';
 import { formatInboundLabel } from '@/lib/inbounds/label';
 import { normalizeClientIps, type ClientIpInfo } from '@/lib/clients/ip-log';
 import { useDatepicker } from '@/hooks/useDatepicker';
@@ -133,6 +133,37 @@ export default function ClientInfoModal({
 
   const showSubscription = !!(subSettings?.enable && client?.subId);
 
+  const wgInbound = useMemo(() => {
+    if (!client?.wgPeer || !client.inboundIds) return undefined;
+    for (const id of client.inboundIds) {
+      const ib = inboundsById[id];
+      if (ib?.protocol === 'wireguard') return ib;
+    }
+    return undefined;
+  }, [client, inboundsById]);
+
+  const wgConfigText = useMemo(() => {
+    if (!client?.wgPeer) return '';
+    const wg = client.wgPeer;
+    const serverPubKey = wgInbound?.wgPublicKey || '';
+    const endpoint = `${window.location.hostname}:${wgInbound?.port || ''}`;
+    const address = (wg.allowedIPs || []).join(', ') || '10.0.0.2/32';
+    const lines = [
+      '[Interface]',
+      `PrivateKey = ${client.password || ''}`,
+      `Address = ${address}`,
+      'DNS = 8.8.8.8',
+      '',
+      '[Peer]',
+      `PublicKey = ${serverPubKey}`,
+      'AllowedIPs = 0.0.0.0/0, ::/0',
+      `Endpoint = ${endpoint}`,
+    ];
+    if (wg.preSharedKey) lines.push(`PresharedKey = ${wg.preSharedKey}`);
+    if ((wg.keepAlive ?? 0) > 0) lines.push(`PersistentKeepalive = ${wg.keepAlive}`);
+    return lines.join('\n');
+  }, [client, wgInbound]);
+
   async function copyValue(text: string) {
     if (!text) return;
     const ok = await ClipboardManager.copyText(String(text));
@@ -225,6 +256,19 @@ export default function ClientInfoModal({
                       <tr>
                         <td>{t('pages.clients.wg.keepAlive')}</td>
                         <td><Tag>{client.wgPeer.keepAlive}s</Tag></td>
+                      </tr>
+                    )}
+                    {wgConfigText && (
+                      <tr>
+                        <td>Config</td>
+                        <td>
+                          <Tooltip title={t('copy')}>
+                            <Button size="small" type="text" icon={<CopyOutlined />} onClick={() => copyValue(wgConfigText)} />
+                          </Tooltip>
+                          <Tooltip title={t('download')}>
+                            <Button size="small" type="text" icon={<DownloadOutlined />} onClick={() => FileManager.downloadTextFile(wgConfigText, `${client!.email}.conf`)} />
+                          </Tooltip>
+                        </td>
                       </tr>
                     )}
                   </>

--- a/frontend/src/pages/clients/ClientInfoModal.tsx
+++ b/frontend/src/pages/clients/ClientInfoModal.tsx
@@ -429,7 +429,7 @@ export default function ClientInfoModal({
               </tbody>
             </table>
 
-            {links.length > 0 && (
+            {!client.wgPeer && links.length > 0 && (
               <>
                 <Divider>{t('pages.inbounds.copyLink')}</Divider>
                 {links.map((link, idx) => {
@@ -467,7 +467,7 @@ export default function ClientInfoModal({
               </>
             )}
 
-            {showSubscription && subLink && (
+            {!client.wgPeer && showSubscription && subLink && (
               <>
                 <Divider>{t('subscription.title')}</Divider>
                 <div className="link-row">

--- a/frontend/src/pages/clients/ClientInfoModal.tsx
+++ b/frontend/src/pages/clients/ClientInfoModal.tsx
@@ -182,15 +182,6 @@ export default function ClientInfoModal({
             <table className="info-table block">
               <tbody>
                 <tr>
-                  <td>{t('pages.clients.online')}</td>
-                  <td>
-                    {client.enable && isOnline
-                      ? <Tag color="green">{t('pages.clients.online')}</Tag>
-                      : <Tag>{t('pages.clients.offline')}</Tag>}
-                    <span className="hint">{t('lastOnline')}: {dateLabel(traffic?.lastOnline)}</span>
-                  </td>
-                </tr>
-                <tr>
                   <td>{t('status')}</td>
                   <td>
                     <Tag color={client.enable ? 'green' : 'default'}>
@@ -206,91 +197,135 @@ export default function ClientInfoModal({
                       : <Tag color="red">{t('none')}</Tag>}
                   </td>
                 </tr>
-                <tr>
-                  <td>{t('pages.clients.subId')}</td>
-                  <td>
-                    <Tag className="info-large-tag">{client.subId || '-'}</Tag>
-                    {client.subId && (
-                      <Button size="small" type="text" icon={<CopyOutlined />} onClick={() => copyValue(client.subId!)} />
+                {client.wgPeer ? (
+                  <>
+                    <tr>
+                      <td>{t('pages.clients.wg.publicKey')}</td>
+                      <td>
+                        <Tag className="info-large-tag">{client.wgPeer.publicKey}</Tag>
+                        <Button size="small" type="text" icon={<CopyOutlined />} onClick={() => copyValue(client.wgPeer!.publicKey)} />
+                      </td>
+                    </tr>
+                    {(client.wgPeer.allowedIPs || []).length > 0 && (
+                      <tr>
+                        <td>{t('pages.clients.wg.allowedIPs')}</td>
+                        <td>{(client.wgPeer.allowedIPs || []).map((ip, i) => <Tag key={i}>{ip}</Tag>)}</td>
+                      </tr>
                     )}
-                  </td>
-                </tr>
-                {client.uuid && (
-                  <tr>
-                    <td>{t('pages.clients.uuid')}</td>
-                    <td>
-                      <Tag className="info-large-tag">{client.uuid}</Tag>
-                      <Button size="small" type="text" icon={<CopyOutlined />} onClick={() => copyValue(client.uuid!)} />
-                    </td>
-                  </tr>
-                )}
-                {client.password && (
-                  <tr>
-                    <td>{t('password')}</td>
-                    <td>
-                      <Tag className="info-large-tag">{client.password}</Tag>
-                      <Button size="small" type="text" icon={<CopyOutlined />} onClick={() => copyValue(client.password!)} />
-                    </td>
-                  </tr>
-                )}
-                {client.auth && (
-                  <tr>
-                    <td>{t('pages.clients.auth')}</td>
-                    <td>
-                      <Tag className="info-large-tag">{client.auth}</Tag>
-                      <Button size="small" type="text" icon={<CopyOutlined />} onClick={() => copyValue(client.auth!)} />
-                    </td>
-                  </tr>
-                )}
-                <tr>
-                  <td>{t('pages.clients.flow')}</td>
-                  <td>
-                    {client.flow ? <Tag>{client.flow}</Tag> : <Tag color="orange">{t('none')}</Tag>}
-                  </td>
-                </tr>
-                <tr>
-                  <td>{t('pages.inbounds.traffic')}</td>
-                  <td>
-                    <Tag>
-                      ↑ {SizeFormatter.sizeFormat(traffic?.up || 0)}
-                      {' '}/ ↓ {SizeFormatter.sizeFormat(traffic?.down || 0)}
-                    </Tag>
-                    <span className="hint">
-                      {SizeFormatter.sizeFormat(used)} / {totalBytes > 0 ? SizeFormatter.sizeFormat(totalBytes) : '∞'}
-                    </span>
-                  </td>
-                </tr>
-                <tr>
-                  <td>{t('remained')}</td>
-                  <td>
-                    {remaining < 0
-                      ? <Tag color="purple">∞</Tag>
-                      : <Tag color={remaining > 0 ? '' : 'red'}>{SizeFormatter.sizeFormat(remaining)}</Tag>}
-                  </td>
-                </tr>
-                <tr>
-                  <td>{t('pages.inbounds.expireDate')}</td>
-                  <td>
-                    {!client.expiryTime
-                      ? <Tag color="purple">∞</Tag>
-                      : <Tag color={client.expiryTime < 0 ? 'blue' : undefined}>{expiryLabel(client.expiryTime)}</Tag>}
-                    {(client.expiryTime ?? 0) > 0 && (
-                      <span className="hint">{IntlUtil.formatRelativeTime(client.expiryTime)}</span>
+                    {client.wgPeer.preSharedKey && (
+                      <tr>
+                        <td>{t('pages.clients.wg.preSharedKey')}</td>
+                        <td>
+                          <Tag className="info-large-tag">{client.wgPeer.preSharedKey}</Tag>
+                          <Button size="small" type="text" icon={<CopyOutlined />} onClick={() => copyValue(client.wgPeer!.preSharedKey!)} />
+                        </td>
+                      </tr>
                     )}
-                  </td>
-                </tr>
-                <tr>
-                  <td>{t('pages.clients.ipLimit')}</td>
-                  <td>{!client.limitIp ? <Tag>∞</Tag> : <Tag>{client.limitIp}</Tag>}</td>
-                </tr>
-                <tr>
-                  <td>{t('pages.inbounds.IPLimitlog')}</td>
-                  <td>
-                    <Button size="small" icon={<EyeOutlined />} loading={ipsLoading} onClick={openIpsModal}>
-                      {clientIps.length > 0 ? clientIps.length : ''}
-                    </Button>
-                  </td>
-                </tr>
+                    {(client.wgPeer.keepAlive ?? 0) > 0 && (
+                      <tr>
+                        <td>{t('pages.clients.wg.keepAlive')}</td>
+                        <td><Tag>{client.wgPeer.keepAlive}s</Tag></td>
+                      </tr>
+                    )}
+                  </>
+                ) : (
+                  <>
+                    <tr>
+                      <td>{t('pages.clients.online')}</td>
+                      <td>
+                        {client.enable && isOnline
+                          ? <Tag color="green">{t('pages.clients.online')}</Tag>
+                          : <Tag>{t('pages.clients.offline')}</Tag>}
+                        <span className="hint">{t('lastOnline')}: {dateLabel(traffic?.lastOnline)}</span>
+                      </td>
+                    </tr>
+                    <tr>
+                      <td>{t('pages.clients.subId')}</td>
+                      <td>
+                        <Tag className="info-large-tag">{client.subId || '-'}</Tag>
+                        {client.subId && (
+                          <Button size="small" type="text" icon={<CopyOutlined />} onClick={() => copyValue(client.subId!)} />
+                        )}
+                      </td>
+                    </tr>
+                    {client.uuid && (
+                      <tr>
+                        <td>{t('pages.clients.uuid')}</td>
+                        <td>
+                          <Tag className="info-large-tag">{client.uuid}</Tag>
+                          <Button size="small" type="text" icon={<CopyOutlined />} onClick={() => copyValue(client.uuid!)} />
+                        </td>
+                      </tr>
+                    )}
+                    {client.password && (
+                      <tr>
+                        <td>{t('password')}</td>
+                        <td>
+                          <Tag className="info-large-tag">{client.password}</Tag>
+                          <Button size="small" type="text" icon={<CopyOutlined />} onClick={() => copyValue(client.password!)} />
+                        </td>
+                      </tr>
+                    )}
+                    {client.auth && (
+                      <tr>
+                        <td>{t('pages.clients.auth')}</td>
+                        <td>
+                          <Tag className="info-large-tag">{client.auth}</Tag>
+                          <Button size="small" type="text" icon={<CopyOutlined />} onClick={() => copyValue(client.auth!)} />
+                        </td>
+                      </tr>
+                    )}
+                    <tr>
+                      <td>{t('pages.clients.flow')}</td>
+                      <td>
+                        {client.flow ? <Tag>{client.flow}</Tag> : <Tag color="orange">{t('none')}</Tag>}
+                      </td>
+                    </tr>
+                    <tr>
+                      <td>{t('pages.inbounds.traffic')}</td>
+                      <td>
+                        <Tag>
+                          ↑ {SizeFormatter.sizeFormat(traffic?.up || 0)}
+                          {' '}/ ↓ {SizeFormatter.sizeFormat(traffic?.down || 0)}
+                        </Tag>
+                        <span className="hint">
+                          {SizeFormatter.sizeFormat(used)} / {totalBytes > 0 ? SizeFormatter.sizeFormat(totalBytes) : '∞'}
+                        </span>
+                      </td>
+                    </tr>
+                    <tr>
+                      <td>{t('remained')}</td>
+                      <td>
+                        {remaining < 0
+                          ? <Tag color="purple">∞</Tag>
+                          : <Tag color={remaining > 0 ? '' : 'red'}>{SizeFormatter.sizeFormat(remaining)}</Tag>}
+                      </td>
+                    </tr>
+                    <tr>
+                      <td>{t('pages.inbounds.expireDate')}</td>
+                      <td>
+                        {!client.expiryTime
+                          ? <Tag color="purple">∞</Tag>
+                          : <Tag color={client.expiryTime < 0 ? 'blue' : undefined}>{expiryLabel(client.expiryTime)}</Tag>}
+                        {(client.expiryTime ?? 0) > 0 && (
+                          <span className="hint">{IntlUtil.formatRelativeTime(client.expiryTime)}</span>
+                        )}
+                      </td>
+                    </tr>
+                    <tr>
+                      <td>{t('pages.clients.ipLimit')}</td>
+                      <td>{!client.limitIp ? <Tag>∞</Tag> : <Tag>{client.limitIp}</Tag>}</td>
+                    </tr>
+                    <tr>
+                      <td>{t('pages.inbounds.IPLimitlog')}</td>
+                      <td>
+                        <Button size="small" icon={<EyeOutlined />} loading={ipsLoading} onClick={openIpsModal}>
+                          {clientIps.length > 0 ? clientIps.length : ''}
+                        </Button>
+                      </td>
+                    </tr>
+                  </>
+                )}
                 <tr>
                   <td>{t('pages.inbounds.createdAt')}</td>
                   <td><Tag>{dateLabel(client.createdAt)}</Tag></td>

--- a/frontend/src/pages/clients/ClientQrModal.tsx
+++ b/frontend/src/pages/clients/ClientQrModal.tsx
@@ -1,7 +1,8 @@
 import { useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { Collapse, Modal, Spin } from 'antd';
-import { HttpUtil } from '@/utils';
+import { Button, Collapse, Modal, Spin, Tooltip, message } from 'antd';
+import { CopyOutlined, DownloadOutlined } from '@ant-design/icons';
+import { HttpUtil, ClipboardManager, FileManager } from '@/utils';
 import { isPostQuantumLink } from '@/lib/xray/inbound-link';
 import { LinkTags, linkMetaText, parseLinkParts } from '@/lib/xray/link-label';
 import { QrPanel } from '@/pages/inbounds/qr';
@@ -49,6 +50,55 @@ function buildWgConfig(client: ClientRecord, inbound: InboundOption | undefined)
   if (wg.preSharedKey) lines.push(`PresharedKey = ${wg.preSharedKey}`);
   if (wg.keepAlive && wg.keepAlive > 0) lines.push(`PersistentKeepalive = ${wg.keepAlive}`);
   return lines.join('\n');
+}
+
+function WgConfigPanel({ config, email }: { config: string; email: string }) {
+  const { t } = useTranslation();
+  const [messageApi, ctx] = message.useMessage();
+
+  async function copy() {
+    const ok = await ClipboardManager.copyText(config);
+    if (ok) messageApi.success(t('copied'));
+  }
+
+  function download() {
+    FileManager.downloadTextFile(config, `${email}.conf`);
+  }
+
+  return (
+    <div>
+      {ctx}
+      <div style={{ display: 'flex', justifyContent: 'flex-end', gap: 8, marginBottom: 8 }}>
+        <Tooltip title={t('copy')}>
+          <Button size="small" icon={<CopyOutlined />} onClick={copy} />
+        </Tooltip>
+        <Tooltip title={t('download')}>
+          <Button size="small" icon={<DownloadOutlined />} onClick={download} />
+        </Tooltip>
+      </div>
+      <pre style={{
+        background: 'var(--ant-color-fill-quaternary, #f5f5f5)',
+        borderRadius: 6,
+        padding: '10px 14px',
+        margin: 0,
+        fontSize: 13,
+        lineHeight: 1.6,
+        overflowX: 'auto',
+        whiteSpace: 'pre',
+        userSelect: 'all',
+      }}>
+        {config}
+      </pre>
+      <div style={{ marginTop: 12 }}>
+        <QrPanel
+          value={config}
+          remark={email}
+          downloadName={`${email}.conf`}
+          showQr={true}
+        />
+      </div>
+    </div>
+  );
 }
 
 export default function ClientQrModal({
@@ -124,13 +174,7 @@ export default function ClientQrModal({
       out.push({
         key: 'wg',
         label: 'WireGuard Config',
-        children: (
-          <QrPanel
-            value={wgConfig}
-            remark={client?.email || 'wg'}
-            downloadName={`${client?.email || 'peer'}.conf`}
-          />
-        ),
+        children: <WgConfigPanel config={wgConfig} email={client?.email || 'peer'} />,
       });
     }
 

--- a/frontend/src/pages/clients/ClientQrModal.tsx
+++ b/frontend/src/pages/clients/ClientQrModal.tsx
@@ -5,7 +5,7 @@ import { HttpUtil } from '@/utils';
 import { isPostQuantumLink } from '@/lib/xray/inbound-link';
 import { LinkTags, linkMetaText, parseLinkParts } from '@/lib/xray/link-label';
 import { QrPanel } from '@/pages/inbounds/qr';
-import type { ClientRecord } from '@/hooks/useClients';
+import type { ClientRecord, InboundOption } from '@/hooks/useClients';
 
 interface SubSettings {
   enable: boolean;
@@ -17,6 +17,7 @@ interface SubSettings {
 interface ClientQrModalProps {
   open: boolean;
   client: ClientRecord | null;
+  inboundsById?: Record<number, InboundOption>;
   subSettings?: SubSettings;
   onOpenChange: (open: boolean) => void;
 }
@@ -28,9 +29,32 @@ interface ApiMsg<T = unknown> {
 
 const DEFAULT_SUB: SubSettings = { enable: false, subURI: '', subJsonURI: '', subJsonEnable: false };
 
+function buildWgConfig(client: ClientRecord, inbound: InboundOption | undefined): string {
+  const wg = client.wgPeer;
+  if (!wg) return '';
+  const serverPubKey = inbound?.wgPublicKey || '';
+  const endpoint = `${window.location.hostname}:${inbound?.port || ''}`;
+  const address = (wg.allowedIPs || []).join(', ') || '10.0.0.2/32';
+  const lines: string[] = [
+    '[Interface]',
+    `PrivateKey = ${client.password || ''}`,
+    `Address = ${address}`,
+    'DNS = 8.8.8.8',
+    '',
+    '[Peer]',
+    `PublicKey = ${serverPubKey}`,
+    'AllowedIPs = 0.0.0.0/0, ::/0',
+    `Endpoint = ${endpoint}`,
+  ];
+  if (wg.preSharedKey) lines.push(`PresharedKey = ${wg.preSharedKey}`);
+  if (wg.keepAlive && wg.keepAlive > 0) lines.push(`PersistentKeepalive = ${wg.keepAlive}`);
+  return lines.join('\n');
+}
+
 export default function ClientQrModal({
   open,
   client,
+  inboundsById,
   subSettings = DEFAULT_SUB,
   onOpenChange,
 }: ClientQrModalProps) {
@@ -38,21 +62,39 @@ export default function ClientQrModal({
   const [links, setLinks] = useState<string[]>([]);
   const [loading, setLoading] = useState(false);
 
+  const isWg = !!(client?.wgPeer);
+
   const subLink = useMemo(() => {
+    if (isWg) return '';
     if (!client?.subId || !subSettings?.enable || !subSettings?.subURI) return '';
     return subSettings.subURI + client.subId;
-  }, [client?.subId, subSettings?.enable, subSettings?.subURI]);
+  }, [isWg, client?.subId, subSettings?.enable, subSettings?.subURI]);
 
   const subJsonLink = useMemo(() => {
+    if (isWg) return '';
     if (!client?.subId || !subSettings?.enable) return '';
     if (!subSettings?.subJsonEnable || !subSettings?.subJsonURI) return '';
     return subSettings.subJsonURI + client.subId;
-  }, [client?.subId, subSettings?.enable, subSettings?.subJsonEnable, subSettings?.subJsonURI]);
+  }, [isWg, client?.subId, subSettings?.enable, subSettings?.subJsonEnable, subSettings?.subJsonURI]);
 
-  const hasAnything = !!subLink || !!subJsonLink || links.length > 0;
+  const wgInbound = useMemo(() => {
+    if (!isWg || !client?.inboundIds || !inboundsById) return undefined;
+    for (const id of client.inboundIds) {
+      const ib = inboundsById[id];
+      if (ib?.protocol === 'wireguard') return ib;
+    }
+    return undefined;
+  }, [isWg, client?.inboundIds, inboundsById]);
+
+  const wgConfig = useMemo(() => {
+    if (!isWg || !client) return '';
+    return buildWgConfig(client, wgInbound);
+  }, [isWg, client, wgInbound]);
+
+  const hasAnything = !!subLink || !!subJsonLink || links.length > 0 || !!wgConfig;
 
   useEffect(() => {
-    if (!open || !client?.subId) {
+    if (!open || !client?.subId || isWg) {
       setLinks([]);
       return;
     }
@@ -71,12 +113,27 @@ export default function ClientQrModal({
       }
     })();
     return () => { cancelled = true; };
-  }, [open, client?.subId]);
+  }, [open, client?.subId, isWg]);
 
   const [activeKey, setActiveKey] = useState<string[]>([]);
 
   const items = useMemo(() => {
     const out: { key: string; label: React.ReactNode; children: React.ReactNode }[] = [];
+
+    if (wgConfig) {
+      out.push({
+        key: 'wg',
+        label: 'WireGuard Config',
+        children: (
+          <QrPanel
+            value={wgConfig}
+            remark={client?.email || 'wg'}
+            downloadName={`${client?.email || 'peer'}.conf`}
+          />
+        ),
+      });
+    }
+
     if (subLink) {
       out.push({
         key: 'sub',
@@ -113,7 +170,7 @@ export default function ClientQrModal({
       });
     });
     return out;
-  }, [subLink, subJsonLink, links, client?.email, t]);
+  }, [wgConfig, subLink, subJsonLink, links, client?.email, t]);
 
   useEffect(() => {
     if (!open) {
@@ -133,10 +190,7 @@ export default function ClientQrModal({
       onCancel={() => onOpenChange(false)}
     >
       <Spin spinning={loading}>
-        {!client?.subId && !loading && (
-          <div style={{ padding: 24, textAlign: 'center', opacity: 0.6 }}>{t('pages.clients.noSubId')}</div>
-        )}
-        {client?.subId && !hasAnything && !loading && (
+        {!hasAnything && !loading && (
           <div style={{ padding: 24, textAlign: 'center', opacity: 0.6 }}>{t('pages.clients.noLinks')}</div>
         )}
         {hasAnything && (

--- a/frontend/src/pages/clients/ClientsPage.tsx
+++ b/frontend/src/pages/clients/ClientsPage.tsx
@@ -501,7 +501,14 @@ export default function ClientsPage() {
 
   async function onShowQr(row: ClientRecord) {
     const full = await hydrate(row.email);
-    setQrClient(full ? { ...row, ...full.client, inboundIds: full.inboundIds } : row);
+    if (!full) {
+      setQrClient(row);
+      setQrOpen(true);
+      return;
+    }
+    const merged: ClientRecord = { ...row, ...full.client, inboundIds: full.inboundIds };
+    if (!merged.wgPeer && row.wgPeer) merged.wgPeer = row.wgPeer;
+    setQrClient(merged);
     setQrOpen(true);
   }
 

--- a/frontend/src/pages/clients/ClientsPage.tsx
+++ b/frontend/src/pages/clients/ClientsPage.tsx
@@ -313,6 +313,21 @@ export default function ClientsPage() {
     return out;
   }, [inbounds]);
 
+  const getNextWgAllowedIp = useCallback((inboundId: number): string => {
+    const used = new Set<string>();
+    for (const c of clients) {
+      if (!(c.inboundIds || []).includes(inboundId)) continue;
+      for (const ip of c.wgPeer?.allowedIPs || []) {
+        used.add(ip.split('/')[0]);
+      }
+    }
+    for (let i = 2; i <= 254; i++) {
+      const ip = `10.0.0.${i}`;
+      if (!used.has(ip)) return `${ip}/32`;
+    }
+    return '10.0.0.2/32';
+  }, [clients]);
+
   const protocolOptions = useMemo(() => {
     const values = new Set<string>((inbounds || []).map((i) => i.protocol).filter((x): x is string => !!x));
     return [...values].sort();
@@ -1263,6 +1278,7 @@ export default function ClientsPage() {
             groups={allGroups}
             save={onSave}
             resetTraffic={resetTraffic}
+            getNextWgAllowedIp={getNextWgAllowedIp}
             onOpenChange={setFormOpen}
           />
         </LazyMount>
@@ -1280,6 +1296,7 @@ export default function ClientsPage() {
           <ClientQrModal
             open={qrOpen}
             client={qrClient}
+            inboundsById={inboundsById}
             subSettings={subSettings}
             onOpenChange={setQrOpen}
           />

--- a/frontend/src/pages/clients/ClientsPage.tsx
+++ b/frontend/src/pages/clients/ClientsPage.tsx
@@ -495,7 +495,14 @@ export default function ClientsPage() {
 
   async function onShowInfo(row: ClientRecord) {
     const full = await hydrate(row.email);
-    setInfoClient(full ? { ...row, ...full.client, inboundIds: full.inboundIds } : row);
+    if (!full) {
+      setInfoClient(row);
+      setInfoOpen(true);
+      return;
+    }
+    const merged: ClientRecord = { ...row, ...full.client, inboundIds: full.inboundIds };
+    if (!merged.wgPeer && row.wgPeer) merged.wgPeer = row.wgPeer;
+    setInfoClient(merged);
     setInfoOpen(true);
   }
 

--- a/frontend/src/pages/inbounds/form/InboundFormModal.tsx
+++ b/frontend/src/pages/inbounds/form/InboundFormModal.tsx
@@ -271,12 +271,6 @@ export default function InboundFormModal({
     form.setFieldValue(['settings', 'secretKey'], kp.privateKey);
   };
 
-  const regenWgPeerKeypair = (peerName: number) => {
-    const kp = Wireguard.generateKeypair();
-    form.setFieldValue(['settings', 'peers', peerName, 'privateKey'], kp.privateKey);
-    form.setFieldValue(['settings', 'peers', peerName, 'publicKey'], kp.publicKey);
-  };
-
   const matchesVlessAuth = (
     block: { id?: string; label?: string } | undefined | null,
     authId: string,
@@ -663,7 +657,7 @@ export default function InboundFormModal({
 
   const protocolTab = (
     <>
-      {protocol === Protocols.WIREGUARD && <WireguardFields wgPubKey={wgPubKey} regenInboundWg={regenInboundWg} regenWgPeerKeypair={regenWgPeerKeypair} />}
+      {protocol === Protocols.WIREGUARD && <WireguardFields wgPubKey={wgPubKey} regenInboundWg={regenInboundWg} />}
 
       {protocol === Protocols.TUN && <TunFields />}
 

--- a/frontend/src/pages/inbounds/form/protocols/wireguard.tsx
+++ b/frontend/src/pages/inbounds/form/protocols/wireguard.tsx
@@ -1,44 +1,14 @@
 import { useTranslation } from 'react-i18next';
-import { Button, Divider, Form, Input, InputNumber, Select, Space, Switch } from 'antd';
-import { MinusOutlined, PlusOutlined, ReloadOutlined } from '@ant-design/icons';
-
-import { Wireguard } from '@/utils';
+import { Button, Form, Input, InputNumber, Select, Space, Switch } from 'antd';
+import { ReloadOutlined } from '@ant-design/icons';
 
 interface WireguardFieldsProps {
   wgPubKey: string;
   regenInboundWg: () => void;
-  regenWgPeerKeypair: (name: number) => void;
 }
 
-function nextWgPeerAllowedIP(peers: Array<{ allowedIPs?: string[] }> | undefined): string {
-  const fallback = '10.0.0.2/32';
-  let maxInt = -1;
-  let prefix = 32;
-  for (const peer of peers ?? []) {
-    for (const ip of peer?.allowedIPs ?? []) {
-      const m = /^\s*(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})(?:\/(\d{1,2}))?\s*$/.exec(String(ip));
-      if (!m) continue;
-      const octets = [Number(m[1]), Number(m[2]), Number(m[3]), Number(m[4])];
-      if (octets.some((o) => o > 255)) continue;
-      const asInt = octets[0] * 16777216 + octets[1] * 65536 + octets[2] * 256 + octets[3];
-      if (asInt > maxInt) {
-        maxInt = asInt;
-        prefix = m[5] !== undefined ? Math.min(Number(m[5]), 32) : 32;
-      }
-    }
-  }
-  if (maxInt < 0) return fallback;
-  const next = maxInt + 1;
-  const a = Math.floor(next / 16777216) % 256;
-  const b = Math.floor(next / 65536) % 256;
-  const c = Math.floor(next / 256) % 256;
-  const d = next % 256;
-  return `${a}.${b}.${c}.${d}/${prefix}`;
-}
-
-export default function WireguardFields({ wgPubKey, regenInboundWg, regenWgPeerKeypair }: WireguardFieldsProps) {
+export default function WireguardFields({ wgPubKey, regenInboundWg }: WireguardFieldsProps) {
   const { t } = useTranslation();
-  const form = Form.useFormInstance();
   return (
     <>
       <Form.Item label={t('pages.xray.wireguard.secretKey')}>
@@ -77,96 +47,6 @@ export default function WireguardFields({ wgPubKey, regenInboundWg, regenWgPeerK
           ]}
         />
       </Form.Item>
-      <Form.List name={['settings', 'peers']}>
-        {(fields, { add, remove }) => (
-          <>
-            <Form.Item label={t('pages.inbounds.form.peers')}>
-              <Button
-                size="small"
-                onClick={() => {
-                  const kp = Wireguard.generateKeypair();
-                  const peers = form.getFieldValue(['settings', 'peers']) as Array<{ allowedIPs?: string[] }> | undefined;
-                  add({
-                    privateKey: kp.privateKey,
-                    publicKey: kp.publicKey,
-                    allowedIPs: [nextWgPeerAllowedIP(peers)],
-                    keepAlive: 0,
-                  });
-                }}
-              >
-                <PlusOutlined /> {t('pages.inbounds.form.addPeer')}
-              </Button>
-            </Form.Item>
-            {fields.map((field, idx) => (
-              <div key={field.key} className="wg-peer">
-                <Divider titlePlacement="center">
-                  <Space>
-                    <span>{t('pages.inbounds.info.peerNumber', { n: idx + 1 })}</span>
-                    <Form.Item noStyle shouldUpdate>
-                      {() => {
-                        const comment = form.getFieldValue(['settings', 'peers', field.name, 'comment']) as string | undefined;
-                        return comment ? <span style={{ opacity: 0.65 }}>— {comment}</span> : null;
-                      }}
-                    </Form.Item>
-                    {fields.length > 1 && (
-                      <Button
-                        size="small"
-                        danger
-                        icon={<MinusOutlined />}
-                        onClick={() => remove(field.name)}
-                      />
-                    )}
-                  </Space>
-                </Divider>
-                <Form.Item name={[field.name, 'comment']} label={t('comment')}>
-                  <Input placeholder="e.g. Alice's laptop" />
-                </Form.Item>
-                <Form.Item label={t('pages.xray.wireguard.secretKey')}>
-                  <Space.Compact block>
-                    <Form.Item name={[field.name, 'privateKey']} noStyle>
-                      <Input style={{ width: 'calc(100% - 32px)' }} />
-                    </Form.Item>
-                    <Button
-                      icon={<ReloadOutlined />}
-                      onClick={() => regenWgPeerKeypair(field.name)}
-                    />
-                  </Space.Compact>
-                </Form.Item>
-                <Form.Item name={[field.name, 'publicKey']} label={t('pages.xray.wireguard.publicKey')}>
-                  <Input />
-                </Form.Item>
-                <Form.Item name={[field.name, 'preSharedKey']} label="PSK">
-                  <Input />
-                </Form.Item>
-                <Form.List name={[field.name, 'allowedIPs']}>
-                  {(ipFields, { add: addIp, remove: removeIp }) => (
-                    <Form.Item label={t('pages.xray.wireguard.allowedIPs')}>
-                      <Button size="small" onClick={() => addIp('')}>
-                        <PlusOutlined />
-                      </Button>
-                      {ipFields.map((ipField) => (
-                        <Space.Compact key={ipField.key} block className="mt-4">
-                          <Form.Item name={ipField.name} noStyle>
-                            <Input />
-                          </Form.Item>
-                          {ipFields.length > 1 && (
-                            <Button size="small" onClick={() => removeIp(ipField.name)}>
-                              <MinusOutlined />
-                            </Button>
-                          )}
-                        </Space.Compact>
-                      ))}
-                    </Form.Item>
-                  )}
-                </Form.List>
-                <Form.Item name={[field.name, 'keepAlive']} label={t('pages.inbounds.form.keepAlive')}>
-                  <InputNumber min={0} />
-                </Form.Item>
-              </div>
-            ))}
-          </>
-        )}
-      </Form.List>
     </>
   );
 }

--- a/frontend/src/pages/inbounds/info/InboundInfoModal.tsx
+++ b/frontend/src/pages/inbounds/info/InboundInfoModal.tsx
@@ -1,7 +1,7 @@
-import { Fragment, useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Button, Divider, Modal, Space, Tabs, Tag, Tooltip } from 'antd';
-import { CopyOutlined, SyncOutlined, DeleteOutlined, DownloadOutlined } from '@ant-design/icons';
+import { CopyOutlined, SyncOutlined, DeleteOutlined } from '@ant-design/icons';
 
 import { HttpUtil, IntlUtil, SizeFormatter, ColorUtils } from '@/utils';
 import { Protocols } from '@/schemas/primitives';
@@ -9,8 +9,6 @@ import { InfinityIcon } from '@/components/ui';
 import { useDatepicker } from '@/hooks/useDatepicker';
 import {
   genAllLinks,
-  genWireguardConfigs,
-  genWireguardLinks,
   preferPublicHost,
 } from '@/lib/xray/inbound-link';
 import { inboundFromDb } from '@/lib/xray/inbound-from-db';
@@ -18,7 +16,6 @@ import { inboundFromDb } from '@/lib/xray/inbound-from-db';
 import {
   buildInboundInfo,
   copyText,
-  downloadText,
   formatIpInfo,
   hasShareLink,
   statsColor,
@@ -46,8 +43,6 @@ export default function InboundInfoModal({
   const [clientSettings, setClientSettings] = useState<ClientSetting | null>(null);
   const [clientStats, setClientStats] = useState<ClientStats | null>(null);
   const [links, setLinks] = useState<{ remark?: string; link: string }[]>([]);
-  const [wireguardConfigs, setWireguardConfigs] = useState<string[]>([]);
-  const [wireguardLinks, setWireguardLinks] = useState<string[]>([]);
   const [subLink, setSubLink] = useState('');
   const [subJsonLink, setSubJsonLink] = useState('');
   const [refreshing, setRefreshing] = useState(false);
@@ -114,25 +109,7 @@ export default function InboundInfoModal({
 
     const inboundForLinks = inboundFromDb(dbInbound);
     const fallbackHostname = preferPublicHost(window.location.hostname, subSettings?.publicHost ?? '');
-    if (info.protocol === Protocols.WIREGUARD) {
-      setWireguardConfigs(
-        genWireguardConfigs({
-          inbound: inboundForLinks,
-          remark: dbInbound.remark,
-          hostOverride: nodeAddress,
-          fallbackHostname,
-        }).split('\r\n'),
-      );
-      setWireguardLinks(
-        genWireguardLinks({
-          inbound: inboundForLinks,
-          remark: dbInbound.remark,
-          hostOverride: nodeAddress,
-          fallbackHostname,
-        }).split('\r\n'),
-      );
-      setLinks([]);
-    } else {
+    if (info.protocol !== Protocols.WIREGUARD) {
       setLinks(
         genAllLinks({
           inbound: inboundForLinks,
@@ -142,8 +119,8 @@ export default function InboundInfoModal({
           fallbackHostname,
         }),
       );
-      setWireguardConfigs([]);
-      setWireguardLinks([]);
+    } else {
+      setLinks([]);
     }
 
     if (clientSet?.subId) {
@@ -806,62 +783,12 @@ export default function InboundInfoModal({
               </dd>
             </div>
           </dl>
-          {Array.isArray(inbound.settings.peers) && (inbound.settings.peers as { privateKey: string; publicKey: string; psk: string; allowedIPs?: string[]; keepAlive?: number }[]).map((peer, idx) => (
-            <Fragment key={idx}>
-              <Divider>{t('pages.inbounds.info.peerNumber', { n: idx + 1 })}</Divider>
-              <dl className="info-list info-list-block">
-                <div className="info-row">
-                  <dt>{t('pages.xray.wireguard.secretKey')}</dt>
-                  <dd><Tag className="value-tag">{peer.privateKey}</Tag></dd>
-                </div>
-                <div className="info-row">
-                  <dt>{t('pages.xray.wireguard.publicKey')}</dt>
-                  <dd><Tag className="value-tag">{peer.publicKey}</Tag></dd>
-                </div>
-                <div className="info-row">
-                  <dt>PSK</dt>
-                  <dd><Tag className="value-tag">{peer.psk}</Tag></dd>
-                </div>
-                <div className="info-row">
-                  <dt>{t('pages.xray.wireguard.allowedIPs')}</dt>
-                  <dd>
-                    {(peer.allowedIPs || []).map((ip, j) => (
-                      <Tag key={`wg-ip-${idx}-${j}`} className="value-tag">{ip}</Tag>
-                    ))}
-                  </dd>
-                </div>
-                <div className="info-row">
-                  <dt>{t('pages.inbounds.info.keepAlive')}</dt>
-                  <dd><Tag>{peer.keepAlive}</Tag></dd>
-                </div>
-              </dl>
-              {wireguardConfigs[idx] && (
-                <div className="link-panel">
-                  <div className="link-panel-header">
-                    <Tag color="green">{t('pages.inbounds.info.peerNumberConfig', { n: idx + 1 })}</Tag>
-                    <Tooltip title={t('copy')}>
-                      <Button size="small" icon={<CopyOutlined />} onClick={() => copyText(wireguardConfigs[idx], t)} />
-                    </Tooltip>
-                    <Tooltip title={t('download')}>
-                      <Button size="small" icon={<DownloadOutlined />} onClick={() => downloadText(wireguardConfigs[idx], `peer-${idx + 1}.conf`)} />
-                    </Tooltip>
-                  </div>
-                  <code className="link-panel-text">{wireguardConfigs[idx]}</code>
-                </div>
-              )}
-              {wireguardLinks[idx] && (
-                <div className="link-panel">
-                  <div className="link-panel-header">
-                    <Tag color="green">Peer {idx + 1} link</Tag>
-                    <Tooltip title={t('copy')}>
-                      <Button size="small" icon={<CopyOutlined />} onClick={() => copyText(wireguardLinks[idx], t)} />
-                    </Tooltip>
-                  </div>
-                  <code className="link-panel-text">{wireguardLinks[idx]}</code>
-                </div>
-              )}
-            </Fragment>
-          ))}
+          {Array.isArray(inbound.settings.peers) && inbound.settings.peers.length > 0 && (
+            <div className="info-row" style={{ marginTop: 8 }}>
+              <Tag>{t('pages.inbounds.info.peerCount', { count: (inbound.settings.peers as unknown[]).length })}</Tag>
+              <span style={{ marginLeft: 8, opacity: 0.65, fontSize: 12 }}>{t('pages.inbounds.info.managePeersOnClientsTab')}</span>
+            </div>
+          )}
         </>
       )}
 

--- a/frontend/src/pages/inbounds/useInbounds.ts
+++ b/frontend/src/pages/inbounds/useInbounds.ts
@@ -55,6 +55,7 @@ const TRACKED_PROTOCOLS: readonly string[] = [
   Protocols.TROJAN,
   Protocols.SHADOWSOCKS,
   Protocols.HYSTERIA,
+  Protocols.WIREGUARD,
 ];
 
 async function fetchSlimInbounds(): Promise<unknown[]> {
@@ -297,9 +298,15 @@ export function useInbounds() {
       const settings = coerceInboundJsonField(dbInbound.settings) as {
         method?: string;
         clients?: Array<{ email?: string; enable?: boolean; comment?: string }>;
+        peers?: Array<{ comment?: string }>;
       };
       if (protocol === Protocols.SHADOWSOCKS && !isSSMultiUser({ protocol, settings })) continue;
-      counts[dbInbound.id] = rollupClients(dbInbound, { clients: settings.clients });
+      if (protocol === Protocols.WIREGUARD) {
+        const peers = (settings.peers || []).map((p) => ({ email: p.comment || '', enable: true as boolean }));
+        counts[dbInbound.id] = rollupClients(dbInbound, { clients: peers });
+      } else {
+        counts[dbInbound.id] = rollupClients(dbInbound, { clients: settings.clients });
+      }
     }
     setClientCount(counts);
   }, [rollupClients]);
@@ -317,9 +324,15 @@ export function useInbounds() {
         const settings = coerceInboundJsonField(dbInbound.settings) as {
           method?: string;
           clients?: Array<{ email?: string; enable?: boolean; comment?: string }>;
+          peers?: Array<{ comment?: string }>;
         };
         if (row.protocol === Protocols.SHADOWSOCKS && !isSSMultiUser({ protocol: row.protocol, settings })) continue;
-        counts[row.id] = rollupClients(dbInbound, { clients: settings.clients });
+        if (row.protocol === Protocols.WIREGUARD) {
+          const peers = (settings.peers || []).map((p) => ({ email: p.comment || '', enable: true as boolean }));
+          counts[row.id] = rollupClients(dbInbound, { clients: peers });
+        } else {
+          counts[row.id] = rollupClients(dbInbound, { clients: settings.clients });
+        }
       }
     }
     dbInboundsRef.current = next;

--- a/frontend/src/schemas/client.ts
+++ b/frontend/src/schemas/client.ts
@@ -52,6 +52,7 @@ export const InboundOptionSchema = z.object({
   port: z.number().optional(),
   tlsFlowCapable: z.boolean().optional(),
   ssMethod: z.string().optional(),
+  wgPublicKey: z.string().optional(),
   // Hosting node id; absent/null for this panel's own inbounds (#4997).
   nodeId: z.number().nullable().optional(),
 }).loose();

--- a/frontend/src/schemas/client.ts
+++ b/frontend/src/schemas/client.ts
@@ -12,6 +12,13 @@ export const ClientTrafficSchema = z.object({
   lastOnline: z.number().optional(),
 });
 
+export const WgPeerSchema = z.object({
+  publicKey: z.string(),
+  preSharedKey: z.string().optional(),
+  allowedIPs: z.array(z.string()).optional(),
+  keepAlive: z.number().optional(),
+}).loose();
+
 export const ClientRecordSchema = z.object({
   id: z.number().optional(),
   email: z.string(),
@@ -32,6 +39,7 @@ export const ClientRecordSchema = z.object({
   inboundIds: nullableNumberArray.optional(),
   traffic: ClientTrafficSchema.nullable().optional(),
   reverse: z.object({ tag: z.string().optional() }).loose().nullable().optional(),
+  wgPeer: WgPeerSchema.nullable().optional(),
   createdAt: z.number().optional(),
   updatedAt: z.number().optional(),
 }).loose();

--- a/internal/database/model/model.go
+++ b/internal/database/model/model.go
@@ -584,26 +584,35 @@ type ClientReverse struct {
 	Tag string `json:"tag"`
 }
 
+// WgPeerSettings holds WireGuard-specific peer configuration stored as JSON in the clients table.
+type WgPeerSettings struct {
+	PublicKey    string   `json:"publicKey"`
+	PreSharedKey string   `json:"preSharedKey,omitempty"`
+	AllowedIPs   []string `json:"allowedIPs"`
+	KeepAlive    int      `json:"keepAlive,omitempty"`
+}
+
 // Client represents a client configuration for Xray inbounds with traffic limits and settings.
 type Client struct {
-	ID         string         `json:"id,omitempty"`                 // Unique client identifier
-	Security   string         `json:"security"`                     // Security method (e.g., "auto", "aes-128-gcm")
-	Password   string         `json:"password,omitempty"`           // Client password
-	Flow       string         `json:"flow,omitempty"`               // Flow control (XTLS)
-	Reverse    *ClientReverse `json:"reverse,omitempty"`            // VLESS simple reverse proxy settings
-	Auth       string         `json:"auth,omitempty"`               // Auth password (Hysteria)
-	Email      string         `json:"email"`                        // Client email identifier
-	LimitIP    int            `json:"limitIp"`                      // IP limit for this client
-	TotalGB    int64          `json:"totalGB" form:"totalGB"`       // Total traffic limit in GB
-	ExpiryTime int64          `json:"expiryTime" form:"expiryTime"` // Expiration timestamp
-	Enable     bool           `json:"enable" form:"enable"`         // Whether the client is enabled
-	TgID       int64          `json:"tgId" form:"tgId"`             // Telegram user ID for notifications
-	SubID      string         `json:"subId" form:"subId"`           // Subscription identifier
-	Group      string         `json:"group,omitempty" form:"group"` // Logical grouping label
-	Comment    string         `json:"comment" form:"comment"`       // Client comment
-	Reset      int            `json:"reset" form:"reset"`           // Reset period in days
-	CreatedAt  int64          `json:"created_at,omitempty"`         // Creation timestamp
-	UpdatedAt  int64          `json:"updated_at,omitempty"`         // Last update timestamp
+	ID         string          `json:"id,omitempty"`                 // Unique client identifier
+	Security   string          `json:"security"`                     // Security method (e.g., "auto", "aes-128-gcm")
+	Password   string          `json:"password,omitempty"`           // Client password (WireGuard: private key)
+	Flow       string          `json:"flow,omitempty"`               // Flow control (XTLS)
+	Reverse    *ClientReverse  `json:"reverse,omitempty"`            // VLESS simple reverse proxy settings
+	Auth       string          `json:"auth,omitempty"`               // Auth password (Hysteria)
+	Email      string          `json:"email"`                        // Client email identifier
+	LimitIP    int             `json:"limitIp"`                      // IP limit for this client
+	TotalGB    int64           `json:"totalGB" form:"totalGB"`       // Total traffic limit in GB
+	ExpiryTime int64           `json:"expiryTime" form:"expiryTime"` // Expiration timestamp
+	Enable     bool            `json:"enable" form:"enable"`         // Whether the client is enabled
+	TgID       int64           `json:"tgId" form:"tgId"`             // Telegram user ID for notifications
+	SubID      string          `json:"subId" form:"subId"`           // Subscription identifier
+	Group      string          `json:"group,omitempty" form:"group"` // Logical grouping label
+	Comment    string          `json:"comment" form:"comment"`       // Client comment
+	Reset      int             `json:"reset" form:"reset"`           // Reset period in days
+	WgPeer     *WgPeerSettings `json:"wgPeer,omitempty"`             // WireGuard peer settings (nil for non-WG clients)
+	CreatedAt  int64           `json:"created_at,omitempty"`         // Creation timestamp
+	UpdatedAt  int64           `json:"updated_at,omitempty"`         // Last update timestamp
 }
 
 type ClientRecord struct {
@@ -616,6 +625,7 @@ type ClientRecord struct {
 	Flow       string `json:"flow"`
 	Security   string `json:"security"`
 	Reverse    string `json:"reverse" gorm:"column:reverse"`
+	WgSettings string `json:"-" gorm:"column:wg_settings;type:text"`
 	LimitIP    int    `json:"limitIp" gorm:"column:limit_ip"`
 	TotalGB    int64  `json:"totalGB" gorm:"column:total_gb"`
 	ExpiryTime int64  `json:"expiryTime" gorm:"column:expiry_time"`
@@ -639,27 +649,30 @@ type ClientGroup struct {
 
 func (ClientGroup) TableName() string { return "client_groups" }
 
-// MarshalJSON emits the reverse column as a nested JSON object rather than an
-// escaped JSON-text string, matching the same convention Inbound uses for its
+// MarshalJSON emits reverse and wgPeer columns as nested JSON objects rather than
+// escaped JSON-text strings, matching the same convention Inbound uses for its
 // JSON-text columns. Empty storage renders as null.
 func (r ClientRecord) MarshalJSON() ([]byte, error) {
 	type alias ClientRecord
 	return json.Marshal(struct {
 		alias
 		Reverse json.RawMessage `json:"reverse"`
+		WgPeer  json.RawMessage `json:"wgPeer"`
 	}{
 		alias:   alias(r),
 		Reverse: jsonStringFieldToRaw(r.Reverse),
+		WgPeer:  jsonStringFieldToRaw(r.WgSettings),
 	})
 }
 
-// UnmarshalJSON accepts reverse as either a JSON object (modern shape) or a
-// JSON-encoded string (legacy shape).
+// UnmarshalJSON accepts reverse and wgPeer as either JSON objects (modern shape)
+// or JSON-encoded strings (legacy shape).
 func (r *ClientRecord) UnmarshalJSON(data []byte) error {
 	type alias ClientRecord
 	aux := struct {
 		*alias
 		Reverse json.RawMessage `json:"reverse"`
+		WgPeer  json.RawMessage `json:"wgPeer"`
 	}{
 		alias: (*alias)(r),
 	}
@@ -667,6 +680,7 @@ func (r *ClientRecord) UnmarshalJSON(data []byte) error {
 		return err
 	}
 	r.Reverse = jsonStringFieldFromRaw(aux.Reverse)
+	r.WgSettings = jsonStringFieldFromRaw(aux.WgPeer)
 	return nil
 }
 
@@ -797,6 +811,11 @@ func (c *Client) ToRecord() *ClientRecord {
 			rec.Reverse = string(b)
 		}
 	}
+	if c.WgPeer != nil {
+		if b, err := json.Marshal(c.WgPeer); err == nil {
+			rec.WgSettings = string(b)
+		}
+	}
 	return rec
 }
 
@@ -824,6 +843,12 @@ func (r *ClientRecord) ToClient() *Client {
 		var rev ClientReverse
 		if err := json.Unmarshal([]byte(r.Reverse), &rev); err == nil {
 			c.Reverse = &rev
+		}
+	}
+	if r.WgSettings != "" {
+		var wg WgPeerSettings
+		if err := json.Unmarshal([]byte(r.WgSettings), &wg); err == nil {
+			c.WgPeer = &wg
 		}
 	}
 	return c

--- a/internal/web/controller/inbound.go
+++ b/internal/web/controller/inbound.go
@@ -79,6 +79,10 @@ func (a *InboundController) initRouter(g *gin.RouterGroup) {
 	g.POST("/import", a.importInbound)
 	g.POST("/:id/fallbacks", a.setFallbacks)
 	g.POST("/pushClientTraffics", a.pushClientTraffics)
+
+	g.POST("/:id/addWgClient", a.addWgClient)
+	g.POST("/:id/updateWgClient", a.updateWgClient)
+	g.POST("/:id/delWgClient", a.delWgClient)
 }
 
 // getInbounds retrieves the list of inbounds for the logged-in user.
@@ -463,4 +467,92 @@ func (a *InboundController) setFallbacks(c *gin.Context) {
 	}
 	a.xrayService.SetToNeedRestart()
 	jsonMsg(c, I18nWeb(c, "pages.inbounds.toasts.inboundUpdateSuccess"), nil)
+}
+
+// addWgClient adds a WireGuard peer as a client to the given inbound.
+// Body: model.ClientRecord with wg_settings populated.
+func (a *InboundController) addWgClient(c *gin.Context) {
+	id, err := strconv.Atoi(c.Param("id"))
+	if err != nil {
+		jsonMsg(c, I18nWeb(c, "somethingWentWrong"), err)
+		return
+	}
+	var rec model.ClientRecord
+	if err := c.ShouldBindJSON(&rec); err != nil {
+		jsonMsg(c, I18nWeb(c, "somethingWentWrong"), err)
+		return
+	}
+	needRestart, err := a.clientService.AddWgClient(&a.inboundService, id, &rec)
+	if err != nil {
+		jsonMsg(c, I18nWeb(c, "somethingWentWrong"), err)
+		return
+	}
+	jsonMsg(c, I18nWeb(c, "pages.clients.toasts.clientAdded"), nil)
+	if needRestart {
+		a.xrayService.SetToNeedRestart()
+	}
+	user := session.GetLoginUser(c)
+	a.broadcastInboundsUpdate(user.Id)
+	notifyClientsChanged()
+}
+
+// updateWgClient updates a WireGuard peer by email for the given inbound.
+// Body: model.ClientRecord with updated fields.
+func (a *InboundController) updateWgClient(c *gin.Context) {
+	id, err := strconv.Atoi(c.Param("id"))
+	if err != nil {
+		jsonMsg(c, I18nWeb(c, "somethingWentWrong"), err)
+		return
+	}
+	type updateBody struct {
+		Email string            `json:"email"`
+		Peer  model.ClientRecord `json:"peer"`
+	}
+	var b updateBody
+	if err := c.ShouldBindJSON(&b); err != nil {
+		jsonMsg(c, I18nWeb(c, "somethingWentWrong"), err)
+		return
+	}
+	needRestart, err := a.clientService.UpdateWgClient(&a.inboundService, id, b.Email, &b.Peer)
+	if err != nil {
+		jsonMsg(c, I18nWeb(c, "somethingWentWrong"), err)
+		return
+	}
+	jsonMsg(c, I18nWeb(c, "pages.clients.toasts.clientUpdated"), nil)
+	if needRestart {
+		a.xrayService.SetToNeedRestart()
+	}
+	user := session.GetLoginUser(c)
+	a.broadcastInboundsUpdate(user.Id)
+	notifyClientsChanged()
+}
+
+// delWgClient removes a WireGuard peer by email from the given inbound.
+// Body: {"email": "peer-name"}.
+func (a *InboundController) delWgClient(c *gin.Context) {
+	id, err := strconv.Atoi(c.Param("id"))
+	if err != nil {
+		jsonMsg(c, I18nWeb(c, "somethingWentWrong"), err)
+		return
+	}
+	type delBody struct {
+		Email string `json:"email"`
+	}
+	var b delBody
+	if err := c.ShouldBindJSON(&b); err != nil {
+		jsonMsg(c, I18nWeb(c, "somethingWentWrong"), err)
+		return
+	}
+	needRestart, err := a.clientService.DelWgClient(&a.inboundService, id, b.Email)
+	if err != nil {
+		jsonMsg(c, I18nWeb(c, "somethingWentWrong"), err)
+		return
+	}
+	jsonMsg(c, I18nWeb(c, "pages.clients.toasts.clientDeleted"), nil)
+	if needRestart {
+		a.xrayService.SetToNeedRestart()
+	}
+	user := session.GetLoginUser(c)
+	a.broadcastInboundsUpdate(user.Id)
+	notifyClientsChanged()
 }

--- a/internal/web/service/client_crud.go
+++ b/internal/web/service/client_crud.go
@@ -381,6 +381,32 @@ func (s *ClientService) Update(inboundSvc *InboundService, id int, updated model
 		if existing.Email == "" {
 			continue
 		}
+		if inbound.Protocol == model.WireGuard {
+			wgRec := *existing
+			wgRec.Enable = updated.Enable
+			if updated.Email != "" {
+				wgRec.Email = updated.Email
+			}
+			if updated.Password != "" {
+				wgRec.Password = updated.Password
+			}
+			if updated.Comment != "" {
+				wgRec.Comment = updated.Comment
+			}
+			if updated.WgPeer != nil {
+				if b, mErr := json.Marshal(updated.WgPeer); mErr == nil {
+					wgRec.WgSettings = string(b)
+				}
+			}
+			nr, upErr := s.UpdateWgClient(inboundSvc, ibId, existing.Email, &wgRec)
+			if upErr != nil {
+				return needRestart, upErr
+			}
+			if nr {
+				needRestart = true
+			}
+			continue
+		}
 		if err := s.fillProtocolDefaults(&updated, inbound); err != nil {
 			return needRestart, err
 		}

--- a/internal/web/service/client_crud.go
+++ b/internal/web/service/client_crud.go
@@ -101,6 +101,22 @@ func (s *ClientService) Create(inboundSvc *InboundService, payload *ClientCreate
 		if getErr != nil {
 			return needRestart, getErr
 		}
+
+		if inbound.Protocol == model.WireGuard {
+			if client.WgPeer == nil {
+				return false, common.NewError("WireGuard peer settings (wgPeer) are required")
+			}
+			rec := client.ToRecord()
+			nr, addErr := s.AddWgClient(inboundSvc, ibId, rec)
+			if addErr != nil {
+				return needRestart, addErr
+			}
+			if nr {
+				needRestart = true
+			}
+			continue
+		}
+
 		if err := s.fillProtocolDefaults(&client, inbound); err != nil {
 			return needRestart, err
 		}
@@ -513,6 +529,21 @@ func (s *ClientService) Attach(inboundSvc *InboundService, id int, inboundIds []
 		if getErr != nil {
 			return needRestart, getErr
 		}
+
+		if inbound.Protocol == model.WireGuard {
+			if existing.WgSettings == "" {
+				return false, common.NewError("client has no WireGuard peer settings; cannot attach to WireGuard inbound")
+			}
+			nr, addErr := s.AddWgClient(inboundSvc, ibId, existing)
+			if addErr != nil {
+				return needRestart, addErr
+			}
+			if nr {
+				needRestart = true
+			}
+			continue
+		}
+
 		copyClient := *clientWire
 		if err := s.fillProtocolDefaults(&copyClient, inbound); err != nil {
 			return needRestart, err

--- a/internal/web/service/client_crud.go
+++ b/internal/web/service/client_crud.go
@@ -446,21 +446,28 @@ func (s *ClientService) Delete(inboundSvc *InboundService, id int, keepTraffic b
 
 	needRestart := false
 	for _, ibId := range inboundIds {
-		if _, getErr := inboundSvc.GetInbound(ibId); getErr != nil {
+		ib, getErr := inboundSvc.GetInbound(ibId)
+		if getErr != nil {
 			if errors.Is(getErr, gorm.ErrRecordNotFound) {
 				continue
 			}
 			return needRestart, getErr
 		}
 
-		// Always delete by email — the client's stable identity. This removes
-		// every matching entry from the inbound's settings even when the stored
-		// credential (UUID/password/auth) drifted from the inbound JSON, or a
-		// duplicate entry with the same email exists.
 		if existing.Email == "" {
 			continue
 		}
-		nr, delErr := s.DelInboundClientByEmail(inboundSvc, ibId, existing.Email, false)
+
+		var nr bool
+		var delErr error
+		if ib.Protocol == model.WireGuard {
+			// WireGuard peers are managed via the dedicated WG path which
+			// rebuilds settings.peers[] and does its own client-record cleanup.
+			nr, delErr = s.DelWgClient(inboundSvc, ibId, existing.Email)
+		} else {
+			// Always delete by email — the client's stable identity.
+			nr, delErr = s.DelInboundClientByEmail(inboundSvc, ibId, existing.Email, false)
+		}
 		if delErr != nil {
 			// The client is already absent from this inbound (data drift or a
 			// retried delete). Skip it — deletion stays idempotent.

--- a/internal/web/service/client_link.go
+++ b/internal/web/service/client_link.go
@@ -82,6 +82,9 @@ func (s *ClientService) SyncInbound(tx *gorm.DB, inboundId int, clients []model.
 		if incoming.Reverse != "" {
 			row.Reverse = incoming.Reverse
 		}
+		if incoming.WgSettings != "" {
+			row.WgSettings = incoming.WgSettings
+		}
 		row.SubID = incoming.SubID
 		row.LimitIP = incoming.LimitIP
 		row.TotalGB = incoming.TotalGB

--- a/internal/web/service/client_paging.go
+++ b/internal/web/service/client_paging.go
@@ -1,12 +1,14 @@
 package service
 
 import (
+	"encoding/json"
 	"slices"
 	"sort"
 	"strconv"
 	"strings"
 	"time"
 
+	"github.com/mhsanaei/3x-ui/v3/internal/database/model"
 	"github.com/mhsanaei/3x-ui/v3/internal/xray"
 )
 
@@ -15,19 +17,20 @@ import (
 // so the list payload stays compact even when the panel manages thousands
 // of clients. Modals that need the full record still call /get/:email.
 type ClientSlim struct {
-	Email      string              `json:"email"`
-	SubID      string              `json:"subId"`
-	Enable     bool                `json:"enable"`
-	TotalGB    int64               `json:"totalGB"`
-	ExpiryTime int64               `json:"expiryTime"`
-	LimitIP    int                 `json:"limitIp"`
-	Reset      int                 `json:"reset"`
-	Group      string              `json:"group,omitempty"`
-	Comment    string              `json:"comment,omitempty"`
-	InboundIds []int               `json:"inboundIds"`
-	Traffic    *xray.ClientTraffic `json:"traffic,omitempty"`
-	CreatedAt  int64               `json:"createdAt"`
-	UpdatedAt  int64               `json:"updatedAt"`
+	Email      string                 `json:"email"`
+	SubID      string                 `json:"subId"`
+	Enable     bool                   `json:"enable"`
+	TotalGB    int64                  `json:"totalGB"`
+	ExpiryTime int64                  `json:"expiryTime"`
+	LimitIP    int                    `json:"limitIp"`
+	Reset      int                    `json:"reset"`
+	Group      string                 `json:"group,omitempty"`
+	Comment    string                 `json:"comment,omitempty"`
+	InboundIds []int                  `json:"inboundIds"`
+	Traffic    *xray.ClientTraffic    `json:"traffic,omitempty"`
+	WgPeer     *model.WgPeerSettings  `json:"wgPeer,omitempty"`
+	CreatedAt  int64                  `json:"createdAt"`
+	UpdatedAt  int64                  `json:"updatedAt"`
 }
 
 // ClientPageParams are the query params accepted by /panel/api/clients/list/paged.
@@ -263,7 +266,7 @@ func buildClientsSummary(all []ClientWithAttachments, onlineSet map[string]struc
 }
 
 func toClientSlim(c ClientWithAttachments) ClientSlim {
-	return ClientSlim{
+	s := ClientSlim{
 		Email:      c.Email,
 		SubID:      c.SubID,
 		Enable:     c.Enable,
@@ -278,6 +281,13 @@ func toClientSlim(c ClientWithAttachments) ClientSlim {
 		CreatedAt:  c.CreatedAt,
 		UpdatedAt:  c.UpdatedAt,
 	}
+	if c.WgSettings != "" {
+		var wg model.WgPeerSettings
+		if err := json.Unmarshal([]byte(c.WgSettings), &wg); err == nil {
+			s.WgPeer = &wg
+		}
+	}
+	return s
 }
 
 func clientMatchesSearch(c ClientWithAttachments, needle string) bool {

--- a/internal/web/service/client_wg_apply.go
+++ b/internal/web/service/client_wg_apply.go
@@ -13,37 +13,8 @@ import (
 	"gorm.io/gorm"
 )
 
-// wgRecordsForInbound fetches all ClientRecord rows attached to a WireGuard inbound.
-func wgRecordsForInbound(tx *gorm.DB, inboundId int) ([]*model.ClientRecord, error) {
-	if tx == nil {
-		tx = database.GetDB()
-	}
-	var recs []*model.ClientRecord
-	err := tx.Table("clients").
-		Joins("JOIN client_inbounds ON client_inbounds.client_id = clients.id").
-		Where("client_inbounds.inbound_id = ?", inboundId).
-		Order("clients.id ASC").
-		Find(&recs).Error
-	return recs, err
-}
-
-// rebuildAndSaveWgPeers rebuilds settings.peers[] from the current clients list
-// and persists the inbound to the database. Must be called inside a transaction.
-func rebuildAndSaveWgPeers(tx *gorm.DB, inbound *model.Inbound) error {
-	recs, err := wgRecordsForInbound(tx, inbound.Id)
-	if err != nil {
-		return err
-	}
-	newSettings, err := syncWgPeersFromClients(inbound.Settings, recs)
-	if err != nil {
-		return err
-	}
-	inbound.Settings = newSettings
-	return tx.Save(inbound).Error
-}
-
 // AddWgClient creates a WireGuard peer as a client record, attaches it to the
-// inbound, rebuilds settings.peers[], and triggers an xray restart.
+// inbound, appends the peer to settings.peers[], and triggers an xray hot-reload.
 func (s *ClientService) AddWgClient(inboundSvc *InboundService, inboundId int, rec *model.ClientRecord) (bool, error) {
 	defer lockInbound(inboundId).Unlock()
 
@@ -62,7 +33,6 @@ func (s *ClientService) AddWgClient(inboundSvc *InboundService, inboundId int, r
 		return false, common.NewError("inbound is not WireGuard")
 	}
 
-	// Check for duplicate email.
 	var existing model.ClientRecord
 	checkErr := database.GetDB().Where("email = ?", rec.Email).First(&existing).Error
 	if checkErr == nil {
@@ -70,6 +40,11 @@ func (s *ClientService) AddWgClient(inboundSvc *InboundService, inboundId int, r
 	}
 	if !errors.Is(checkErr, gorm.ErrRecordNotFound) {
 		return false, checkErr
+	}
+
+	peer, err := buildPeerMap(rec)
+	if err != nil {
+		return false, err
 	}
 
 	now := time.Now().UnixMilli()
@@ -86,7 +61,12 @@ func (s *ClientService) AddWgClient(inboundSvc *InboundService, inboundId int, r
 		if err := tx.Create(&link).Error; err != nil {
 			return err
 		}
-		return rebuildAndSaveWgPeers(tx, inbound)
+		newSettings, sErr := addPeerToSettings(inbound.Settings, peer)
+		if sErr != nil {
+			return sErr
+		}
+		inbound.Settings = newSettings
+		return tx.Save(inbound).Error
 	})
 	if txErr != nil {
 		return false, txErr
@@ -108,7 +88,7 @@ func (s *ClientService) AddWgClient(inboundSvc *InboundService, inboundId int, r
 }
 
 // UpdateWgClient finds the peer by email, updates its record and wg_settings,
-// rebuilds settings.peers[], and triggers an xray restart.
+// patches settings.peers[] in-place, and triggers an xray hot-reload.
 func (s *ClientService) UpdateWgClient(inboundSvc *InboundService, inboundId int, email string, rec *model.ClientRecord) (bool, error) {
 	defer lockInbound(inboundId).Unlock()
 
@@ -133,12 +113,23 @@ func (s *ClientService) UpdateWgClient(inboundSvc *InboundService, inboundId int
 	existing.Comment = rec.Comment
 	existing.UpdatedAt = now
 
+	peer, err := buildPeerMap(&existing)
+	if err != nil {
+		return false, err
+	}
+
 	needRestart := false
 	txErr := runSerializedTx(func(tx *gorm.DB) error {
 		if err := tx.Save(&existing).Error; err != nil {
 			return err
 		}
-		return rebuildAndSaveWgPeers(tx, inbound)
+		// peer == nil when WgSettings is empty: treat as disabled in peers[].
+		newSettings, sErr := updatePeerInSettings(inbound.Settings, email, peer, existing.Enable && peer != nil)
+		if sErr != nil {
+			return sErr
+		}
+		inbound.Settings = newSettings
+		return tx.Save(inbound).Error
 	})
 	if txErr != nil {
 		return false, txErr
@@ -159,8 +150,8 @@ func (s *ClientService) UpdateWgClient(inboundSvc *InboundService, inboundId int
 	return needRestart, nil
 }
 
-// DelWgClient removes the peer by email, rebuilds settings.peers[], and
-// triggers an xray restart.
+// DelWgClient removes the peer by email, removes it from settings.peers[], and
+// triggers an xray hot-reload.
 func (s *ClientService) DelWgClient(inboundSvc *InboundService, inboundId int, email string) (bool, error) {
 	defer lockInbound(inboundId).Unlock()
 
@@ -183,7 +174,6 @@ func (s *ClientService) DelWgClient(inboundSvc *InboundService, inboundId int, e
 			Delete(&model.ClientInbound{}).Error; err != nil {
 			return err
 		}
-		// Check if this client is attached to other inbounds before deleting the record.
 		var otherLinks int64
 		tx.Model(&model.ClientInbound{}).Where("client_id = ?", rec.Id).Count(&otherLinks)
 		if otherLinks == 0 {
@@ -191,7 +181,12 @@ func (s *ClientService) DelWgClient(inboundSvc *InboundService, inboundId int, e
 				return err
 			}
 		}
-		return rebuildAndSaveWgPeers(tx, inbound)
+		newSettings, sErr := removePeerFromSettings(inbound.Settings, email)
+		if sErr != nil {
+			return sErr
+		}
+		inbound.Settings = newSettings
+		return tx.Save(inbound).Error
 	})
 	if txErr != nil {
 		return false, txErr

--- a/internal/web/service/client_wg_apply.go
+++ b/internal/web/service/client_wg_apply.go
@@ -1,0 +1,213 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"github.com/mhsanaei/3x-ui/v3/internal/database"
+	"github.com/mhsanaei/3x-ui/v3/internal/database/model"
+	"github.com/mhsanaei/3x-ui/v3/internal/logger"
+	"github.com/mhsanaei/3x-ui/v3/internal/util/common"
+
+	"gorm.io/gorm"
+)
+
+// wgRecordsForInbound fetches all ClientRecord rows attached to a WireGuard inbound.
+func wgRecordsForInbound(tx *gorm.DB, inboundId int) ([]*model.ClientRecord, error) {
+	if tx == nil {
+		tx = database.GetDB()
+	}
+	var recs []*model.ClientRecord
+	err := tx.Table("clients").
+		Joins("JOIN client_inbounds ON client_inbounds.client_id = clients.id").
+		Where("client_inbounds.inbound_id = ?", inboundId).
+		Order("clients.id ASC").
+		Find(&recs).Error
+	return recs, err
+}
+
+// rebuildAndSaveWgPeers rebuilds settings.peers[] from the current clients list
+// and persists the inbound to the database. Must be called inside a transaction.
+func rebuildAndSaveWgPeers(tx *gorm.DB, inbound *model.Inbound) error {
+	recs, err := wgRecordsForInbound(tx, inbound.Id)
+	if err != nil {
+		return err
+	}
+	newSettings, err := syncWgPeersFromClients(inbound.Settings, recs)
+	if err != nil {
+		return err
+	}
+	inbound.Settings = newSettings
+	return tx.Save(inbound).Error
+}
+
+// AddWgClient creates a WireGuard peer as a client record, attaches it to the
+// inbound, rebuilds settings.peers[], and triggers an xray restart.
+func (s *ClientService) AddWgClient(inboundSvc *InboundService, inboundId int, rec *model.ClientRecord) (bool, error) {
+	defer lockInbound(inboundId).Unlock()
+
+	if rec.Email == "" {
+		return false, common.NewError("peer name (email) is required")
+	}
+	if rec.WgSettings == "" {
+		return false, common.NewError("WireGuard peer settings are required")
+	}
+
+	inbound, err := inboundSvc.GetInbound(inboundId)
+	if err != nil {
+		return false, err
+	}
+	if inbound.Protocol != model.WireGuard {
+		return false, common.NewError("inbound is not WireGuard")
+	}
+
+	// Check for duplicate email.
+	var existing model.ClientRecord
+	checkErr := database.GetDB().Where("email = ?", rec.Email).First(&existing).Error
+	if checkErr == nil {
+		return false, common.NewError("peer name already in use:", rec.Email)
+	}
+	if !errors.Is(checkErr, gorm.ErrRecordNotFound) {
+		return false, checkErr
+	}
+
+	now := time.Now().UnixMilli()
+	rec.Enable = true
+	rec.CreatedAt = now
+	rec.UpdatedAt = now
+
+	needRestart := false
+	txErr := runSerializedTx(func(tx *gorm.DB) error {
+		if err := tx.Create(rec).Error; err != nil {
+			return err
+		}
+		link := model.ClientInbound{ClientId: rec.Id, InboundId: inboundId}
+		if err := tx.Create(&link).Error; err != nil {
+			return err
+		}
+		return rebuildAndSaveWgPeers(tx, inbound)
+	})
+	if txErr != nil {
+		return false, txErr
+	}
+
+	rt, push, _, perr := inboundSvc.nodePushPlan(inbound)
+	if perr != nil {
+		logger.Warning("nodePushPlan failed after WG peer add:", perr)
+		needRestart = true
+	} else if push {
+		if err := rt.UpdateInbound(context.Background(), inbound, inbound); err != nil {
+			logger.Warning("WG inbound update on runtime failed:", err)
+			needRestart = true
+		}
+	} else {
+		needRestart = true
+	}
+	return needRestart, nil
+}
+
+// UpdateWgClient finds the peer by email, updates its record and wg_settings,
+// rebuilds settings.peers[], and triggers an xray restart.
+func (s *ClientService) UpdateWgClient(inboundSvc *InboundService, inboundId int, email string, rec *model.ClientRecord) (bool, error) {
+	defer lockInbound(inboundId).Unlock()
+
+	inbound, err := inboundSvc.GetInbound(inboundId)
+	if err != nil {
+		return false, err
+	}
+	if inbound.Protocol != model.WireGuard {
+		return false, common.NewError("inbound is not WireGuard")
+	}
+
+	var existing model.ClientRecord
+	if err := database.GetDB().Where("email = ?", email).First(&existing).Error; err != nil {
+		return false, common.NewError("peer not found:", email)
+	}
+
+	now := time.Now().UnixMilli()
+	existing.Email = rec.Email
+	existing.Password = rec.Password
+	existing.WgSettings = rec.WgSettings
+	existing.Enable = rec.Enable
+	existing.Comment = rec.Comment
+	existing.UpdatedAt = now
+
+	needRestart := false
+	txErr := runSerializedTx(func(tx *gorm.DB) error {
+		if err := tx.Save(&existing).Error; err != nil {
+			return err
+		}
+		return rebuildAndSaveWgPeers(tx, inbound)
+	})
+	if txErr != nil {
+		return false, txErr
+	}
+
+	rt, push, _, perr := inboundSvc.nodePushPlan(inbound)
+	if perr != nil {
+		logger.Warning("nodePushPlan failed after WG peer update:", perr)
+		needRestart = true
+	} else if push {
+		if err := rt.UpdateInbound(context.Background(), inbound, inbound); err != nil {
+			logger.Warning("WG inbound update on runtime failed:", err)
+			needRestart = true
+		}
+	} else {
+		needRestart = true
+	}
+	return needRestart, nil
+}
+
+// DelWgClient removes the peer by email, rebuilds settings.peers[], and
+// triggers an xray restart.
+func (s *ClientService) DelWgClient(inboundSvc *InboundService, inboundId int, email string) (bool, error) {
+	defer lockInbound(inboundId).Unlock()
+
+	inbound, err := inboundSvc.GetInbound(inboundId)
+	if err != nil {
+		return false, err
+	}
+	if inbound.Protocol != model.WireGuard {
+		return false, common.NewError("inbound is not WireGuard")
+	}
+
+	var rec model.ClientRecord
+	if err := database.GetDB().Where("email = ?", email).First(&rec).Error; err != nil {
+		return false, common.NewError("peer not found:", email)
+	}
+
+	needRestart := false
+	txErr := runSerializedTx(func(tx *gorm.DB) error {
+		if err := tx.Where("client_id = ? AND inbound_id = ?", rec.Id, inboundId).
+			Delete(&model.ClientInbound{}).Error; err != nil {
+			return err
+		}
+		// Check if this client is attached to other inbounds before deleting the record.
+		var otherLinks int64
+		tx.Model(&model.ClientInbound{}).Where("client_id = ?", rec.Id).Count(&otherLinks)
+		if otherLinks == 0 {
+			if err := tx.Delete(&rec).Error; err != nil {
+				return err
+			}
+		}
+		return rebuildAndSaveWgPeers(tx, inbound)
+	})
+	if txErr != nil {
+		return false, txErr
+	}
+
+	rt, push, _, perr := inboundSvc.nodePushPlan(inbound)
+	if perr != nil {
+		logger.Warning("nodePushPlan failed after WG peer del:", perr)
+		needRestart = true
+	} else if push {
+		if err := rt.UpdateInbound(context.Background(), inbound, inbound); err != nil {
+			logger.Warning("WG inbound update on runtime failed:", err)
+			needRestart = true
+		}
+	} else {
+		needRestart = true
+	}
+	return needRestart, nil
+}

--- a/internal/web/service/client_wg_peers.go
+++ b/internal/web/service/client_wg_peers.go
@@ -59,6 +59,100 @@ func syncWgPeersFromClients(settingsJSON string, clients []*model.ClientRecord) 
 	return string(updated), nil
 }
 
+// buildPeerMap converts a ClientRecord into a peer map for settings.peers[].
+// Returns nil if the record has no WgSettings.
+func buildPeerMap(rec *model.ClientRecord) (map[string]any, error) {
+	if rec.WgSettings == "" {
+		return nil, nil
+	}
+	var wg model.WgPeerSettings
+	if err := json.Unmarshal([]byte(rec.WgSettings), &wg); err != nil {
+		return nil, err
+	}
+	peer := map[string]any{
+		"publicKey":  wg.PublicKey,
+		"allowedIPs": wg.AllowedIPs,
+	}
+	if rec.Password != "" {
+		peer["privateKey"] = rec.Password
+	}
+	if wg.PreSharedKey != "" {
+		peer["preSharedKey"] = wg.PreSharedKey
+	}
+	if wg.KeepAlive > 0 {
+		peer["keepAlive"] = wg.KeepAlive
+	}
+	if rec.Email != "" {
+		peer["comment"] = rec.Email
+	}
+	return peer, nil
+}
+
+// addPeerToSettings appends one peer to settings.peers[] without a DB query.
+func addPeerToSettings(settingsJSON string, peer map[string]any) (string, error) {
+	var settings map[string]any
+	if err := json.Unmarshal([]byte(settingsJSON), &settings); err != nil {
+		return settingsJSON, err
+	}
+	raw, _ := settings["peers"].([]any)
+	settings["peers"] = append(raw, peer)
+	updated, err := json.MarshalIndent(settings, "", "  ")
+	if err != nil {
+		return settingsJSON, err
+	}
+	return string(updated), nil
+}
+
+// removePeerFromSettings removes the peer whose comment matches email.
+func removePeerFromSettings(settingsJSON string, email string) (string, error) {
+	var settings map[string]any
+	if err := json.Unmarshal([]byte(settingsJSON), &settings); err != nil {
+		return settingsJSON, err
+	}
+	raw, _ := settings["peers"].([]any)
+	peers := make([]any, 0, len(raw))
+	for _, p := range raw {
+		m, ok := p.(map[string]any)
+		if ok && m["comment"] == email {
+			continue
+		}
+		peers = append(peers, p)
+	}
+	settings["peers"] = peers
+	updated, err := json.MarshalIndent(settings, "", "  ")
+	if err != nil {
+		return settingsJSON, err
+	}
+	return string(updated), nil
+}
+
+// updatePeerInSettings removes the peer with oldEmail and (if enabled and peer != nil)
+// appends newPeer. Mirrors syncWgPeersFromClients: disabled peers are absent from peers[].
+func updatePeerInSettings(settingsJSON, oldEmail string, newPeer map[string]any, enabled bool) (string, error) {
+	var settings map[string]any
+	if err := json.Unmarshal([]byte(settingsJSON), &settings); err != nil {
+		return settingsJSON, err
+	}
+	raw, _ := settings["peers"].([]any)
+	peers := make([]any, 0, len(raw)+1)
+	for _, p := range raw {
+		m, ok := p.(map[string]any)
+		if ok && m["comment"] == oldEmail {
+			continue
+		}
+		peers = append(peers, p)
+	}
+	if enabled && newPeer != nil {
+		peers = append(peers, newPeer)
+	}
+	settings["peers"] = peers
+	updated, err := json.MarshalIndent(settings, "", "  ")
+	if err != nil {
+		return settingsJSON, err
+	}
+	return string(updated), nil
+}
+
 // wgPeersFromSettings extracts the peers array from a WireGuard inbound settings JSON.
 func wgPeersFromSettings(settingsJSON string) ([]map[string]any, error) {
 	var settings map[string]any

--- a/internal/web/service/client_wg_peers.go
+++ b/internal/web/service/client_wg_peers.go
@@ -21,6 +21,9 @@ func syncWgPeersFromClients(settingsJSON string, clients []*model.ClientRecord) 
 
 	peers := make([]map[string]any, 0, len(clients))
 	for _, rec := range clients {
+		if !rec.Enable {
+			continue
+		}
 		if rec.WgSettings == "" {
 			continue
 		}

--- a/internal/web/service/client_wg_peers.go
+++ b/internal/web/service/client_wg_peers.go
@@ -1,0 +1,145 @@
+package service
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/mhsanaei/3x-ui/v3/internal/database/model"
+	"gorm.io/gorm"
+)
+
+// syncWgPeersFromClients rebuilds settings.peers[] in the inbound JSON from
+// the provided list of WireGuard client records. Call this after any WireGuard
+// client create/update/delete so that xray always sees the canonical peer list.
+//
+// Returns the updated settings JSON string.
+func syncWgPeersFromClients(settingsJSON string, clients []*model.ClientRecord) (string, error) {
+	var settings map[string]any
+	if err := json.Unmarshal([]byte(settingsJSON), &settings); err != nil {
+		return settingsJSON, err
+	}
+
+	peers := make([]map[string]any, 0, len(clients))
+	for _, rec := range clients {
+		if rec.WgSettings == "" {
+			continue
+		}
+		var wg model.WgPeerSettings
+		if err := json.Unmarshal([]byte(rec.WgSettings), &wg); err != nil {
+			continue
+		}
+		peer := map[string]any{
+			"publicKey":  wg.PublicKey,
+			"allowedIPs": wg.AllowedIPs,
+		}
+		if rec.Password != "" {
+			peer["privateKey"] = rec.Password
+		}
+		if wg.PreSharedKey != "" {
+			peer["preSharedKey"] = wg.PreSharedKey
+		}
+		if wg.KeepAlive > 0 {
+			peer["keepAlive"] = wg.KeepAlive
+		}
+		if rec.Email != "" {
+			peer["comment"] = rec.Email
+		}
+		peers = append(peers, peer)
+	}
+
+	settings["peers"] = peers
+
+	updated, err := json.MarshalIndent(settings, "", "  ")
+	if err != nil {
+		return settingsJSON, err
+	}
+	return string(updated), nil
+}
+
+// wgPeersFromSettings extracts the peers array from a WireGuard inbound settings JSON.
+func wgPeersFromSettings(settingsJSON string) ([]map[string]any, error) {
+	var settings map[string]any
+	if err := json.Unmarshal([]byte(settingsJSON), &settings); err != nil {
+		return nil, err
+	}
+	raw, _ := settings["peers"].([]any)
+	peers := make([]map[string]any, 0, len(raw))
+	for _, p := range raw {
+		if m, ok := p.(map[string]any); ok {
+			peers = append(peers, m)
+		}
+	}
+	return peers, nil
+}
+
+// wgPeerToRecord converts a WireGuard peer map (from settings.peers[]) into a
+// ClientRecord for migration. If comment is empty, a fallback email is generated
+// using the inbound name and index.
+func wgPeerToRecord(peer map[string]any, inboundName string, idx int) *model.ClientRecord {
+	allowedIPs := []string{}
+	if ips, ok := peer["allowedIPs"].([]any); ok {
+		for _, ip := range ips {
+			if s, ok := ip.(string); ok {
+				allowedIPs = append(allowedIPs, s)
+			}
+		}
+	}
+
+	pubKey, _ := peer["publicKey"].(string)
+	privKey, _ := peer["privateKey"].(string)
+	psk, _ := peer["preSharedKey"].(string)
+	keepAlive := 0
+	if ka, ok := peer["keepAlive"].(float64); ok {
+		keepAlive = int(ka)
+	}
+
+	email, _ := peer["comment"].(string)
+	if email == "" {
+		email = fmt.Sprintf("%s-peer-%d", inboundName, idx+1)
+	}
+
+	wg := model.WgPeerSettings{
+		PublicKey:    pubKey,
+		PreSharedKey: psk,
+		AllowedIPs:   allowedIPs,
+		KeepAlive:    keepAlive,
+	}
+	wgJSON, _ := json.Marshal(wg)
+
+	return &model.ClientRecord{
+		Email:      email,
+		Password:   privKey,
+		Enable:     true,
+		WgSettings: string(wgJSON),
+	}
+}
+
+// SyncWgInbound builds Client list from settings.peers[] and calls SyncInbound
+// so that the clients table and client_inbounds junction stay in sync with the
+// inbound's peers array. Used during migration and after inbound save.
+func (s *ClientService) SyncWgInbound(tx *gorm.DB, inbound *model.Inbound) error {
+	peers, err := wgPeersFromSettings(inbound.Settings)
+	if err != nil {
+		return err
+	}
+
+	inboundName := inbound.Remark
+	if inboundName == "" {
+		inboundName = fmt.Sprintf("wg-%d", inbound.Id)
+	}
+
+	// Deduplicate by email: if two peers have the same comment, keep first.
+	seen := make(map[string]struct{}, len(peers))
+	clients := make([]model.Client, 0, len(peers))
+	for i, peer := range peers {
+		rec := wgPeerToRecord(peer, inboundName, i)
+		if _, dup := seen[rec.Email]; dup {
+			continue
+		}
+		seen[rec.Email] = struct{}{}
+		c := rec.ToClient()
+		clients = append(clients, *c)
+	}
+
+	return s.SyncInbound(tx, inbound.Id, clients)
+}

--- a/internal/web/service/inbound.go
+++ b/internal/web/service/inbound.go
@@ -297,6 +297,8 @@ type InboundOption struct {
 	Port           int    `json:"port" example:"443"`
 	TlsFlowCapable bool   `json:"tlsFlowCapable" example:"true"`
 	SsMethod       string `json:"ssMethod"`
+	// WireGuard server public key; only set for wireguard inbounds.
+	WgPublicKey string `json:"wgPublicKey,omitempty"`
 	// Hosting node; nil for this panel's own inbounds. Lets the clients
 	// page map a node filter onto inbound IDs (#4997).
 	NodeId *int `json:"nodeId,omitempty"`
@@ -324,7 +326,7 @@ func (s *InboundService) GetInboundOptions(userId int) ([]InboundOption, error) 
 	}
 	out := make([]InboundOption, 0, len(rows))
 	for _, r := range rows {
-		out = append(out, InboundOption{
+		opt := InboundOption{
 			Id:             r.Id,
 			Remark:         r.Remark,
 			Tag:            r.Tag,
@@ -333,9 +335,22 @@ func (s *InboundService) GetInboundOptions(userId int) ([]InboundOption, error) 
 			TlsFlowCapable: inboundCanEnableTlsFlow(r.Protocol, r.StreamSettings, r.Settings),
 			SsMethod:       inboundShadowsocksMethod(r.Protocol, r.Settings),
 			NodeId:         r.NodeId,
-		})
+		}
+		if r.Protocol == string(model.WireGuard) {
+			opt.WgPublicKey = inboundWgPublicKey(r.Settings)
+		}
+		out = append(out, opt)
 	}
 	return out, nil
+}
+
+func inboundWgPublicKey(settings string) string {
+	var s map[string]any
+	if err := json.Unmarshal([]byte(settings), &s); err != nil {
+		return ""
+	}
+	pk, _ := s["publicKey"].(string)
+	return pk
 }
 
 // GetAllInbounds retrieves all inbounds with client stats.
@@ -1074,6 +1089,25 @@ func (s *InboundService) UpdateInbound(inbound *model.Inbound) (*model.Inbound, 
 		oldInbound.Listen = inbound.Listen
 		oldInbound.Port = inbound.Port
 		oldInbound.Protocol = inbound.Protocol
+		// WireGuard peers are managed via the clients table, not the inbound form.
+		// If the incoming settings don't carry peers (frontend omits them), restore
+		// them from the existing inbound so nothing is accidentally erased.
+		if inbound.Protocol == model.WireGuard {
+			var newSM map[string]any
+			if jsonErr := json.Unmarshal([]byte(inbound.Settings), &newSM); jsonErr == nil {
+				if _, hasPeers := newSM["peers"]; !hasPeers {
+					var oldSM map[string]any
+					if jsonErr2 := json.Unmarshal([]byte(oldInbound.Settings), &oldSM); jsonErr2 == nil {
+						if peers, ok := oldSM["peers"]; ok {
+							newSM["peers"] = peers
+							if bs, marshalErr := json.MarshalIndent(newSM, "", "  "); marshalErr == nil {
+								inbound.Settings = string(bs)
+							}
+						}
+					}
+				}
+			}
+		}
 		oldInbound.Settings = inbound.Settings
 		oldInbound.StreamSettings = inbound.StreamSettings
 		oldInbound.Sniffing = inbound.Sniffing
@@ -1153,12 +1187,20 @@ func (s *InboundService) UpdateInbound(inbound *model.Inbound) (*model.Inbound, 
 		if err := tx.Save(oldInbound).Error; err != nil {
 			return err
 		}
-		newClients, gcErr := s.GetClients(oldInbound)
-		if gcErr != nil {
-			return gcErr
-		}
-		if err := s.clientService.SyncInbound(tx, oldInbound.Id, newClients); err != nil {
-			return err
+		// WireGuard peers live in the clients table — sync from settings.peers[]
+		// rather than from settings.clients[] (which WG inbounds don't have).
+		if oldInbound.Protocol == model.WireGuard {
+			if syncErr := s.clientService.SyncWgInbound(tx, oldInbound); syncErr != nil {
+				logger.Warning("SyncWgInbound in UpdateInbound failed:", syncErr)
+			}
+		} else {
+			newClients, gcErr := s.GetClients(oldInbound)
+			if gcErr != nil {
+				return gcErr
+			}
+			if err := s.clientService.SyncInbound(tx, oldInbound.Id, newClients); err != nil {
+				return err
+			}
 		}
 		// (Re)generate the Xray config whenever routing was or is now enabled, so
 		// the egress SOCKS bridge is added, moved, or dropped to match the new

--- a/internal/web/service/inbound.go
+++ b/internal/web/service/inbound.go
@@ -4,12 +4,15 @@ package service
 
 import (
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"net"
 	"sort"
 	"strings"
 	"time"
+
+	"golang.org/x/crypto/curve25519"
 
 	"github.com/mhsanaei/3x-ui/v3/internal/database"
 	"github.com/mhsanaei/3x-ui/v3/internal/database/model"
@@ -349,8 +352,21 @@ func inboundWgPublicKey(settings string) string {
 	if err := json.Unmarshal([]byte(settings), &s); err != nil {
 		return ""
 	}
-	pk, _ := s["publicKey"].(string)
-	return pk
+	if pk, _ := s["publicKey"].(string); pk != "" {
+		return pk
+	}
+	sk, _ := s["secretKey"].(string)
+	if sk == "" {
+		return ""
+	}
+	privBytes, err := base64.StdEncoding.DecodeString(sk)
+	if err != nil || len(privBytes) != 32 {
+		return ""
+	}
+	var priv, pub [32]byte
+	copy(priv[:], privBytes)
+	curve25519.ScalarBaseMult(&pub, &priv)
+	return base64.StdEncoding.EncodeToString(pub[:])
 }
 
 // GetAllInbounds retrieves all inbounds with client stats.

--- a/internal/web/service/inbound_migration.go
+++ b/internal/web/service/inbound_migration.go
@@ -183,6 +183,16 @@ func (s *InboundService) MigrationRequirements() {
 	}
 	tx.Save(inbounds)
 
+	// Migrate WireGuard peers from settings.peers[] into the clients table.
+	var wgInbounds []*model.Inbound
+	if wgErr := tx.Where("protocol = ?", model.WireGuard).Find(&wgInbounds).Error; wgErr == nil {
+		for _, wgIb := range wgInbounds {
+			if syncErr := s.clientService.SyncWgInbound(tx, wgIb); syncErr != nil {
+				logger.Warning("MigrationRequirements SyncWgInbound failed for inbound", wgIb.Id, ":", syncErr)
+			}
+		}
+	}
+
 	// Remove orphaned traffics
 	tx.Where("inbound_id = 0").Delete(xray.ClientTraffic{})
 

--- a/internal/web/translation/en-US.json
+++ b/internal/web/translation/en-US.json
@@ -637,7 +637,9 @@
         "noKernelTun": "No-kernel TUN",
         "keepAlive": "Keep alive",
         "peerNumber": "Peer {n}",
-        "peerNumberConfig": "Peer {n} config"
+        "peerNumberConfig": "Peer {n} config",
+        "peerCount": "{count} peer(s)",
+        "managePeersOnClientsTab": "Manage peers on the Clients page"
       },
       "stream": {
         "general": {
@@ -814,6 +816,16 @@
       "flow": "Flow",
       "vmessSecurity": "VMess Security",
       "reverseTag": "Reverse tag",
+      "wg": {
+        "privateKey": "Private Key",
+        "publicKey": "Public Key",
+        "preSharedKey": "Pre-Shared Key",
+        "allowedIPs": "Allowed IPs",
+        "keepAlive": "Keep Alive (sec)",
+        "regenerateKeypair": "Regenerate keypair",
+        "generatePsk": "Generate PSK",
+        "addAllowedIP": "Add IP"
+      },
       "reverseTagPlaceholder": "Optional reverse tag",
       "telegramId": "Telegram user ID",
       "telegramIdPlaceholder": "Numeric Telegram user ID (0 = none)",

--- a/internal/web/translation/ru-RU.json
+++ b/internal/web/translation/ru-RU.json
@@ -637,7 +637,9 @@
         "noKernelTun": "TUN без kernel",
         "keepAlive": "Keep alive",
         "peerNumber": "Peer {n}",
-        "peerNumberConfig": "Конфиг Peer {n}"
+        "peerNumberConfig": "Конфиг Peer {n}",
+        "peerCount": "{count} peer(ов)",
+        "managePeersOnClientsTab": "Управляйте peers на странице Клиенты"
       },
       "stream": {
         "general": {
@@ -814,6 +816,16 @@
       "flow": "Flow",
       "vmessSecurity": "VMess Security",
       "reverseTag": "Обратный тег",
+      "wg": {
+        "privateKey": "Приватный ключ",
+        "publicKey": "Публичный ключ",
+        "preSharedKey": "Общий ключ (PSK)",
+        "allowedIPs": "Разрешённые IP",
+        "keepAlive": "Keep Alive (сек)",
+        "regenerateKeypair": "Сгенерировать ключевую пару",
+        "generatePsk": "Сгенерировать PSK",
+        "addAllowedIP": "Добавить IP"
+      },
       "reverseTagPlaceholder": "Необязательный Reverse tag",
       "telegramId": "ID пользователя Telegram",
       "telegramIdPlaceholder": "Числовой ID пользователя Telegram (0 = нет)",

--- a/tools/openapigen/main.go
+++ b/tools/openapigen/main.go
@@ -39,6 +39,7 @@ func run(root, outDir string) error {
 				"ClientInbound",
 				"InboundFallback",
 				"Host",
+				"WgPeerSettings",
 			),
 			AliasAllow: setOf("Protocol"),
 			Overrides: map[string][]walkOverride{


### PR DESCRIPTION
## Summary

- **WireGuard peer management moved to Clients tab**: peers are now created/edited/deleted from the Clients page like any other protocol; the Inbounds form retains WG settings (key, MTU, etc.) but the peer list is removed from it
- **Auto-migration on upgrade**: existing `settings.peers[]` are migrated to the `clients` table on first startup — no data loss
- **Peer count on Inbounds tab**: WireGuard inbounds now show active peer count

## Key changes

### Backend
- `model.go` — `WgPeerSettings` struct + `wg_settings` column on `ClientRecord`; `MarshalJSON`/`UnmarshalJSON` expose it as `wgPeer` in API responses
- `client_wg_apply.go` — `AddWgClient`, `UpdateWgClient`, `DelWgClient`: full CRUD; each mutation rebuilds `settings.peers[]` from the clients table
- `client_wg_peers.go` — `syncWgPeersFromClients`, `wgPeerToRecord`, `SyncWgInbound`
- `inbound.go` — `UpdateInbound` preserves `settings.peers[]` when the form omits them; `inboundWgPublicKey` derives server public key from `secretKey` via curve25519; `GetInboundOptions` exposes `wgPublicKey`
- `client_crud.go` — `Delete()` routes WG inbounds through `DelWgClient` (fixes "invalid clients format" error)
- `client_paging.go` — `ClientSlim` includes `wgPeer` so next-IP suggestion works from the paged list
- `inbound_migration.go` — `MigrateWgPeers` syncs existing peers to clients table on startup
- `inbound.go` controller — WG CRUD endpoints under `/panel/api/inbounds/wg/`

### Frontend
- `ClientFormModal` — WG fields (public/private key, PSK, allowed IPs, keepalive) when WG inbound selected; irrelevant fields hidden; auto-suggests next sequential IP
- `ClientQrModal` — generates WireGuard `.conf` (`[Interface]` + `[Peer]`); supports `.conf` download
- `ClientInfoModal` — WG-specific fields shown; non-applicable ones hidden
- `useInbounds` — WireGuard added to `TRACKED_PROTOCOLS`; peer count read from `settings.peers`

## Test plan

- [ ] Existing WG inbound: open Clients tab, verify peers migrated automatically
- [ ] Add new WG peer: form shows WG fields, auto-suggests next available IP
- [ ] QR button: shows WireGuard `.conf` with correct keys and endpoint
- [ ] Info button: shows peer-specific fields
- [ ] Delete: peer removed from both DB and xray config
- [ ] Edit WG inbound (save form): existing peers are preserved
- [ ] Inbounds tab: WireGuard shows peer count
