### PR TITLE
feat(metrics): extend history bucket options to include 12h, 24h, and 48h intervals

### DIFF
--- a/frontend/src/pages/index/SystemHistoryModal.tsx
+++ b/frontend/src/pages/index/SystemHistoryModal.tsx
@@ -213,6 +213,9 @@ export default function SystemHistoryModal({ open, status, onClose }: SystemHist
               { value: 120, label: '2h' },
               { value: 180, label: '3h' },
               { value: 300, label: '5h' },
+              { value: 720, label: '12h' },
+              { value: 1440, label: '24h' },
+              { value: 2880, label: '48h' },
             ]}
           />
         </div>

--- a/internal/web/service/metric_history.go
+++ b/internal/web/service/metric_history.go
@@ -19,11 +19,10 @@ type MetricSample struct {
 	V float64 `json:"v"`
 }
 
-// metricCapacityDefault caps each ring buffer at ~5h worth of @2s samples
-// or ~25h worth of @10s samples. Plenty for the bucketed aggregation
-// view and small enough that the working set per metric stays under
-// ~150 KiB.
-const metricCapacityDefault = 9000
+// metricCapacityDefault caps each ring buffer at 48h worth of @2s samples.
+// Node metrics arrive less frequently, so they fit the same retention window
+// with room to spare.
+const metricCapacityDefault = 86400
 
 // metricHistory is a thread-safe, in-memory ring buffer keyed by
 // arbitrary strings. Two singletons live below: one for system-wide

--- a/internal/web/service/server.go
+++ b/internal/web/service/server.go
@@ -155,12 +155,15 @@ const xrayVersionsCacheTTL = 15 * time.Minute
 // callers from triggering arbitrary aggregation work and keeps the
 // frontend's bucket selector self-documenting.
 var allowedHistoryBuckets = map[int]bool{
-	2:   true, // Real-time view
-	30:  true, // 30s intervals
-	60:  true, // 1m intervals
-	120: true, // 2m intervals
-	180: true, // 3m intervals
-	300: true, // 5m intervals
+	2:    true, // Real-time view
+	30:   true, // 30s intervals
+	60:   true, // 1m intervals
+	120:  true, // 2m intervals
+	180:  true, // 3m intervals
+	300:  true, // 5m intervals
+	720:  true, // 12m intervals
+	1440: true, // 24m intervals
+	2880: true, // 48m intervals
 }
 
 // IsAllowedHistoryBucket reports whether a bucket-seconds value is in the


### PR DESCRIPTION

## Summary

Extend the system history chart range up to 48 hours by adding 12h, 24h, and 48h options.

## Why

 Closes #5463

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactoring (no behavior change)
- [ ] Documentation
- [ ] Tests only
- [ ] Build / CI / tooling
- [ ] Other

## Areas affected

- [x] Frontend (UI / panel pages)
- [x] Backend (API endpoints, login, settings)
- [ ] Xray config generation
- [ ] Subscription (share links / Clash / JSON)
- [x] Statistics / traffic counters
- [ ] Database / migrations
- [ ] Install / upgrade script
- [ ] Docker image
- [ ] Multi-node (sub-nodes)
- [ ] Telegram bot

