### PR TITLE
fix(frontend): guard IntlUtil.formatDate against out-of-range timestamps

### DIFF
--- a/frontend/src/utils/index.ts
+++ b/frontend/src/utils/index.ts
@@ -920,6 +920,8 @@ export type CalendarKind = 'gregorian' | 'jalalian';
 export class IntlUtil {
   static formatDate(date: string | number | Date | null | undefined, calendar: CalendarKind = 'gregorian'): string {
     if (date == null) return '';
+    const d = new Date(date);
+    if (!isFinite(d.getTime())) return '';
     const language = LanguageManager.getLanguage();
     const locale = calendar === 'jalalian' ? 'fa-IR' : language;
 
@@ -934,11 +936,12 @@ export class IntlUtil {
     };
 
     const intl = new Intl.DateTimeFormat(locale, intlOptions);
-    return intl.format(new Date(date));
+    return intl.format(d);
   }
 
   static formatRelativeTime(date: number | null | undefined): string {
     if (date == null) return '';
+    if (!isFinite(date)) return '';
     const language = LanguageManager.getLanguage();
     const now = new Date();
     const diff = date < 0


### PR DESCRIPTION
## Summary

Closes https://github.com/MHSanaei/3x-ui/issues/5464
Guard `IntlUtil.formatDate` against out-of-range timestamps so a single bad `expiryTime` can't crash the clients page.

## Why

Backend `ExpiryTime` is a Go `int64`; JS `Date` only accepts ±8,640,000,000,000,000 ms. A value beyond that yields `Invalid Date`, and `Intl.DateTimeFormat.format(Invalid Date)` throws — taking down `ClientsPage` for every user.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactoring (no behavior change)
- [ ] Documentation
- [ ] Tests only
- [ ] Build / CI / tooling
- [ ] Other


## Areas affected

- [x] Frontend (UI / panel pages)
- [ ] Backend (API endpoints, login, settings)
- [ ] Xray config generation
- [ ] Subscription (share links / Clash / JSON)
- [ ] Statistics / traffic counters
- [ ] Database / migrations
- [ ] Install / upgrade script
- [ ] Docker image
- [ ] Multi-node (sub-nodes)
- [ ] Telegram bot


## How was this tested?

Reproduced in browser devtools:

```js
new Intl.DateTimeFormat('en').format(new Date(8640000000000001))
// throws: `RangeError: date value is not finite in DateTimeFormat format()`
```

After the fix, `IntlUtil.formatDate(8640000000000001)` returns `''` instead of throwing.

## Screenshots / recordings

N/A

## Breaking changes

None

## Checklist

- [x] I tested the change locally and confirmed the described behavior.
- [ ] I added or updated tests for the new behavior (when applicable).
- [x] `go build ./...` and the test suite pass locally.
- [x] For frontend changes: `npm run lint`, `npm run typecheck`, and `npm run build` pass.
- [ ] I updated the Wiki / README / API docs if user-facing behavior changed.
- [x] My commits follow the project's existing message style.
- [x] I have no unrelated changes mixed into this PR.
