### PR TITLE
fix(node): mark node dirty on Update so sync reconciles before snapsh…

### DIFF
--- a/internal/web/service/node.go
+++ b/internal/web/service/node.go
@@ -357,6 +357,9 @@ func (s *NodeService) Update(id int, in *model.Node) error {
 	if err := db.Model(model.Node{}).Where("id = ?", id).Updates(updates).Error; err != nil {
 		return err
 	}
+	if dErr := s.MarkNodeDirty(id); dErr != nil {
+		logger.Warning("mark node dirty after update failed:", dErr)
+	}
 	if mgr := runtime.GetManager(); mgr != nil {
 		mgr.InvalidateNode(id)
 	}

--- a/internal/web/service/node_dirty_test.go
+++ b/internal/web/service/node_dirty_test.go
@@ -144,3 +144,53 @@ func TestNodeDirty_ClearIsCASOnDirtyAt(t *testing.T) {
 		t.Fatal("matching-token clear must clear the dirty flag")
 	}
 }
+
+// Editing a node must mark it config-dirty so the next traffic-sync tick
+// reconciles (pushes the panel's inbounds to the remote) before pulling a
+// snapshot. Without the dirty flag, re-pointing a node to a fresh server
+// makes the orphan sweep delete every central inbound absent from the empty
+// snapshot (#5461).
+func TestNodeService_UpdateMarksNodeDirty(t *testing.T) {
+	setupConflictDB(t)
+	db := database.GetDB()
+
+	node := &model.Node{
+		Name:     "n1",
+		Address:  "10.0.0.1",
+		Port:     2096,
+		ApiToken: "tok",
+		Enable:   true,
+		Status:   "online",
+	}
+	if err := db.Create(node).Error; err != nil {
+		t.Fatalf("create node: %v", err)
+	}
+
+	edited := &model.Node{
+		Name:     node.Name,
+		Address:  "10.0.0.2",
+		Port:     2097,
+		ApiToken: node.ApiToken,
+		Enable:   true,
+	}
+	nodeSvc := NodeService{}
+	if err := nodeSvc.Update(node.Id, edited); err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+
+	_, _, dirty, _, err := nodeSvc.NodeSyncState(node.Id)
+	if err != nil {
+		t.Fatalf("NodeSyncState: %v", err)
+	}
+	if !dirty {
+		t.Fatal("Update must mark the node config-dirty so sync reconciles before snapshot sweep (#5461)")
+	}
+
+	var got model.Node
+	if err := db.First(&got, node.Id).Error; err != nil {
+		t.Fatalf("reload node: %v", err)
+	}
+	if got.Address != "10.0.0.2" || got.Port != 2097 {
+		t.Fatalf("node row not updated: address=%q port=%d", got.Address, got.Port)
+	}
+}


### PR DESCRIPTION
## Summary

Closes https://github.com/MHSanaei/3x-ui/issues/5461
Fixes inbounds being deleted when editing or replacing a node. `NodeService.Update()` now marks the node `config_dirty` after writing the row, so the next traffic-sync tick reconciles the remote (pushing the panel's local inbounds to it) before pulling a traffic snapshot. Previously the orphan sweep in `setRemoteTrafficLocked` treated the freshly-empty snapshot of a re-pointed node as authoritative and deleted every central inbound absent from it.

## Why

Editing or re-pointing a node in the 3x-ui panel caused all its associated inbounds to be deleted within ~5 seconds (one traffic-sync tick). The user had to manually recreate the inbounds after every node edit, or work around it by disabling the node before editing and re-enabling it after.

Root cause: `NodeService.Update()` invalidated the cached HTTP connection (so the next request hit the new address) but never set `config_dirty`. Every inbound-edit path (`inbound.go`, `client_bulk.go`, `client_inbound_apply.go`, `inbound_traffic.go`) already calls `MarkNodeDirty` on the owning node, which is what causes the sync job to run `ReconcileNode` first and push the panel's inbounds to the remote before consuming a snapshot. `Update()` was the only node-mutating path that did not, so the sync job skipped reconciliation, fetched a snapshot from the new (empty) server, and the orphan sweep deleted every central inbound whose tag was missing from that snapshot.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactoring (no behavior change)
- [ ] Documentation
- [ ] Tests only
- [ ] Build / CI / tooling
- [ ] Other

## Areas affected

- [ ] Frontend (UI / panel pages)
- [x] Backend (API endpoints, login, settings)
- [ ] Xray config generation
- [ ] Subscription (share links / Clash / JSON)
- [x] Statistics / traffic counters
- [ ] Database / migrations
- [ ] Install / upgrade script
- [ ] Docker image
- [x] Multi-node (sub-nodes)
- [ ] Telegram bot

## How was this tested?

1. `go build ./...` — passes.
2. Test suite passes.
3. Manually verified the bug repro from #5461: edited a node with attached inbounds (changing its address) and confirmed the inbounds survive the next traffic-sync tick instead of being deleted.

## Implementation details

**Backend — `internal/web/service/node.go`:**
- Added a `s.MarkNodeDirty(id)` call in `NodeService.Update()` immediately after the row write succeeds and before `mgr.InvalidateNode(id)`.
- `MarkNodeDirty` is the same primitive every inbound-edit path uses: it sets `config_dirty = true` and stamps `config_dirty_at`. On the next sync tick, `syncOne` sees the flag, calls `ReconcileNode` (which pushes every central inbound tagged for that node to the remote), then `ClearNodeDirty`, then pulls the traffic snapshot. The orphan sweep's existing `if dirty { continue }` guard then protects the central inbounds during the first post-edit snapshot.
- Errors from `MarkNodeDirty` are logged and swallowed (the row write already succeeded; returning an error now would show a failure toast while the node was in fact updated). This matches the established pattern in `inbound.go:663-665`.
- The flag is set unconditionally on `Update()` (not gated on whether address/port changed). `inbound_sync_mode` and `inbound_tags` also affect what `ReconcileNode` pushes, so dirtying on those edits is correct, and a no-op reconcile on a pure name/remark edit is harmless.
- `SetEnable` / `Create` / `Delete` are deliberately not changed: a brand-new node has no central inbounds to delete, `Delete` already refuses to remove a node with attached inbounds, and `SetEnable` is fine because any inbound edit performed while the node was disabled already marked it dirty.

**Tests — `internal/web/service/node_dirty_test.go`:**
- Added `TestNodeService_UpdateMarksNodeDirty`: creates a node, calls `Update()` to change address/port (the "replace node" case from the bug report), asserts `config_dirty` is now `true`, and asserts the address/port row write persisted. Fails on unfixed code with the message "Update must mark the node config-dirty so sync reconciles before snapshot sweep (#5461)".

## Files changed

- `internal/web/service/node.go`
- `internal/web/service/node_dirty_test.go`

## Screenshots / recordings

N/A

## Breaking changes
None

## Checklist
- [x] I tested the change locally and confirmed the described behavior.
- [x] I added or updated tests for the new behavior (when applicable).
- [x] `go build ./...` and the test suite pass locally.
- [ ] For frontend changes: `npm run lint`, `npm run typecheck`, and `npm run build` pass. *(N/A — no frontend change)*
- [ ] I updated the Wiki / README / API docs if user-facing behavior changed. *(N/A — fixes unintended destructive behavior; no user-facing surface changes)*
- [x] My commits follow the project's existing message style.
- [x] I have no unrelated changes mixed into this PR.
