### PR TITLE
fix(cli): apply -webCert/-webCertKey on the setting subcommand

### DIFF
--- a/main.go
+++ b/main.go
@@ -623,6 +623,9 @@ func main() {
 				return
 			}
 		}
+		if webCertFile != "" || webKeyFile != "" {
+			updateCert(webCertFile, webKeyFile)
+		}
 		if show {
 			showSetting(show)
 		}


### PR DESCRIPTION
Refs [#5481](https://github.com/MHSanaei/3x-ui/issues/5481)

## Summary

Wire `updateCert()` into the `setting` subcommand so the `-webCert` / `-webCertKey` flags are actually applied instead of being silently discarded.

## Why

The `setting` subcommand registers the `-webCert` and `-webCertKey` flags, but the `case "setting":` handler only calls `updateSetting()` (port, username, password, webBasePath, listenIP, resetTwoFactor) and never touches the cert paths. `updateCert()` was reachable only through the separate `case "cert":` branch.

As a result, on a fresh install `x-ui setting -webCert <fullchain> -webCertKey <privkey>` exits 0 but writes nothing: `webCertFile` / `webKeyFile` never land in the `settings` table, `setting -show` keeps printing `Warning: Panel is not secure with SSL`, the panel stays HTTP-only, and browsers fail with `ERR_SSL_PROTOCOL_ERROR` over HTTPS.

This also breaks automated provisioning (cloud-init / install scripts) that set the cert non-interactively through `setting`, forcing a manual `cert` subcommand call or a direct DB write as a workaround.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactoring (no behavior change)
- [ ] Documentation
- [ ] Tests only
- [ ] Build / CI / tooling
- [ ] Other

## Areas affected

- [ ] Frontend (UI / panel pages)
- [x] Backend (API endpoints, login, settings)
- [ ] Xray config generation
- [ ] Subscription (share links / Clash / JSON)
- [ ] Statistics / traffic counters
- [ ] Database / migrations
- [ ] Install / upgrade script
- [ ] Docker image
- [ ] Multi-node (sub-nodes)
- [ ] Telegram bot

## How was this tested?

On a fresh SQLite DB:

1. Build and confirm `x-ui setting -webCert /path/fullchain.pem -webCertKey /path/privkey.pem` exits 0.
2. `x-ui setting -getCert` now reports the cert paths (previously empty).
3. `sqlite3 x-ui.db "SELECT key,value FROM settings WHERE key LIKE 'web%';"` now contains `webCertFile` / `webKeyFile` (previously absent).
4. After restart, `curl -vk https://127.0.0.1:<port>/` completes a TLS handshake (previously `OpenSSL ... wrong version number`, i.e. plain HTTP).

Behavior matches the existing `cert` subcommand; `saveSetting()` already upserts, so the rows are created on a fresh DB.

## Screenshots / recordings

N/A (CLI-only change).

## Breaking changes

None. The flags previously had no effect; the `cert` subcommand is unchanged.

## Checklist

- [x] I tested the change locally and confirmed the described behavior.
- [ ] I added or updated tests for the new behavior (when applicable).
- [x] `go build ./...` and the test suite pass locally.
- [ ] For frontend changes: `npm run lint`, `npm run typecheck`, and `npm run build` pass.
- [ ] I updated the Wiki / README / API docs if user-facing behavior changed.
- [x] My commits follow the project's existing message style.
- [x] I have no unrelated changes mixed into this PR.