### PR TITLE
Localization Issue: “<3” Reduces Clarity and Consistency of the Logout Button

### DIFF
--- a/internal/web/translation/en-US.json
+++ b/internal/web/translation/en-US.json
@@ -6,7 +6,7 @@
   "cancel": "Cancel",
   "close": "Close",
   "save": "Save",
-  "logout": "Log Out <3",
+  "logout": "Log Out",
   "create": "Create",
   "add": "Add",
   "remove": "Remove",

--- a/internal/web/translation/es-ES.json
+++ b/internal/web/translation/es-ES.json
@@ -6,7 +6,7 @@
   "cancel": "Cancelar",
   "close": "Cerrar",
   "save": "Guardar",
-  "logout": "Cerrar Sesión <3",
+  "logout": "Cerrar Sesión",
   "create": "Crear",
   "add": "Añadir",
   "remove": "Quitar",

--- a/internal/web/translation/zh-CN.json
+++ b/internal/web/translation/zh-CN.json
@@ -6,7 +6,7 @@
   "cancel": "取消",
   "close": "关闭",
   "save": "保存",
-  "logout": "登出 <3",
+  "logout": "退出",
   "create": "创建",
   "add": "添加",
   "remove": "移除",

--- a/internal/web/translation/zh-TW.json
+++ b/internal/web/translation/zh-TW.json
@@ -6,7 +6,7 @@
   "cancel": "取消",
   "close": "關閉",
   "save": "儲存",
-  "logout": "登出 <3",
+  "logout": "退出",
   "create": "建立",
   "add": "新增",
   "remove": "移除",


### PR DESCRIPTION
hello，friends

The addition of <3 negatively affects the consistency and professionalism of the localization. Menu labels should clearly and directly convey the function of each action to users. As functional UI elements rather than decorative text, button labels should avoid unnecessary characters that do not contribute to usability.

Compared with other applications, open-source projects, and mainstream operating systems, it is uncommon to see a Logout button augmented with such unrelated characters. This change may create visual inconsistency and reduce clarity for users. I would appreciate it if the label could be restored to its conventional form.

Thank you for your consideration.

I only simply modified and restored 4 languages.