### PR TITLE
fix(online): gate local inbounds correctly when xray is idle

### DIFF
--- a/internal/web/service/inbound_node.go
+++ b/internal/web/service/inbound_node.go
@@ -880,13 +880,19 @@ func (s *InboundService) GetActiveInboundsByGuid() map[string][]string {
 	if p == nil {
 		return map[string][]string{}
 	}
-	active := p.GetLocalActiveInbounds()
-	if len(active) == 0 {
-		return map[string][]string{}
-	}
 	guid := s.panelGuid()
 	if guid == "" {
 		return map[string][]string{}
+	}
+	// Always include the local panel's GUID key, even when no inbounds are
+	// active. A missing key means "unknown node — don't gate" (correct for
+	// remote nodes that haven't reported yet). An empty slice means "this
+	// panel is known but no inbounds carried traffic" — without this
+	// distinction, multi-inbound clients appear online on every inbound they
+	// are attached to whenever the local xray is idle.
+	active := p.GetLocalActiveInbounds()
+	if active == nil {
+		active = []string{}
 	}
 	return map[string][]string{guid: active}
 }


### PR DESCRIPTION
## Summary

Multi-inbound clients appeared **online on every inbound they were attached to**, even when only one of those inbounds had active traffic. The bug surfaced whenever the local xray had no recent traffic (grace window expired between polls, or xray just started).

## Root cause

`GetActiveInboundsByGuid` returned an empty map `{}` when `GetLocalActiveInbounds` returned nil (no active inbounds in the grace window). The frontend distinguishes two states by whether the GUID key is present in the map:

| Map state | Meaning | Frontend behaviour |
|-----------|---------|-------------------|
| `{}` — key absent | unknown node, hasn't reported yet | **don't gate** (show all clients as active per-inbound) |
| `{guid: []}` — empty slice | node known, no active inbounds | gate all inbounds on that node as inactive |

Because the local panel's GUID was missing when idle, `activeByGuidRef.current.get(guid)` returned `undefined`, and the `undefined === undefined` fallback in `rollupClients` ungated all local inbounds — every client appeared online on all their inbounds regardless of which one carried traffic.

## Fix

Resolve the GUID before checking the active list, and always emit `{guid: active}` (where `active` may be an empty slice). A missing key still means "unknown remote node — don't gate", which is the correct semantic for nodes that haven't reported yet. Only the local panel is guaranteed to always know its own state.

```go
// before
active := p.GetLocalActiveInbounds()
if len(active) == 0 {
    return map[string][]string{}   // missing key → frontend ungates all inbounds
}
guid := s.panelGuid()
...

// after
guid := s.panelGuid()
...
active := p.GetLocalActiveInbounds()
if active == nil {
    active = []string{}
}
return map[string][]string{guid: active}
```

## Test plan

- [ ] Attach one client to two local inbounds
- [ ] Generate traffic on inbound A only
- [ ] Confirm client shows online on inbound A but **not** inbound B
- [ ] Wait for the xray grace window to expire (default ~1 min); confirm client shows offline on both inbounds
- [ ] Confirm a client attached only to a remote-node inbound still shows correctly (remote nodes are unaffected — their GUID is only in the map when they have reported)