### PR TITLE
fix(sockopt): honor trustedXForwardedFor on gRPC inbounds (xray v26.6.22)

### DIFF
--- a/frontend/src/pages/inbounds/form/transport/sockopt.tsx
+++ b/frontend/src/pages/inbounds/form/transport/sockopt.tsx
@@ -11,8 +11,10 @@ const TRANSPORT_PROXY_FIELD: Record<string, string> = {
   ws: 'wsSettings',
   httpupgrade: 'httpupgradeSettings',
 };
-// Transports on which xray-core honors sockopt.trustedXForwardedFor.
-const TRUSTED_HEADER_NETWORKS = ['ws', 'httpupgrade', 'xhttp'];
+// Transports on which xray-core honors sockopt.trustedXForwardedFor. gRPC joined
+// in v26.6.22 (xray-core 711aea4): it now reads X-Forwarded-For via this option
+// instead of the old x-real-ip gRPC metadata.
+const TRUSTED_HEADER_NETWORKS = ['ws', 'httpupgrade', 'xhttp', 'grpc'];
 
 type RealClientIpPreset = 'off' | 'cloudflare' | 'proxy';
 
@@ -27,7 +29,7 @@ export default function SockoptForm({
 
   // Presets write the same sockopt fields the user could set by hand below,
   // picking the mechanism xray-core actually honors for the chosen transport:
-  // CF-Connecting-IP via trustedXForwardedFor (ws/httpupgrade/xhttp) or the
+  // CF-Connecting-IP via trustedXForwardedFor (ws/httpupgrade/xhttp/grpc) or the
   // PROXY-protocol header via acceptProxyProtocol (every transport but mKCP).
   const applyRealClientIpPreset = (
     preset: RealClientIpPreset,
@@ -60,7 +62,7 @@ export default function SockoptForm({
     }
 
     // proxy — clear trustedXForwardedFor so a lingering header can't override the
-    // PROXY-recovered IP (xray reads the header last on ws/httpupgrade/xhttp).
+    // PROXY-recovered IP (xray reads the header last on ws/httpupgrade/xhttp/grpc).
     setFieldValue(['streamSettings', 'sockopt', 'trustedXForwardedFor'], []);
     setFieldValue(['streamSettings', 'sockopt', 'acceptProxyProtocol'], true);
     if (transportField) setFieldValue(['streamSettings', transportField, 'acceptProxyProtocol'], true);

--- a/internal/web/translation/ar-EG.json
+++ b/internal/web/translation/ar-EG.json
@@ -562,7 +562,7 @@
         "tcpCongestion": "TCP Congestion",
         "dialerProxy": "Dialer Proxy",
         "trustedXForwardedFor": "X-Forwarded-For موثوق",
-        "trustedXForwardedForHint": "ثِق بترويسة الطلب هذه للحصول على IP الحقيقي للعميل (مثل CF-Connecting-IP خلف CDN الخاص بـ Cloudflare). تعمل فقط على وسائل النقل WebSocket و HTTPUpgrade و XHTTP. اتركها فارغة لتجاهل ترويسات التمرير.",
+        "trustedXForwardedForHint": "ثِق بترويسة الطلب هذه للحصول على IP الحقيقي للعميل (مثل CF-Connecting-IP خلف CDN الخاص بـ Cloudflare). تعمل فقط على وسائل النقل WebSocket و HTTPUpgrade و XHTTP و gRPC. اتركها فارغة لتجاهل ترويسات التمرير.",
         "proxyProtocolHint": "اقبل ترويسة PROXY protocol لمعرفة IP الحقيقي للعميل من نفق/مُرحِّل L4 أعلى (HAProxy و gost و nginx-stream و Xray dokodemo-door) أو Cloudflare Spectrum. يجب على الجهة الأعلى إرسال PROXY protocol. تعمل على TCP و WebSocket و HTTPUpgrade و gRPC؛ ولا تعمل على mKCP.",
         "realClientIp": "IP الحقيقي للعميل",
         "realClientIpHint": "احصل على IP الحقيقي للزائر عندما يصل المرور إلى هذا الـ inbound عبر CDN أو مُرحِّل، بدلاً من تسجيل عنوان الوسيط. اختر إعدادًا مسبقًا لملء حقول sockopt المقابلة أدناه. لا تُرسَل هذه الحقول أبدًا إلى العملاء في الاشتراكات.",

--- a/internal/web/translation/en-US.json
+++ b/internal/web/translation/en-US.json
@@ -562,7 +562,7 @@
         "tcpCongestion": "TCP Congestion",
         "dialerProxy": "Dialer Proxy",
         "trustedXForwardedFor": "Trusted X-Forwarded-For",
-        "trustedXForwardedForHint": "Trust this request header for the real client IP (e.g. CF-Connecting-IP behind Cloudflare's CDN). Only honored on WebSocket, HTTPUpgrade and XHTTP transports. Leave empty to ignore forwarded headers.",
+        "trustedXForwardedForHint": "Trust this request header for the real client IP (e.g. CF-Connecting-IP behind Cloudflare's CDN). Only honored on WebSocket, HTTPUpgrade, XHTTP and gRPC transports. Leave empty to ignore forwarded headers.",
         "proxyProtocolHint": "Accept the PROXY-protocol header to learn the real client IP from an upstream L4 tunnel or relay (HAProxy, gost, nginx-stream, Xray dokodemo-door) or Cloudflare Spectrum. The upstream MUST emit PROXY protocol. Works on TCP, WebSocket, HTTPUpgrade and gRPC; not on mKCP.",
         "realClientIp": "Real client IP",
         "realClientIpHint": "Capture the visitor's real IP when traffic reaches this inbound through a CDN or relay, instead of recording the intermediary's address. Pick a preset to fill the matching sockopt fields below. These fields are never sent to clients in subscriptions.",

--- a/internal/web/translation/es-ES.json
+++ b/internal/web/translation/es-ES.json
@@ -562,7 +562,7 @@
         "tcpCongestion": "TCP Congestion",
         "dialerProxy": "Dialer Proxy",
         "trustedXForwardedFor": "X-Forwarded-For de confianza",
-        "trustedXForwardedForHint": "Confía en esta cabecera de solicitud para obtener la IP real del cliente (p. ej. CF-Connecting-IP detrás del CDN de Cloudflare). Solo válido en los transportes WebSocket, HTTPUpgrade y XHTTP. Déjalo vacío para ignorar las cabeceras reenviadas.",
+        "trustedXForwardedForHint": "Confía en esta cabecera de solicitud para obtener la IP real del cliente (p. ej. CF-Connecting-IP detrás del CDN de Cloudflare). Solo válido en los transportes WebSocket, HTTPUpgrade, XHTTP y gRPC. Déjalo vacío para ignorar las cabeceras reenviadas.",
         "proxyProtocolHint": "Acepta la cabecera PROXY protocol para obtener la IP real del cliente desde un túnel/relé L4 superior (HAProxy, gost, nginx-stream, Xray dokodemo-door) o Cloudflare Spectrum. El nodo superior DEBE enviar PROXY protocol. Funciona en TCP, WebSocket, HTTPUpgrade y gRPC; no en mKCP.",
         "realClientIp": "IP real del cliente",
         "realClientIpHint": "Captura la IP real del visitante cuando el tráfico llega a este inbound a través de un CDN o relé, en lugar de registrar la dirección del intermediario. Elige un preajuste para rellenar los campos sockopt correspondientes más abajo. Estos campos nunca se envían a los clientes en las suscripciones.",

--- a/internal/web/translation/fa-IR.json
+++ b/internal/web/translation/fa-IR.json
@@ -562,7 +562,7 @@
         "tcpCongestion": "تراکم TCP",
         "dialerProxy": "Dialer Proxy",
         "trustedXForwardedFor": "X-Forwarded-For مورد اعتماد",
-        "trustedXForwardedForHint": "این هدر درخواست برای گرفتن IP واقعی کاربر مورد اعتماد قرار می‌گیرد (مثلاً CF-Connecting-IP پشت CDN کلودفلر). فقط روی ترنسپورت‌های WebSocket، HTTPUpgrade و XHTTP اعمال می‌شود. برای نادیده‌گرفتن هدرها خالی بگذارید.",
+        "trustedXForwardedForHint": "این هدر درخواست برای گرفتن IP واقعی کاربر مورد اعتماد قرار می‌گیرد (مثلاً CF-Connecting-IP پشت CDN کلودفلر). فقط روی ترنسپورت‌های WebSocket، HTTPUpgrade، XHTTP و gRPC اعمال می‌شود. برای نادیده‌گرفتن هدرها خالی بگذارید.",
         "proxyProtocolHint": "پذیرش هدر PROXY protocol برای گرفتن IP واقعی کاربر از یک تونل/رله L4 بالادست (HAProxy، gost، nginx-stream، Xray dokodemo-door) یا Cloudflare Spectrum. بالادست باید PROXY protocol را ارسال کند. روی TCP، WebSocket، HTTPUpgrade و gRPC کار می‌کند؛ روی mKCP خیر.",
         "realClientIp": "IP واقعی کاربر",
         "realClientIpHint": "وقتی ترافیک از طریق CDN یا رله به این ورودی می‌رسد، به‌جای ثبت آدرس واسط، IP واقعی کاربر گرفته می‌شود. یک پریست انتخاب کنید تا فیلدهای sockopt مربوطه پایین تکمیل شوند. این فیلدها هرگز در اشتراک‌ها به کلاینت‌ها ارسال نمی‌شوند.",

--- a/internal/web/translation/id-ID.json
+++ b/internal/web/translation/id-ID.json
@@ -562,7 +562,7 @@
         "tcpCongestion": "TCP Congestion",
         "dialerProxy": "Dialer Proxy",
         "trustedXForwardedFor": "X-Forwarded-For tepercaya",
-        "trustedXForwardedForHint": "Percayai header permintaan ini untuk IP klien asli (mis. CF-Connecting-IP di belakang CDN Cloudflare). Hanya berlaku pada transport WebSocket, HTTPUpgrade, dan XHTTP. Kosongkan untuk mengabaikan header yang diteruskan.",
+        "trustedXForwardedForHint": "Percayai header permintaan ini untuk IP klien asli (mis. CF-Connecting-IP di belakang CDN Cloudflare). Hanya berlaku pada transport WebSocket, HTTPUpgrade, XHTTP, dan gRPC. Kosongkan untuk mengabaikan header yang diteruskan.",
         "proxyProtocolHint": "Terima header PROXY protocol untuk mengetahui IP klien asli dari tunnel/relay L4 di hulu (HAProxy, gost, nginx-stream, Xray dokodemo-door) atau Cloudflare Spectrum. Hulu HARUS mengirim PROXY protocol. Berfungsi pada TCP, WebSocket, HTTPUpgrade, dan gRPC; tidak pada mKCP.",
         "realClientIp": "IP klien asli",
         "realClientIpHint": "Tangkap IP asli pengunjung saat lalu lintas mencapai inbound ini melalui CDN atau relay, alih-alih mencatat alamat perantara. Pilih preset untuk mengisi kolom sockopt terkait di bawah. Kolom ini tidak pernah dikirim ke klien dalam langganan.",

--- a/internal/web/translation/ja-JP.json
+++ b/internal/web/translation/ja-JP.json
@@ -583,7 +583,7 @@
         "tcpCongestion": "TCP Congestion",
         "dialerProxy": "Dialer Proxy",
         "trustedXForwardedFor": "信頼できる X-Forwarded-For",
-        "trustedXForwardedForHint": "実際のクライアント IP を取得するためにこのリクエストヘッダーを信頼します（例: Cloudflare CDN の背後の CF-Connecting-IP）。WebSocket、HTTPUpgrade、XHTTP トランスポートでのみ有効です。空欄にすると転送ヘッダーを無視します。",
+        "trustedXForwardedForHint": "実際のクライアント IP を取得するためにこのリクエストヘッダーを信頼します（例: Cloudflare CDN の背後の CF-Connecting-IP）。WebSocket、HTTPUpgrade、XHTTP、gRPC トランスポートでのみ有効です。空欄にすると転送ヘッダーを無視します。",
         "proxyProtocolHint": "PROXY protocol ヘッダーを受け入れ、上流の L4 トンネル/リレー（HAProxy、gost、nginx-stream、Xray dokodemo-door）または Cloudflare Spectrum から実際のクライアント IP を取得します。上流は必ず PROXY protocol を送信する必要があります。TCP、WebSocket、HTTPUpgrade、gRPC で動作します。mKCP では動作しません。",
         "realClientIp": "実際のクライアント IP",
         "realClientIpHint": "トラフィックが CDN やリレーを経由してこのインバウンドに到達したときに、中継ノードのアドレスではなく訪問者の実際の IP を取得します。プリセットを選ぶと、下の対応する sockopt フィールドが自動入力されます。これらのフィールドはサブスクリプションでクライアントに送信されることはありません。",

--- a/internal/web/translation/pt-BR.json
+++ b/internal/web/translation/pt-BR.json
@@ -583,7 +583,7 @@
         "tcpCongestion": "TCP Congestion",
         "dialerProxy": "Dialer Proxy",
         "trustedXForwardedFor": "X-Forwarded-For confiável",
-        "trustedXForwardedForHint": "Confie neste cabeçalho de requisição para obter o IP real do cliente (ex.: CF-Connecting-IP atrás do CDN da Cloudflare). Válido apenas nos transportes WebSocket, HTTPUpgrade e XHTTP. Deixe vazio para ignorar cabeçalhos encaminhados.",
+        "trustedXForwardedForHint": "Confie neste cabeçalho de requisição para obter o IP real do cliente (ex.: CF-Connecting-IP atrás do CDN da Cloudflare). Válido apenas nos transportes WebSocket, HTTPUpgrade, XHTTP e gRPC. Deixe vazio para ignorar cabeçalhos encaminhados.",
         "proxyProtocolHint": "Aceite o cabeçalho PROXY protocol para obter o IP real do cliente a partir de um túnel/relay L4 upstream (HAProxy, gost, nginx-stream, Xray dokodemo-door) ou Cloudflare Spectrum. O upstream DEVE enviar PROXY protocol. Funciona em TCP, WebSocket, HTTPUpgrade e gRPC; não em mKCP.",
         "realClientIp": "IP real do cliente",
         "realClientIpHint": "Capture o IP real do visitante quando o tráfego chega a este inbound através de um CDN ou relay, em vez de registrar o endereço do intermediário. Escolha uma predefinição para preencher os campos sockopt correspondentes abaixo. Esses campos nunca são enviados aos clientes nas assinaturas.",

--- a/internal/web/translation/ru-RU.json
+++ b/internal/web/translation/ru-RU.json
@@ -583,7 +583,7 @@
         "tcpCongestion": "TCP Congestion",
         "dialerProxy": "Dialer Proxy",
         "trustedXForwardedFor": "Доверенный X-Forwarded-For",
-        "trustedXForwardedForHint": "Доверять этому заголовку запроса для определения реального IP клиента (например, CF-Connecting-IP за CDN Cloudflare). Работает только на транспортах WebSocket, HTTPUpgrade и XHTTP. Оставьте пустым, чтобы игнорировать заголовки пересылки.",
+        "trustedXForwardedForHint": "Доверять этому заголовку запроса для определения реального IP клиента (например, CF-Connecting-IP за CDN Cloudflare). Работает только на транспортах WebSocket, HTTPUpgrade, XHTTP и gRPC. Оставьте пустым, чтобы игнорировать заголовки пересылки.",
         "proxyProtocolHint": "Принимать заголовок PROXY protocol, чтобы получить реальный IP клиента от вышестоящего L4-туннеля или релея (HAProxy, gost, nginx-stream, Xray dokodemo-door) либо Cloudflare Spectrum. Вышестоящий узел ДОЛЖЕН отправлять PROXY protocol. Работает на TCP, WebSocket, HTTPUpgrade и gRPC; не работает на mKCP.",
         "realClientIp": "Реальный IP клиента",
         "realClientIpHint": "Получать реальный IP посетителя, когда трафик приходит на этот входящий через CDN или релей, вместо адреса промежуточного узла. Выберите пресет, чтобы заполнить соответствующие поля sockopt ниже. Эти поля никогда не отправляются клиентам в подписках.",

--- a/internal/web/translation/tr-TR.json
+++ b/internal/web/translation/tr-TR.json
@@ -562,7 +562,7 @@
         "tcpCongestion": "TCP Congestion",
         "dialerProxy": "Dialer Proxy",
         "trustedXForwardedFor": "Güvenilir X-Forwarded-For",
-        "trustedXForwardedForHint": "Gerçek istemci IP'sini almak için bu istek başlığına güven (örn. Cloudflare CDN arkasındaki CF-Connecting-IP). Yalnızca WebSocket, HTTPUpgrade ve XHTTP taşımalarında geçerlidir. İletilen başlıkları yok saymak için boş bırakın.",
+        "trustedXForwardedForHint": "Gerçek istemci IP'sini almak için bu istek başlığına güven (örn. Cloudflare CDN arkasındaki CF-Connecting-IP). Yalnızca WebSocket, HTTPUpgrade, XHTTP ve gRPC taşımalarında geçerlidir. İletilen başlıkları yok saymak için boş bırakın.",
         "proxyProtocolHint": "Gerçek istemci IP'sini bir üst L4 tüneli veya rölesi (HAProxy, gost, nginx-stream, Xray dokodemo-door) ya da Cloudflare Spectrum üzerinden öğrenmek için PROXY protocol başlığını kabul et. Üst sunucu PROXY protocol göndermek ZORUNDADIR. TCP, WebSocket, HTTPUpgrade ve gRPC üzerinde çalışır; mKCP üzerinde çalışmaz.",
         "realClientIp": "Gerçek istemci IP'si",
         "realClientIpHint": "Trafik bu gelen bağlantıya bir CDN veya röle üzerinden ulaştığında, aracı adresini kaydetmek yerine ziyaretçinin gerçek IP'sini al. Aşağıdaki ilgili sockopt alanlarını doldurmak için bir hazır ayar seç. Bu alanlar aboneliklerde istemcilere asla gönderilmez.",

--- a/internal/web/translation/uk-UA.json
+++ b/internal/web/translation/uk-UA.json
@@ -562,7 +562,7 @@
         "tcpCongestion": "TCP Congestion",
         "dialerProxy": "Dialer Proxy",
         "trustedXForwardedFor": "Довірений X-Forwarded-For",
-        "trustedXForwardedForHint": "Довіряти цьому заголовку запиту для визначення справжнього IP клієнта (наприклад, CF-Connecting-IP за CDN Cloudflare). Працює лише на транспортах WebSocket, HTTPUpgrade та XHTTP. Залиште порожнім, щоб ігнорувати заголовки пересилання.",
+        "trustedXForwardedForHint": "Довіряти цьому заголовку запиту для визначення справжнього IP клієнта (наприклад, CF-Connecting-IP за CDN Cloudflare). Працює лише на транспортах WebSocket, HTTPUpgrade, XHTTP та gRPC. Залиште порожнім, щоб ігнорувати заголовки пересилання.",
         "proxyProtocolHint": "Приймати заголовок PROXY protocol, щоб отримати справжній IP клієнта від висхідного L4-тунелю чи релея (HAProxy, gost, nginx-stream, Xray dokodemo-door) або Cloudflare Spectrum. Висхідний вузол МУСИТЬ надсилати PROXY protocol. Працює на TCP, WebSocket, HTTPUpgrade та gRPC; не працює на mKCP.",
         "realClientIp": "Справжній IP клієнта",
         "realClientIpHint": "Отримувати справжній IP відвідувача, коли трафік надходить на цей вхідний через CDN або релей, замість адреси проміжного вузла. Виберіть пресет, щоб заповнити відповідні поля sockopt нижче. Ці поля ніколи не надсилаються клієнтам у підписках.",

--- a/internal/web/translation/vi-VN.json
+++ b/internal/web/translation/vi-VN.json
@@ -583,7 +583,7 @@
         "tcpCongestion": "TCP Congestion",
         "dialerProxy": "Dialer Proxy",
         "trustedXForwardedFor": "X-Forwarded-For tin cậy",
-        "trustedXForwardedForHint": "Tin cậy header yêu cầu này để lấy IP thật của client (ví dụ CF-Connecting-IP phía sau CDN của Cloudflare). Chỉ có hiệu lực trên các transport WebSocket, HTTPUpgrade và XHTTP. Để trống để bỏ qua các header chuyển tiếp.",
+        "trustedXForwardedForHint": "Tin cậy header yêu cầu này để lấy IP thật của client (ví dụ CF-Connecting-IP phía sau CDN của Cloudflare). Chỉ có hiệu lực trên các transport WebSocket, HTTPUpgrade, XHTTP và gRPC. Để trống để bỏ qua các header chuyển tiếp.",
         "proxyProtocolHint": "Chấp nhận header PROXY protocol để lấy IP thật của client từ tunnel/relay L4 phía trên (HAProxy, gost, nginx-stream, Xray dokodemo-door) hoặc Cloudflare Spectrum. Phía trên PHẢI gửi PROXY protocol. Hoạt động trên TCP, WebSocket, HTTPUpgrade và gRPC; không hoạt động trên mKCP.",
         "realClientIp": "IP thật của client",
         "realClientIpHint": "Lấy IP thật của khách khi lưu lượng đến inbound này qua CDN hoặc relay, thay vì ghi lại địa chỉ của trung gian. Chọn một preset để tự điền các trường sockopt tương ứng bên dưới. Các trường này không bao giờ được gửi đến client trong subscription.",

--- a/internal/web/translation/zh-CN.json
+++ b/internal/web/translation/zh-CN.json
@@ -582,7 +582,7 @@
         "tcpCongestion": "TCP Congestion",
         "dialerProxy": "Dialer Proxy",
         "trustedXForwardedFor": "可信 X-Forwarded-For",
-        "trustedXForwardedForHint": "信任此请求头来获取真实客户端 IP（例如 Cloudflare CDN 后的 CF-Connecting-IP）。仅在 WebSocket、HTTPUpgrade 和 XHTTP 传输上生效。留空则忽略转发头。",
+        "trustedXForwardedForHint": "信任此请求头来获取真实客户端 IP（例如 Cloudflare CDN 后的 CF-Connecting-IP）。仅在 WebSocket、HTTPUpgrade、XHTTP 和 gRPC 传输上生效。留空则忽略转发头。",
         "proxyProtocolHint": "接受 PROXY protocol 头，从上游 L4 隧道或中继（HAProxy、gost、nginx-stream、Xray dokodemo-door）或 Cloudflare Spectrum 获取真实客户端 IP。上游必须发送 PROXY protocol。适用于 TCP、WebSocket、HTTPUpgrade 和 gRPC；不适用于 mKCP。",
         "realClientIp": "真实客户端 IP",
         "realClientIpHint": "当流量通过 CDN 或中继到达此入站时，获取访客的真实 IP，而不是记录中间节点的地址。选择一个预设以自动填写下方对应的 sockopt 字段。这些字段绝不会在订阅中发送给客户端。",

--- a/internal/web/translation/zh-TW.json
+++ b/internal/web/translation/zh-TW.json
@@ -562,7 +562,7 @@
         "tcpCongestion": "TCP Congestion",
         "dialerProxy": "Dialer Proxy",
         "trustedXForwardedFor": "信任的 X-Forwarded-For",
-        "trustedXForwardedForHint": "信任此請求標頭以取得真實用戶端 IP（例如 Cloudflare CDN 後的 CF-Connecting-IP）。僅在 WebSocket、HTTPUpgrade 和 XHTTP 傳輸上生效。留空則忽略轉發標頭。",
+        "trustedXForwardedForHint": "信任此請求標頭以取得真實用戶端 IP（例如 Cloudflare CDN 後的 CF-Connecting-IP）。僅在 WebSocket、HTTPUpgrade、XHTTP 和 gRPC 傳輸上生效。留空則忽略轉發標頭。",
         "proxyProtocolHint": "接受 PROXY protocol 標頭，從上游 L4 隧道或中繼（HAProxy、gost、nginx-stream、Xray dokodemo-door）或 Cloudflare Spectrum 取得真實用戶端 IP。上游必須傳送 PROXY protocol。適用於 TCP、WebSocket、HTTPUpgrade 和 gRPC；不適用於 mKCP。",
         "realClientIp": "真實用戶端 IP",
         "realClientIpHint": "當流量透過 CDN 或中繼到達此入站時，取得訪客的真實 IP，而非記錄中間節點的位址。選擇一個預設以自動填入下方對應的 sockopt 欄位。這些欄位絕不會在訂閱中傳送給用戶端。",


### PR DESCRIPTION
## Summary

Make gRPC inbounds honor `sockopt.trustedXForwardedFor` in the panel, matching xray-core v26.6.22.

## Why

xray-core v26.6.22 ([commit 711aea4](https://github.com/XTLS/Xray-core/commit/711aea4e34b0a00073d2fea6577f28a5d7c9b5eb)) switched the gRPC server from reading the `x-real-ip` gRPC metadata to resolving the client IP from `X-Forwarded-For` via `sockopt.trustedXForwardedFor` — the same mechanism already used by ws / httpupgrade / xhttp.

The panel already exposes the `trustedXForwardedFor` field, wire-normalizes it, and renders the input. Only the per-transport gate (`TRUSTED_HEADER_NETWORKS` in `transport/sockopt.tsx`) still omitted `grpc`. As a result, on a gRPC inbound the panel raised a false "this transport does not honor the header" warning and mis-flagged the Cloudflare real-client-IP preset, even though the generated config is valid and xray now honors it.

No Go dependency bump is needed: `go.mod` already pins an xray-core pseudo-version dated 2026-06-22, and 711aea4 landed 2026-06-18.

## Type of change

- [x] Bug fix

## Areas affected

- [x] Frontend (UI / panel pages)
- [x] Xray config generation

## How was this tested?

- Inbounds → add/edit a **gRPC** inbound → enable Sockopt → set **Real client IP** to *Cloudflare* (or add a header to *Trusted X-Forwarded-For*): the spurious transport-mismatch warning no longer appears, and the preset is no longer mis-flagged. The same on ws/httpupgrade/xhttp is unchanged.
- `go build ./...` ✓, full Go test suite `go test -shuffle=on -count=1` ✓.
- Frontend `typecheck` ✓, `lint` ✓; test counts unchanged vs. base.

## Screenshots / recordings

N/A — removes an erroneous warning; no new UI surface.

## Breaking changes

None.

## Checklist

- [x] I tested the change locally and confirmed the described behavior.
- [ ] I added or updated tests for the new behavior (gate is a constant list; component gating is not unit-tested today).
- [x] `go build ./...` and the test suite pass locally.
- [x] For frontend changes: lint, typecheck, and build pass.
- [ ] I updated the Wiki / README / API docs if user-facing behavior changed.
- [x] My commits follow the project's existing message style.
- [x] I have no unrelated changes mixed into this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
