### PR TITLE
fix(flow): restore XTLS Vision when an inbound becomes flow-eligible

### DIFF
--- a/internal/web/service/client_effective_flow_test.go
+++ b/internal/web/service/client_effective_flow_test.go
@@ -1,0 +1,64 @@
+package service
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/mhsanaei/3x-ui/v3/internal/database"
+	"github.com/mhsanaei/3x-ui/v3/internal/database/model"
+)
+
+// EffectiveFlowsByEmails resolves intended flow for many clients in one batched
+// query, taking the flow_override of the lowest inbound_id and skipping emails
+// with no non-empty flow anywhere.
+func TestEffectiveFlowsByEmails(t *testing.T) {
+	dbDir := t.TempDir()
+	t.Setenv("XUI_DB_FOLDER", dbDir)
+	if err := database.InitDB(filepath.Join(dbDir, "x-ui.db")); err != nil {
+		t.Fatalf("InitDB: %v", err)
+	}
+	t.Cleanup(func() { _ = database.CloseDB() })
+	db := database.GetDB()
+
+	const vision = "xtls-rprx-vision"
+
+	// vis@x: attached to inbound 20 (empty flow) and 10 (Vision) — lowest
+	// inbound_id (10) wins, so the empty override on 20 must not mask it.
+	// plain@x: only an empty flow_override anywhere — absent from the result.
+	mkClient := func(id int, email string) {
+		if err := db.Create(&model.ClientRecord{Id: id, Email: email, Enable: true}).Error; err != nil {
+			t.Fatalf("create client %s: %v", email, err)
+		}
+	}
+	mkLink := func(clientID, inboundID int, flow string) {
+		if err := db.Create(&model.ClientInbound{ClientId: clientID, InboundId: inboundID, FlowOverride: flow}).Error; err != nil {
+			t.Fatalf("link %d/%d: %v", clientID, inboundID, err)
+		}
+	}
+	mkClient(1, "vis@x")
+	mkClient(2, "plain@x")
+	mkLink(1, 20, "")     // higher inbound_id, empty
+	mkLink(1, 10, vision) // lower inbound_id, Vision
+	mkLink(2, 30, "")     // only empty override
+
+	cs := &ClientService{}
+	got, err := cs.EffectiveFlowsByEmails(nil, []string{"vis@x", "plain@x", "missing@x"})
+	if err != nil {
+		t.Fatalf("EffectiveFlowsByEmails: %v", err)
+	}
+
+	if got["vis@x"] != vision {
+		t.Errorf("vis@x = %q, want %q (lowest inbound_id flow_override)", got["vis@x"], vision)
+	}
+	if v, ok := got["plain@x"]; ok {
+		t.Errorf("plain@x present (%q); want absent (no non-empty flow anywhere)", v)
+	}
+	if v, ok := got["missing@x"]; ok {
+		t.Errorf("missing@x present (%q); want absent (unknown client)", v)
+	}
+
+	// Empty input is a no-op (no query).
+	if m, err := cs.EffectiveFlowsByEmails(nil, nil); err != nil || len(m) != 0 {
+		t.Errorf("empty input: got %v err %v, want empty map", m, err)
+	}
+}

--- a/internal/web/service/client_lookup.go
+++ b/internal/web/service/client_lookup.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"encoding/json"
+	"errors"
 	"strings"
 
 	"github.com/mhsanaei/3x-ui/v3/internal/database"
@@ -47,6 +48,25 @@ func (s *ClientService) EffectiveFlow(tx *gorm.DB, recordId int) (string, error)
 		return "", nil
 	}
 	return flows[0], nil
+}
+
+// EffectiveFlowByEmail returns the client's intended flow (the non-empty
+// flow_override on any of its inbounds, lowest inbound_id first), resolved from
+// the client's email. Returns "" when the client is unknown or carries no flow
+// on any inbound. Used to restore a stripped flow onto an inbound that has just
+// become flow-eligible.
+func (s *ClientService) EffectiveFlowByEmail(tx *gorm.DB, email string) (string, error) {
+	if tx == nil {
+		tx = database.GetDB()
+	}
+	rec, err := s.GetRecordByEmail(tx, email)
+	if err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return "", nil
+		}
+		return "", err
+	}
+	return s.EffectiveFlow(tx, rec.Id)
 }
 
 func (s *ClientService) GetInboundIdsForEmail(tx *gorm.DB, email string) ([]int, error) {

--- a/internal/web/service/client_lookup.go
+++ b/internal/web/service/client_lookup.go
@@ -2,7 +2,6 @@ package service
 
 import (
 	"encoding/json"
-	"errors"
 	"strings"
 
 	"github.com/mhsanaei/3x-ui/v3/internal/database"
@@ -50,23 +49,42 @@ func (s *ClientService) EffectiveFlow(tx *gorm.DB, recordId int) (string, error)
 	return flows[0], nil
 }
 
-// EffectiveFlowByEmail returns the client's intended flow (the non-empty
-// flow_override on any of its inbounds, lowest inbound_id first), resolved from
-// the client's email. Returns "" when the client is unknown or carries no flow
-// on any inbound. Used to restore a stripped flow onto an inbound that has just
-// become flow-eligible.
-func (s *ClientService) EffectiveFlowByEmail(tx *gorm.DB, email string) (string, error) {
+// EffectiveFlowsByEmails resolves the intended flow (non-empty flow_override,
+// lowest inbound_id first — same rule as EffectiveFlow) for many clients in one
+// query, keyed by email. Emails absent from the result carry no flow anywhere.
+// Batched so flow restoration on an inbound with many clients is O(1) queries
+// instead of O(clients). Used to restore a stripped flow onto an inbound that
+// has just become flow-eligible.
+func (s *ClientService) EffectiveFlowsByEmails(tx *gorm.DB, emails []string) (map[string]string, error) {
 	if tx == nil {
 		tx = database.GetDB()
 	}
-	rec, err := s.GetRecordByEmail(tx, email)
-	if err != nil {
-		if errors.Is(err, gorm.ErrRecordNotFound) {
-			return "", nil
-		}
-		return "", err
+	out := make(map[string]string, len(emails))
+	if len(emails) == 0 {
+		return out, nil
 	}
-	return s.EffectiveFlow(tx, rec.Id)
+	type row struct {
+		Email string
+		Flow  string `gorm:"column:flow_override"`
+	}
+	for _, batch := range chunkStrings(emails, sqlInChunk) {
+		var rows []row
+		err := tx.Table("client_inbounds").
+			Select("clients.email AS email, client_inbounds.flow_override AS flow_override").
+			Joins("JOIN clients ON clients.id = client_inbounds.client_id").
+			Where("clients.email IN ? AND client_inbounds.flow_override <> ?", batch, "").
+			Order("client_inbounds.inbound_id ASC").
+			Scan(&rows).Error
+		if err != nil {
+			return nil, err
+		}
+		for _, r := range rows {
+			if _, seen := out[r.Email]; !seen { // ordered by inbound_id ASC → first = lowest
+				out[r.Email] = r.Flow
+			}
+		}
+	}
+	return out, nil
 }
 
 func (s *ClientService) GetInboundIdsForEmail(tx *gorm.DB, email string) ([]int, error) {

--- a/internal/web/service/inbound.go
+++ b/internal/web/service/inbound.go
@@ -1069,7 +1069,7 @@ func (s *InboundService) UpdateInbound(inbound *model.Inbound) (*model.Inbound, 
 		// VLESS inbound just became flow-eligible (e.g. vlessenc was enabled on an
 		// XHTTP inbound), restore Vision for clients whose intended flow is Vision
 		// but was stripped while the inbound was ineligible.
-		if restored, changed := s.restoreVisionFlowForEligibleInbound(inbound.Settings, inbound.StreamSettings, inbound.Protocol); changed {
+		if restored, changed := s.restoreVisionFlowForEligibleInbound(tx, inbound.Settings, inbound.StreamSettings, inbound.Protocol); changed {
 			inbound.Settings = restored
 		}
 

--- a/internal/web/service/inbound.go
+++ b/internal/web/service/inbound.go
@@ -1065,6 +1065,14 @@ func (s *InboundService) UpdateInbound(inbound *model.Inbound) (*model.Inbound, 
 			logger.Warning("Shadowsocks inbound", inbound.Id, "method change resized keys; regenerated mismatched client PSK(s)")
 		}
 
+		// Re-gate Vision flow now that the new stream/encryption is known: if this
+		// VLESS inbound just became flow-eligible (e.g. vlessenc was enabled on an
+		// XHTTP inbound), restore Vision for clients whose intended flow is Vision
+		// but was stripped while the inbound was ineligible.
+		if restored, changed := s.restoreVisionFlowForEligibleInbound(inbound.Settings, inbound.StreamSettings, inbound.Protocol); changed {
+			inbound.Settings = restored
+		}
+
 		oldInbound.Total = inbound.Total
 		oldInbound.Remark = inbound.Remark
 		oldInbound.SubSortIndex = inbound.SubSortIndex

--- a/internal/web/service/inbound_flow_restore.go
+++ b/internal/web/service/inbound_flow_restore.go
@@ -4,6 +4,8 @@ import (
 	"encoding/json"
 
 	"github.com/mhsanaei/3x-ui/v3/internal/database/model"
+
+	"gorm.io/gorm"
 )
 
 const visionFlow = "xtls-rprx-vision"
@@ -20,11 +22,11 @@ const visionFlow = "xtls-rprx-vision"
 //
 // This runs on the now-final inbound settings: when the inbound IS flow-eligible
 // it sets flow=Vision on each client that currently has no flow but whose
-// intended flow (its flow_override on a sibling inbound, via EffectiveFlowByEmail)
+// intended flow (its flow_override on a sibling inbound, via EffectiveFlowsByEmails)
 // is Vision. It never invents a flow for a client that has none anywhere, and it
 // never overwrites an explicit non-empty flow. Returns the rewritten settings
 // JSON and whether anything changed.
-func (s *InboundService) restoreVisionFlowForEligibleInbound(settings, streamSettings string, protocol model.Protocol) (string, bool) {
+func (s *InboundService) restoreVisionFlowForEligibleInbound(tx *gorm.DB, settings, streamSettings string, protocol model.Protocol) (string, bool) {
 	if protocol != model.VLESS {
 		return settings, false
 	}
@@ -39,7 +41,8 @@ func (s *InboundService) restoreVisionFlowForEligibleInbound(settings, streamSet
 	if !ok || len(clients) == 0 {
 		return settings, false
 	}
-	changed := false
+	// Collect empty-flow clients, then resolve their intended flow in one query.
+	emails := make([]string, 0, len(clients))
 	for i := range clients {
 		cm, ok := clients[i].(map[string]any)
 		if !ok {
@@ -48,12 +51,28 @@ func (s *InboundService) restoreVisionFlowForEligibleInbound(settings, streamSet
 		if flow, _ := cm["flow"].(string); flow != "" {
 			continue // respect an explicit flow (Vision or otherwise)
 		}
-		email, _ := cm["email"].(string)
-		if email == "" {
+		if email, _ := cm["email"].(string); email != "" {
+			emails = append(emails, email)
+		}
+	}
+	if len(emails) == 0 {
+		return settings, false
+	}
+	intended, err := s.clientService.EffectiveFlowsByEmails(tx, emails)
+	if err != nil {
+		return settings, false
+	}
+	changed := false
+	for i := range clients {
+		cm, ok := clients[i].(map[string]any)
+		if !ok {
 			continue
 		}
-		intended, err := s.clientService.EffectiveFlowByEmail(nil, email)
-		if err != nil || intended != visionFlow {
+		if flow, _ := cm["flow"].(string); flow != "" {
+			continue
+		}
+		email, _ := cm["email"].(string)
+		if intended[email] != visionFlow {
 			continue
 		}
 		cm["flow"] = visionFlow

--- a/internal/web/service/inbound_flow_restore.go
+++ b/internal/web/service/inbound_flow_restore.go
@@ -63,7 +63,7 @@ func (s *InboundService) restoreVisionFlowForEligibleInbound(settings, streamSet
 	if !changed {
 		return settings, false
 	}
-	out, err := json.Marshal(parsed)
+	out, err := json.MarshalIndent(parsed, "", "  ")
 	if err != nil {
 		return settings, false
 	}

--- a/internal/web/service/inbound_flow_restore.go
+++ b/internal/web/service/inbound_flow_restore.go
@@ -1,0 +1,71 @@
+package service
+
+import (
+	"encoding/json"
+
+	"github.com/mhsanaei/3x-ui/v3/internal/database/model"
+)
+
+const visionFlow = "xtls-rprx-vision"
+
+// restoreVisionFlowForEligibleInbound re-adds the XTLS Vision flow to a VLESS
+// inbound's clients that lost it earlier.
+//
+// clientWithInboundFlow strips Vision from a client whenever the target inbound
+// is not flow-eligible at write time (e.g. an XHTTP inbound before its vlessenc
+// encryption is set). Nothing restored the flow when the inbound later became
+// eligible — an inbound edit stores its settings verbatim and never re-gates the
+// clients — so enabling encryption on an existing XHTTP inbound left every
+// client without flow, and the share links/subscriptions dropped it.
+//
+// This runs on the now-final inbound settings: when the inbound IS flow-eligible
+// it sets flow=Vision on each client that currently has no flow but whose
+// intended flow (its flow_override on a sibling inbound, via EffectiveFlowByEmail)
+// is Vision. It never invents a flow for a client that has none anywhere, and it
+// never overwrites an explicit non-empty flow. Returns the rewritten settings
+// JSON and whether anything changed.
+func (s *InboundService) restoreVisionFlowForEligibleInbound(settings, streamSettings string, protocol model.Protocol) (string, bool) {
+	if protocol != model.VLESS {
+		return settings, false
+	}
+	if !inboundCanEnableTlsFlow(string(protocol), streamSettings, settings) {
+		return settings, false
+	}
+	var parsed map[string]any
+	if err := json.Unmarshal([]byte(settings), &parsed); err != nil {
+		return settings, false
+	}
+	clients, ok := parsed["clients"].([]any)
+	if !ok || len(clients) == 0 {
+		return settings, false
+	}
+	changed := false
+	for i := range clients {
+		cm, ok := clients[i].(map[string]any)
+		if !ok {
+			continue
+		}
+		if flow, _ := cm["flow"].(string); flow != "" {
+			continue // respect an explicit flow (Vision or otherwise)
+		}
+		email, _ := cm["email"].(string)
+		if email == "" {
+			continue
+		}
+		intended, err := s.clientService.EffectiveFlowByEmail(nil, email)
+		if err != nil || intended != visionFlow {
+			continue
+		}
+		cm["flow"] = visionFlow
+		clients[i] = cm
+		changed = true
+	}
+	if !changed {
+		return settings, false
+	}
+	out, err := json.Marshal(parsed)
+	if err != nil {
+		return settings, false
+	}
+	return string(out), true
+}

--- a/internal/web/service/inbound_flow_restore_test.go
+++ b/internal/web/service/inbound_flow_restore_test.go
@@ -64,7 +64,7 @@ func TestRestoreVisionFlowForEligibleInbound(t *testing.T) {
 		`{"id":"u2","email":"none@x","flow":"","subId":"s2","enable":true}` +
 		`]}`
 
-	out, changed := ibSvc.restoreVisionFlowForEligibleInbound(target, xhttpEnc, model.VLESS)
+	out, changed := ibSvc.restoreVisionFlowForEligibleInbound(nil, target, xhttpEnc, model.VLESS)
 	if !changed {
 		t.Fatal("expected changed=true")
 	}
@@ -86,11 +86,11 @@ func TestRestoreVisionFlowForEligibleInbound(t *testing.T) {
 
 	// Ineligible inbound (xhttp without encryption) must be a no-op.
 	noenc := `{"clients":[{"id":"u1","email":"keep@x","flow":"","subId":"s1","enable":true}]}`
-	if _, ch := ibSvc.restoreVisionFlowForEligibleInbound(noenc, `{"network":"xhttp","security":"reality"}`, model.VLESS); ch {
+	if _, ch := ibSvc.restoreVisionFlowForEligibleInbound(nil, noenc, `{"network":"xhttp","security":"reality"}`, model.VLESS); ch {
 		t.Error("ineligible xhttp (no vlessenc) must not change")
 	}
 	// Non-VLESS must be a no-op.
-	if _, ch := ibSvc.restoreVisionFlowForEligibleInbound(target, xhttpEnc, model.VMESS); ch {
+	if _, ch := ibSvc.restoreVisionFlowForEligibleInbound(nil, target, xhttpEnc, model.VMESS); ch {
 		t.Error("non-VLESS must not change")
 	}
 }

--- a/internal/web/service/inbound_flow_restore_test.go
+++ b/internal/web/service/inbound_flow_restore_test.go
@@ -1,0 +1,96 @@
+package service
+
+import (
+	"encoding/json"
+	"path/filepath"
+	"testing"
+
+	"github.com/mhsanaei/3x-ui/v3/internal/database"
+	"github.com/mhsanaei/3x-ui/v3/internal/database/model"
+)
+
+// restoreVisionFlowForEligibleInbound must re-add Vision to a client whose flow
+// was stripped while the XHTTP inbound was not yet vlessenc-encrypted, but only
+// when the client's intended flow (its flow_override on a sibling) is Vision,
+// only on now-eligible inbounds, and never overwriting an explicit flow.
+func TestRestoreVisionFlowForEligibleInbound(t *testing.T) {
+	dbDir := t.TempDir()
+	t.Setenv("XUI_DB_FOLDER", dbDir)
+	if err := database.InitDB(filepath.Join(dbDir, "x-ui.db")); err != nil {
+		t.Fatalf("InitDB: %v", err)
+	}
+	t.Cleanup(func() { _ = database.CloseDB() })
+	db := database.GetDB()
+
+	const vision = "xtls-rprx-vision"
+	const realityStream = `{"network":"tcp","security":"reality"}`
+	const xhttpEnc = `{"network":"xhttp","security":"reality"}`
+	const encSettings = `"decryption":"mlkem768x25519plus.native.0rtt.KEY","encryption":"mlkem768x25519plus.native.0rtt.KEY"`
+
+	cs := &ClientService{}
+	ibSvc := &InboundService{}
+
+	// Sibling reality inbound where the client legitimately has Vision.
+	sibling := &model.Inbound{
+		Tag: "sib", Enable: true, Port: 51001, Protocol: model.VLESS, StreamSettings: realityStream,
+		Settings: `{"clients":[{"id":"u1","email":"keep@x","flow":"` + vision + `","subId":"s1","enable":true}]}`,
+	}
+	if err := db.Create(sibling).Error; err != nil {
+		t.Fatalf("create sibling: %v", err)
+	}
+	keep, _ := ibSvc.GetClients(sibling)
+	if err := cs.SyncInbound(nil, sibling.Id, keep); err != nil {
+		t.Fatalf("sync sibling: %v", err)
+	}
+
+	// A client with no intended Vision anywhere — must NOT be touched.
+	other := &model.Inbound{
+		Tag: "oth", Enable: true, Port: 51002, Protocol: model.VLESS, StreamSettings: realityStream,
+		Settings: `{"clients":[{"id":"u2","email":"none@x","subId":"s2","enable":true}]}`,
+	}
+	if err := db.Create(other).Error; err != nil {
+		t.Fatalf("create other: %v", err)
+	}
+	oc, _ := ibSvc.GetClients(other)
+	if err := cs.SyncInbound(nil, other.Id, oc); err != nil {
+		t.Fatalf("sync other: %v", err)
+	}
+
+	// The now-eligible XHTTP inbound: keep@x has empty flow (was stripped),
+	// none@x has empty flow (no Vision anywhere), set@x has an explicit empty
+	// stays empty unless intended Vision.
+	target := `{` + encSettings + `,"clients":[` +
+		`{"id":"u1","email":"keep@x","flow":"","subId":"s1","enable":true},` +
+		`{"id":"u2","email":"none@x","flow":"","subId":"s2","enable":true}` +
+		`]}`
+
+	out, changed := ibSvc.restoreVisionFlowForEligibleInbound(target, xhttpEnc, model.VLESS)
+	if !changed {
+		t.Fatal("expected changed=true")
+	}
+	var parsed map[string]any
+	if err := json.Unmarshal([]byte(out), &parsed); err != nil {
+		t.Fatalf("parse out: %v", err)
+	}
+	flows := map[string]string{}
+	for _, c := range parsed["clients"].([]any) {
+		cm := c.(map[string]any)
+		flows[cm["email"].(string)], _ = cm["flow"].(string)
+	}
+	if flows["keep@x"] != vision {
+		t.Errorf("keep@x flow = %q, want Vision (intended on sibling)", flows["keep@x"])
+	}
+	if flows["none@x"] != "" {
+		t.Errorf("none@x flow = %q, want empty (no Vision intent)", flows["none@x"])
+	}
+
+	// Ineligible inbound (xhttp without encryption) must be a no-op.
+	noenc := `{"clients":[{"id":"u1","email":"keep@x","flow":"","subId":"s1","enable":true}]}`
+	if _, ch := ibSvc.restoreVisionFlowForEligibleInbound(noenc, `{"network":"xhttp","security":"reality"}`, model.VLESS); ch {
+		t.Error("ineligible xhttp (no vlessenc) must not change")
+	}
+	// Non-VLESS must be a no-op.
+	if _, ch := ibSvc.restoreVisionFlowForEligibleInbound(target, xhttpEnc, model.VMESS); ch {
+		t.Error("non-VLESS must not change")
+	}
+}

--- a/internal/web/service/inbound_migration.go
+++ b/internal/web/service/inbound_migration.go
@@ -253,4 +253,45 @@ func (s *InboundService) MigrationRequirements() {
 func (s *InboundService) MigrateDB() {
 	s.MigrationRequirements()
 	s.MigrationRemoveOrphanedTraffics()
+	s.MigrationRestoreVisionFlow()
+}
+
+// MigrationRestoreVisionFlow repairs VLESS inbounds whose clients lost their
+// XTLS Vision flow because the inbound was not flow-eligible when the client was
+// written (e.g. an XHTTP inbound whose vlessenc encryption was enabled only
+// later). For each now-eligible inbound it restores flow=xtls-rprx-vision on
+// clients whose intended flow (their flow_override on a sibling inbound) is
+// Vision. Idempotent: once a client carries the flow it is skipped, so this is a
+// no-op on healthy installs and on subsequent boots.
+func (s *InboundService) MigrationRestoreVisionFlow() {
+	db := database.GetDB()
+	var inbounds []*model.Inbound
+	if err := db.Model(&model.Inbound{}).
+		Where("protocol = ?", model.VLESS).
+		Find(&inbounds).Error; err != nil {
+		logger.Warning("MigrationRestoreVisionFlow: load inbounds failed:", err)
+		return
+	}
+	for _, ib := range inbounds {
+		restored, changed := s.restoreVisionFlowForEligibleInbound(ib.Settings, ib.StreamSettings, ib.Protocol)
+		if !changed {
+			continue
+		}
+		clients, err := s.GetClients(&model.Inbound{Settings: restored})
+		if err != nil {
+			logger.Warning("MigrationRestoreVisionFlow: parse clients for inbound", ib.Id, "failed:", err)
+			continue
+		}
+		err = db.Transaction(func(tx *gorm.DB) error {
+			if e := tx.Model(&model.Inbound{}).Where("id = ?", ib.Id).Update("settings", restored).Error; e != nil {
+				return e
+			}
+			return s.clientService.SyncInbound(tx, ib.Id, clients)
+		})
+		if err != nil {
+			logger.Warning("MigrationRestoreVisionFlow: update inbound", ib.Id, "failed:", err)
+			continue
+		}
+		logger.Info("MigrationRestoreVisionFlow: restored XTLS Vision flow on inbound", ib.Id)
+	}
 }

--- a/internal/web/service/inbound_migration.go
+++ b/internal/web/service/inbound_migration.go
@@ -273,7 +273,7 @@ func (s *InboundService) MigrationRestoreVisionFlow() {
 		return
 	}
 	for _, ib := range inbounds {
-		restored, changed := s.restoreVisionFlowForEligibleInbound(ib.Settings, ib.StreamSettings, ib.Protocol)
+		restored, changed := s.restoreVisionFlowForEligibleInbound(nil, ib.Settings, ib.StreamSettings, ib.Protocol)
 		if !changed {
 			continue
 		}


### PR DESCRIPTION
## Summary

Restore the XTLS Vision flow on VLESS clients when an inbound becomes flow-eligible, fixing `flow=xtls-rprx-vision` silently missing from generated configs / share links / subscriptions.

## Why

`clientWithInboundFlow` strips Vision from a client whenever the target inbound is **not flow-eligible at client-write time** — e.g. an XHTTP inbound before its `vlessenc` (ML-KEM) encryption is set, or a client attached to such an inbound. That gate is correct, but nothing ever restored the flow once the inbound *later* became eligible: an inbound edit stores its settings verbatim and never re-gates its clients.

Result: enabling encryption on an existing XHTTP inbound (or attaching clients before encryption was set) leaves every client on it without flow. The subscription then faithfully emits links without `flow=xtls-rprx-vision`. This shows up most visibly on **node inbounds** and on any inbound where vlessenc was turned on after the clients already existed, while a sibling inbound configured vision-first keeps it — so the same client gets vision on one endpoint and not another.

Diagnosed on a live multi-node deployment (master + 3 nodes, PostgreSQL): the per-inbound flow (`client_inbounds.flow_override`, mirrored into each inbound's `settings` JSON) was empty on the affected inbounds while a sibling reality inbound held vision for the same client. Re-saving the client restored it end-to-end (master → node → subscription), confirming the gate/push/sub paths are correct and the gap is purely the missing re-evaluation.

## What

- **`UpdateInbound`**: after the new stream/settings are finalized, re-add Vision to clients that currently carry no flow but whose intended flow (their `flow_override` on a sibling inbound) is Vision — only when the inbound is now flow-eligible (`inboundCanEnableTlsFlow`).
- **`MigrationRestoreVisionFlow`**: an idempotent boot migration that applies the same repair to existing installs and refreshes `flow_override` via `SyncInbound`.
- **Batched, transaction-local flow resolution** (`EffectiveFlowsByEmails`): the intended flow for every empty-flow client on the inbound is resolved in a **single** join over `client_inbounds` + `clients` (lowest `inbound_id` wins), instead of two queries per client. The lookup also runs on the active write transaction in `UpdateInbound` rather than a separate pooled connection. See the perf note below.

Conservative by design: never invents a flow for a client that has none anywhere, never overwrites an explicit flow, no-op on healthy installs and on later boots.

### Performance / correctness of the lookup

The first revision resolved each empty-flow client with a per-client helper that issued two queries (`GetRecordByEmail` + `EffectiveFlow`). A client that genuinely uses no Vision keeps an empty flow forever, so it was re-queried on every `UpdateInbound` and every boot — O(clients) queries per save on a Reality/TCP or XHTTP+vlessenc inbound carrying many non-Vision clients, executed inside the serialized writer transaction. This is now a single batched query (chunked for the SQLite bind-var limit), and `restoreVisionFlowForEligibleInbound` takes the active `tx` so the read uses the writer's own connection while it holds the lock (the boot migration still passes `nil` → `GetDB()`).

## Type of change

- [x] Bug fix

## Areas affected

- [x] Backend (API endpoints, login, settings)
- [x] Xray config generation
- [x] Subscription (share links / Clash / JSON)
- [x] Database / migrations
- [x] Multi-node (sub-nodes)

## How was this tested?

- `inbound_flow_restore_test.go`: restores Vision for a client whose sibling has it, skips a client with no Vision intent, no-op on ineligible (xhttp without vlessenc) and non-VLESS inbounds — now exercised through the batched resolver.
- `client_effective_flow_test.go` (new): `EffectiveFlowsByEmails` takes the lowest-`inbound_id` `flow_override`, skips emails with no non-empty flow anywhere, skips unknown emails, and is a no-op (no query) on empty input.
- `go build ./...`, `go vet ./...`, and `go test ./...` pass.
- Verified the underlying behavior on a live master+nodes deployment: re-applying Vision on a previously-empty node XHTTP inbound propagated to the node DB and into the subscription link.

## Breaking changes

None. Behavior only adds flow back where it was intended; existing explicit flows are untouched.

## Checklist

- [x] I tested the change locally and confirmed the described behavior.
- [x] I added or updated tests for the new behavior.
- [x] `go build ./...` and the test suite pass locally.
- [ ] For frontend changes: N/A (backend only).
- [ ] I updated the Wiki / README / API docs if user-facing behavior changed.
- [x] My commits follow the project's existing message style.
- [x] I have no unrelated changes mixed into this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
