### PR TITLE
fix(inbounds): accept null rewritePort in tunnel settings (#5516)

### DIFF
--- a/frontend/src/schemas/protocols/inbound/tunnel.ts
+++ b/frontend/src/schemas/protocols/inbound/tunnel.ts
@@ -11,7 +11,12 @@ export type TunnelNetwork = z.infer<typeof TunnelNetworkSchema>;
 // with arr=false.
 export const TunnelInboundSettingsSchema = z.object({
   rewriteAddress: z.string().optional(),
-  rewritePort: PortSchema.optional(),
+  // AntD InputNumber writes null when cleared; accept it and collapse to
+  // undefined so the field is omitted from the payload instead of crashing
+  // validation with "Invalid input" (issue #5516). The trailing .optional()
+  // keeps the key optional in the inferred type (a bare .transform() would
+  // make it required).
+  rewritePort: PortSchema.nullable().transform((v) => v ?? undefined).optional(),
   portMap: z.record(z.string(), z.string()).default({}),
   allowedNetwork: TunnelNetworkSchema.default('tcp,udp'),
   followRedirect: z.boolean().default(false),

--- a/frontend/src/test/tunnel-rewriteport.test.ts
+++ b/frontend/src/test/tunnel-rewriteport.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest';
+
+import { TunnelInboundSettingsSchema } from '@/schemas/protocols/inbound/tunnel';
+
+// Regression for issue #5516: AntD InputNumber writes null when the Rewrite
+// port field is cleared, which used to crash validation with "Invalid input".
+describe('TunnelInboundSettingsSchema rewritePort', () => {
+  it('accepts null (cleared field) and omits the port', () => {
+    const parsed = TunnelInboundSettingsSchema.parse({ rewritePort: null });
+    expect(parsed.rewritePort).toBeUndefined();
+  });
+
+  it('accepts a missing field', () => {
+    const parsed = TunnelInboundSettingsSchema.parse({});
+    expect(parsed.rewritePort).toBeUndefined();
+  });
+
+  it('preserves a valid port', () => {
+    const parsed = TunnelInboundSettingsSchema.parse({ rewritePort: 8443 });
+    expect(parsed.rewritePort).toBe(8443);
+  });
+
+  it('still rejects out-of-range ports', () => {
+    expect(() => TunnelInboundSettingsSchema.parse({ rewritePort: 70000 })).toThrow();
+  });
+});


### PR DESCRIPTION
## Summary

Fix a validation crash when the tunnel inbound's **Rewrite port** field is cleared. Closes #5516.

## Why

When the Rewrite port field is cleared, Ant Design's `InputNumber` writes `null` into the form store (its standard behavior for an empty numeric field). The advanced JSON tab reflects this as `"rewritePort": null`.

On save, the tunnel schema declared:

```ts
rewritePort: PortSchema.optional()
```

Zod's `.optional()` permits `undefined` but **not** `null`, so the form-store `null` was rejected with `settings.rewritePort — Invalid input`. The only workaround was to manually delete the `rewritePort` key in the JSON editor (which sets the value to `undefined`).

The fix accepts `null` and collapses it to `undefined`, so the field is omitted from the serialized payload — matching the deleted-key behavior:

```ts
rewritePort: PortSchema.nullable().transform((v) => v ?? undefined).optional()
```

The trailing `.optional()` keeps the key optional in the inferred type (a bare `.transform()` would make it required and break the default-settings factory).

## Type of change

- [x] Bug fix

## Areas affected

- [x] Frontend (UI / panel pages)

## How was this tested?

- Added `frontend/src/test/tunnel-rewriteport.test.ts` covering: `null` → omitted, missing → omitted, valid port preserved, out-of-range still rejected.
- `npm run typecheck` and `npm run lint` pass.
- `npm run gen` produces no diff (codegen gate clean).
- Verified schema behavior directly against zod: `{ rewritePort: null }` and `{}` both parse to `{}`; `8443` is preserved; `70000` is rejected.
- Manual: tunnel inbound → clear Rewrite port → Save succeeds, and the port is omitted from settings.

## Breaking changes

None. A previously-crashing input (`null`) now parses to "port omitted"; all valid ports behave as before.

## Checklist

- [x] I tested the change locally and confirmed the described behavior.
- [x] I added or updated tests for the new behavior (when applicable).
- [x] For frontend changes: `npm run lint`, `npm run typecheck` pass.
- [x] My commits follow the project's existing message style.
- [x] I have no unrelated changes mixed into this PR.
