### PR TITLE
fix(settings): normalize API token timestamps

### DIFF
--- a/frontend/src/pages/settings/SecurityTab.tsx
+++ b/frontend/src/pages/settings/SecurityTab.tsx
@@ -13,7 +13,7 @@ import {
   message,
 } from 'antd';
 import { ApiOutlined, SafetyOutlined, UserOutlined } from '@ant-design/icons';
-import { ClipboardManager, HttpUtil, RandomUtil } from '@/utils';
+import { ClipboardManager, HttpUtil, IntlUtil, RandomUtil } from '@/utils';
 import type { AllSetting } from '@/models/setting';
 import { SettingListItem } from '@/components/ui';
 import { useMediaQuery } from '@/hooks/useMediaQuery';
@@ -37,6 +37,12 @@ interface ApiTokenRow {
 interface SecurityTabProps {
   allSetting: AllSetting;
   updateSetting: (patch: Partial<AllSetting>) => void;
+}
+
+const UNIX_MILLISECONDS_THRESHOLD = 100_000_000_000;
+
+function apiTokenCreatedAtMilliseconds(createdAt: number): number {
+  return createdAt < UNIX_MILLISECONDS_THRESHOLD ? createdAt * 1000 : createdAt;
 }
 
 type TfaType = 'set' | 'confirm';
@@ -194,7 +200,7 @@ export default function SecurityTab({ allSetting, updateSetting }: SecurityTabPr
 
   function formatTokenDate(ts: number): string {
     if (!ts) return '';
-    return new Date(ts * 1000).toLocaleString();
+    return IntlUtil.formatDate(apiTokenCreatedAtMilliseconds(ts));
   }
 
   function toggleTwoFactor() {

--- a/frontend/src/test/api-token-date.test.tsx
+++ b/frontend/src/test/api-token-date.test.tsx
@@ -1,0 +1,36 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import type { AllSetting } from '@/models/setting';
+import SecurityTab from '@/pages/settings/SecurityTab';
+import { HttpUtil } from '@/utils';
+
+describe('API token creation date', () => {
+  it('renders both API seconds and legacy millisecond timestamps', async () => {
+    vi.spyOn(HttpUtil, 'get').mockResolvedValueOnce({
+      success: true,
+      msg: '',
+      obj: [
+        {
+          id: 2,
+          name: 'seconds-token',
+          enabled: true,
+          createdAt: 1782485394,
+        },
+        {
+          id: 3,
+          name: 'legacy-milliseconds-token',
+          enabled: true,
+          createdAt: 1782485394270,
+        },
+      ],
+    });
+
+    render(<SecurityTab allSetting={{} as AllSetting} updateSetting={vi.fn()} />);
+    fireEvent.click(screen.getByRole('tab', { name: /API Token/ }));
+
+    expect(await screen.findByText('seconds-token')).toBeTruthy();
+    expect(screen.getByText('legacy-milliseconds-token')).toBeTruthy();
+    expect(screen.getAllByText(/2026/)).toHaveLength(2);
+  });
+});

--- a/internal/database/api_token_timestamp_test.go
+++ b/internal/database/api_token_timestamp_test.go
@@ -1,0 +1,49 @@
+package database
+
+import (
+	"testing"
+
+	"github.com/mhsanaei/3x-ui/v3/internal/database/model"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+	"gorm.io/gorm/logger"
+)
+
+func TestNormalizeApiTokenCreatedAtSeconds(t *testing.T) {
+	originalDB := db
+	t.Cleanup(func() { db = originalDB })
+
+	var err error
+	db, err = gorm.Open(sqlite.Open(":memory:"), &gorm.Config{Logger: logger.Discard})
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	if err := db.AutoMigrate(&model.ApiToken{}); err != nil {
+		t.Fatalf("migrate api_tokens: %v", err)
+	}
+
+	rows := []model.ApiToken{
+		{Name: "seconds", Token: "a", CreatedAt: 1_782_485_394},
+		{Name: "milliseconds", Token: "b", CreatedAt: 1_782_485_394_270},
+	}
+	if err := db.Create(&rows).Error; err != nil {
+		t.Fatalf("seed api tokens: %v", err)
+	}
+
+	if err := normalizeApiTokenCreatedAtSeconds(); err != nil {
+		t.Fatalf("normalize timestamps: %v", err)
+	}
+	if err := normalizeApiTokenCreatedAtSeconds(); err != nil {
+		t.Fatalf("normalize timestamps again: %v", err)
+	}
+
+	var got []model.ApiToken
+	if err := db.Order("id asc").Find(&got).Error; err != nil {
+		t.Fatalf("read api tokens: %v", err)
+	}
+	for _, row := range got {
+		if row.CreatedAt != 1_782_485_394 {
+			t.Fatalf("%s created_at = %d, want seconds", row.Name, row.CreatedAt)
+		}
+	}
+}

--- a/internal/database/db.go
+++ b/internal/database/db.go
@@ -1092,9 +1092,8 @@ func InitDB(dbPath string) error {
 // autoCreateTime:milli. The threshold separates modern Unix milliseconds from
 // Unix seconds and makes this safe to run on every startup.
 func normalizeApiTokenCreatedAtSeconds() error {
-	const unixMillisecondsThreshold int64 = 100_000_000_000
 	return db.Model(&model.ApiToken{}).
-		Where("created_at >= ?", unixMillisecondsThreshold).
+		Where("created_at >= ?", model.ApiTokenUnixMillisecondsThreshold).
 		UpdateColumn("created_at", gorm.Expr("created_at / ?", 1000)).Error
 }
 

--- a/internal/database/db.go
+++ b/internal/database/db.go
@@ -94,6 +94,9 @@ func initModels() error {
 	if err := migrateHostVerifyPeerCertByNameColumn(); err != nil {
 		return err
 	}
+	if err := normalizeApiTokenCreatedAtSeconds(); err != nil {
+		return err
+	}
 	if err := dropLegacyForeignKeys(); err != nil {
 		return err
 	}
@@ -1083,6 +1086,16 @@ func InitDB(dbPath string) error {
 		return err
 	}
 	return runSeeders(isUsersEmpty)
+}
+
+// normalizeApiTokenCreatedAtSeconds repairs rows written while ApiToken used
+// autoCreateTime:milli. The threshold separates modern Unix milliseconds from
+// Unix seconds and makes this safe to run on every startup.
+func normalizeApiTokenCreatedAtSeconds() error {
+	const unixMillisecondsThreshold int64 = 100_000_000_000
+	return db.Model(&model.ApiToken{}).
+		Where("created_at >= ?", unixMillisecondsThreshold).
+		UpdateColumn("created_at", gorm.Expr("created_at / ?", 1000)).Error
 }
 
 // sqliteSynchronous returns the SQLite synchronous mode, defaulting to FULL.

--- a/internal/database/model/model.go
+++ b/internal/database/model/model.go
@@ -154,7 +154,7 @@ type ApiToken struct {
 	Name      string `json:"name" gorm:"uniqueIndex;not null"`
 	Token     string `json:"token" gorm:"not null"` // SHA-256 hash; the plaintext is shown only once at creation
 	Enabled   bool   `json:"enabled" gorm:"default:true"`
-	CreatedAt int64  `json:"createdAt" gorm:"autoCreateTime:milli"`
+	CreatedAt int64  `json:"createdAt" gorm:"autoCreateTime"`
 }
 
 // MarshalJSON emits settings, streamSettings, and sniffing as nested JSON

--- a/internal/database/model/model.go
+++ b/internal/database/model/model.go
@@ -149,6 +149,10 @@ type HistoryOfSeeders struct {
 	SeederName string `json:"seederName"`
 }
 
+// ApiTokenUnixMillisecondsThreshold separates legacy millisecond timestamps
+// from the seconds-based API token timestamp contract.
+const ApiTokenUnixMillisecondsThreshold int64 = 100_000_000_000
+
 type ApiToken struct {
 	Id        int    `json:"id" gorm:"primaryKey;autoIncrement"`
 	Name      string `json:"name" gorm:"uniqueIndex;not null"`

--- a/internal/web/service/panel/api_token.go
+++ b/internal/web/service/panel/api_token.go
@@ -16,11 +16,6 @@ type ApiTokenService struct{}
 
 const apiTokenLength = 48
 
-// API token timestamps predate the model's temporary switch to milliseconds.
-// Keep the API contract in Unix seconds while accepting rows written in either
-// unit during that period.
-const unixMillisecondsThreshold int64 = 100_000_000_000
-
 type ApiTokenView struct {
 	Id        int    `json:"id" example:"2"`
 	Name      string `json:"name" example:"central-panel-a"`
@@ -30,7 +25,7 @@ type ApiTokenView struct {
 }
 
 func apiTokenCreatedAtSeconds(createdAt int64) int64 {
-	if createdAt >= unixMillisecondsThreshold {
+	if createdAt >= model.ApiTokenUnixMillisecondsThreshold {
 		return createdAt / 1000
 	}
 	return createdAt

--- a/internal/web/service/panel/api_token.go
+++ b/internal/web/service/panel/api_token.go
@@ -16,12 +16,24 @@ type ApiTokenService struct{}
 
 const apiTokenLength = 48
 
+// API token timestamps predate the model's temporary switch to milliseconds.
+// Keep the API contract in Unix seconds while accepting rows written in either
+// unit during that period.
+const unixMillisecondsThreshold int64 = 100_000_000_000
+
 type ApiTokenView struct {
 	Id        int    `json:"id" example:"2"`
 	Name      string `json:"name" example:"central-panel-a"`
 	Token     string `json:"token,omitempty" example:"new-token-string"`
 	Enabled   bool   `json:"enabled" example:"true"`
 	CreatedAt int64  `json:"createdAt" example:"1736000000"`
+}
+
+func apiTokenCreatedAtSeconds(createdAt int64) int64 {
+	if createdAt >= unixMillisecondsThreshold {
+		return createdAt / 1000
+	}
+	return createdAt
 }
 
 // toView builds the metadata view returned by List. It never carries the
@@ -32,7 +44,7 @@ func toView(t *model.ApiToken) *ApiTokenView {
 		Id:        t.Id,
 		Name:      t.Name,
 		Enabled:   t.Enabled,
-		CreatedAt: t.CreatedAt,
+		CreatedAt: apiTokenCreatedAtSeconds(t.CreatedAt),
 	}
 }
 

--- a/internal/web/service/panel/api_token_test.go
+++ b/internal/web/service/panel/api_token_test.go
@@ -1,0 +1,23 @@
+package panel
+
+import "testing"
+
+func TestApiTokenCreatedAtSeconds(t *testing.T) {
+	tests := []struct {
+		name string
+		in   int64
+		want int64
+	}{
+		{name: "seconds", in: 1_782_485_394, want: 1_782_485_394},
+		{name: "legacy milliseconds", in: 1_782_485_394_270, want: 1_782_485_394},
+		{name: "unset", in: 0, want: 0},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := apiTokenCreatedAtSeconds(tt.in); got != tt.want {
+				t.Fatalf("apiTokenCreatedAtSeconds(%d) = %d, want %d", tt.in, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Fix incorrect API-token creation dates in Panel Settings → Authentication → API Token. API-token timestamps now consistently use Unix seconds while remaining compatible with legacy millisecond values.

## Why

The API contract and frontend expected `ApiToken.createdAt` in Unix seconds, but the database model used `autoCreateTime:milli`.

For example, the backend returned:

`1782485394270`

The frontend multiplied this value by 1,000 again, producing a date thousands of years in the future instead of:

`06/26/2026, 22:49:54`

This PR restores the documented seconds-based contract and safely handles data created by affected versions.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactoring (no behavior change)
- [ ] Documentation
- [ ] Tests only
- [ ] Build / CI / tooling
- [ ] Other

## Areas affected

- [x] Frontend (UI / panel pages)
- [x] Backend (API endpoints, login, settings)
- [ ] Xray config generation
- [ ] Subscription (share links / Clash / JSON)
- [ ] Statistics / traffic counters
- [x] Database / migrations
- [ ] Install / upgrade script
- [ ] Docker image
- [ ] Multi-node (sub-nodes)
- [ ] Telegram bot

## How was this tested?

### Automated validation

The following commands passed locally:

- `go build ./...`
- `go test ./...`
- `npm run lint`
- `npm run typecheck`
- `npm run test` — 40 test files and 589 tests passed
- `npm run build`

### Added regression coverage

- Added a frontend test covering both:
  - Unix seconds: `1782485394`
  - Legacy Unix milliseconds: `1782485394270`
- Added a backend unit test for API response normalization.
- Added a database migration test confirming that:
  - Legacy millisecond values are converted to seconds.
  - Existing seconds values remain unchanged.
  - Running the migration multiple times is safe.

### Real database test

Tested locally with a copy of an existing `x-ui.db` containing:

`created_at = 1782485394270`

After backend startup, the copied database contained:

`created_at = 1782485394`

The authenticated endpoint:

`GET /panel/api/setting/apiTokens`

returned:

```json
{
  "success": true,
  "msg": "",
  "obj": [
    {
      "id": 2,
      "name": "central-panel",
      "enabled": true,
      "createdAt": 1782485394
    }
  ]
}
```

The frontend was tested through the Vite development server in a Chromium-based browser.

On Panel Settings → Authentication → API Token, the token rendered as:

`central-panel — 06/26/2026, 22:49:54`

The original database was not modified.

## Screenshots / recordings

Screenshot of  Authentication → API Token Datetime Bug:
<img width="2938" height="1668" alt="image" src="https://github.com/user-attachments/assets/e9873253-8d43-41e3-a567-800eeab7c4a5" />

<img width="2484" height="1282" alt="image" src="https://github.com/user-attachments/assets/3ceb7ac6-5a5f-498c-9ec5-3f52d23056c7" />



Fixed:
<img width="2938" height="1742" alt="image" src="https://github.com/user-attachments/assets/dcfb80ab-f24b-48e5-a600-6be46882fc54" />



## Breaking changes

None expected.

- Newly created API-token timestamps are stored in Unix seconds.
- Existing millisecond values are automatically migrated to seconds during startup.
- The migration is idempotent.
- The backend also normalizes remaining legacy millisecond values before returning them.
- The frontend accepts both seconds and milliseconds for compatibility with older panel versions.
- The existing API documentation already defines `createdAt` using Unix seconds.

## Checklist

- [x] I tested the change locally and confirmed the described behavior.
- [x] I added or updated tests for the new behavior (when applicable).
- [x] `go build ./...` and the test suite pass locally.
- [x] For frontend changes: `npm run lint`, `npm run typecheck`, and `npm run build` pass.
- [x] I verified the Wiki / README / API docs; the existing API contract already documents seconds.
- [x] My commits follow the project's existing message style.
- [x] I have no unrelated changes mixed into this PR.