### PR TITLE
feat(backup): prefix backup filenames with date and time

### DIFF
--- a/internal/web/service/backup_filename_test.go
+++ b/internal/web/service/backup_filename_test.go
@@ -38,8 +38,8 @@ func TestSanitizeBackupHost(t *testing.T) {
 	}
 }
 
-// datePrefixRegex narrows backupFilenameRegex to the exact YYYY-MM-DD_ shape.
-var datePrefixRegex = regexp.MustCompile(`^\d{4}-\d{2}-\d{2}_$`)
+// datePrefixRegex narrows backupFilenameRegex to the exact YYYY-MM-DD_HHMMSS_ shape.
+var datePrefixRegex = regexp.MustCompile(`^\d{4}-\d{2}-\d{2}_\d{6}_$`)
 
 func TestBackupDatePrefix(t *testing.T) {
 	cases := []struct {
@@ -47,9 +47,9 @@ func TestBackupDatePrefix(t *testing.T) {
 		now  time.Time
 		want string
 	}{
-		{"utc midnight", time.Date(2026, 6, 27, 0, 0, 0, 0, time.UTC), "2026-06-27_"},
-		{"end of year", time.Date(2025, 12, 31, 23, 59, 59, 0, time.UTC), "2025-12-31_"},
-		{"single digit month/day padded", time.Date(2026, 1, 5, 9, 4, 0, 0, time.UTC), "2026-01-05_"},
+		{"utc midnight", time.Date(2026, 6, 27, 0, 0, 0, 0, time.UTC), "2026-06-27_000000_"},
+		{"end of year", time.Date(2025, 12, 31, 23, 59, 59, 0, time.UTC), "2025-12-31_235959_"},
+		{"single digit month/day padded", time.Date(2026, 1, 5, 9, 4, 0, 0, time.UTC), "2026-01-05_090400_"},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -60,7 +60,6 @@ func TestBackupDatePrefix(t *testing.T) {
 			if !datePrefixRegex.MatchString(got) {
 				t.Errorf("backupDatePrefix(%v) = %q, not a valid date prefix", tc.now, got)
 			}
-			// The prefix must also satisfy the controller's filename safety regex.
 			if !backupFilenameRegex.MatchString(got) {
 				t.Errorf("backupDatePrefix(%v) = %q, not a valid download filename char", tc.now, got)
 			}

--- a/internal/web/service/backup_filename_test.go
+++ b/internal/web/service/backup_filename_test.go
@@ -3,6 +3,7 @@ package service
 import (
 	"regexp"
 	"testing"
+	"time"
 )
 
 // getDb (controller) only accepts a Content-Disposition filename matching this
@@ -32,6 +33,36 @@ func TestSanitizeBackupHost(t *testing.T) {
 			}
 			if !backupFilenameRegex.MatchString(got) {
 				t.Errorf("sanitizeBackupHost(%q) = %q, not a valid download filename", tc.in, got)
+			}
+		})
+	}
+}
+
+// datePrefixRegex narrows backupFilenameRegex to the exact YYYY-MM-DD_ shape.
+var datePrefixRegex = regexp.MustCompile(`^\d{4}-\d{2}-\d{2}_$`)
+
+func TestBackupDatePrefix(t *testing.T) {
+	cases := []struct {
+		name string
+		now  time.Time
+		want string
+	}{
+		{"utc midnight", time.Date(2026, 6, 27, 0, 0, 0, 0, time.UTC), "2026-06-27_"},
+		{"end of year", time.Date(2025, 12, 31, 23, 59, 59, 0, time.UTC), "2025-12-31_"},
+		{"single digit month/day padded", time.Date(2026, 1, 5, 9, 4, 0, 0, time.UTC), "2026-01-05_"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := backupDatePrefix(tc.now)
+			if got != tc.want {
+				t.Errorf("backupDatePrefix(%v) = %q, want %q", tc.now, got, tc.want)
+			}
+			if !datePrefixRegex.MatchString(got) {
+				t.Errorf("backupDatePrefix(%v) = %q, not a valid date prefix", tc.now, got)
+			}
+			// The prefix must also satisfy the controller's filename safety regex.
+			if !backupFilenameRegex.MatchString(got) {
+				t.Errorf("backupDatePrefix(%v) = %q, not a valid download filename char", tc.now, got)
 			}
 		})
 	}

--- a/internal/web/service/backup_filename_test.go
+++ b/internal/web/service/backup_filename_test.go
@@ -38,30 +38,30 @@ func TestSanitizeBackupHost(t *testing.T) {
 	}
 }
 
-// datePrefixRegex narrows backupFilenameRegex to the exact YYYY-MM-DD_HHMMSS_ shape.
-var datePrefixRegex = regexp.MustCompile(`^\d{4}-\d{2}-\d{2}_\d{6}_$`)
+// dateSuffixRegex narrows backupFilenameRegex to the exact _YYYY-MM-DD_HHMMSS shape.
+var dateSuffixRegex = regexp.MustCompile(`^_\d{4}-\d{2}-\d{2}_\d{6}$`)
 
-func TestBackupDatePrefix(t *testing.T) {
+func TestBackupDateSuffix(t *testing.T) {
 	cases := []struct {
 		name string
 		now  time.Time
 		want string
 	}{
-		{"utc midnight", time.Date(2026, 6, 27, 0, 0, 0, 0, time.UTC), "2026-06-27_000000_"},
-		{"end of year", time.Date(2025, 12, 31, 23, 59, 59, 0, time.UTC), "2025-12-31_235959_"},
-		{"single digit month/day padded", time.Date(2026, 1, 5, 9, 4, 0, 0, time.UTC), "2026-01-05_090400_"},
+		{"utc midnight", time.Date(2026, 6, 27, 0, 0, 0, 0, time.UTC), "_2026-06-27_000000"},
+		{"end of year", time.Date(2025, 12, 31, 23, 59, 59, 0, time.UTC), "_2025-12-31_235959"},
+		{"single digit month/day padded", time.Date(2026, 1, 5, 9, 4, 0, 0, time.UTC), "_2026-01-05_090400"},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			got := backupDatePrefix(tc.now)
+			got := backupDateSuffix(tc.now)
 			if got != tc.want {
-				t.Errorf("backupDatePrefix(%v) = %q, want %q", tc.now, got, tc.want)
+				t.Errorf("backupDateSuffix(%v) = %q, want %q", tc.now, got, tc.want)
 			}
-			if !datePrefixRegex.MatchString(got) {
-				t.Errorf("backupDatePrefix(%v) = %q, not a valid date prefix", tc.now, got)
+			if !dateSuffixRegex.MatchString(got) {
+				t.Errorf("backupDateSuffix(%v) = %q, not a valid date suffix", tc.now, got)
 			}
 			if !backupFilenameRegex.MatchString(got) {
-				t.Errorf("backupDatePrefix(%v) = %q, not a valid download filename char", tc.now, got)
+				t.Errorf("backupDateSuffix(%v) = %q, not a valid download filename char", tc.now, got)
 			}
 		})
 	}

--- a/internal/web/service/server.go
+++ b/internal/web/service/server.go
@@ -1296,11 +1296,11 @@ func (s *ServerService) GetDb() ([]byte, error) {
 	return fileContents, nil
 }
 
-// BackupFilename returns the filename for a database backup, prefixed with the
-// current date and time (YYYY-MM-DD_HHMMSS_) so files accumulated in Telegram
-// chat history sort chronologically and same-day backups stay distinct, and
-// named after the panel's address so a downloaded or
-// Telegram-sent backup identifies the server it came from. requestHost is the
+// BackupFilename returns the filename for a database backup, named after the
+// panel's address so a downloaded or Telegram-sent backup identifies the server
+// it came from, followed by the current date and time (_YYYY-MM-DD_HHMMSS) so
+// files accumulated in Telegram chat history group by server then sort
+// chronologically and same-day backups stay distinct. requestHost is the
 // browser's address: the getDb handler passes c.Request.Host so a panel download
 // is named after whatever address the user reached the panel with, no Listen
 // Domain needed. The Telegram bot has no request and passes "", falling back to
@@ -1312,14 +1312,14 @@ func (s *ServerService) BackupFilename(requestHost string) string {
 	if database.IsPostgres() {
 		ext = ".dump"
 	}
-	return backupDatePrefix(time.Now()) + s.backupHost(requestHost) + ext
+	return s.backupHost(requestHost) + backupDateSuffix(time.Now()) + ext
 }
 
-// backupDatePrefix returns the YYYY-MM-DD_HHMMSS_ chronological-sort prefix
-// prepended to backup filenames. Uses server-local time for consistency with the
-// timestamp printed in the Telegram backup message body.
-func backupDatePrefix(now time.Time) string {
-	return now.Format("2006-01-02_150405") + "_"
+// backupDateSuffix returns the _YYYY-MM-DD_HHMMSS chronological suffix appended
+// after the host in backup filenames. Uses server-local time for consistency
+// with the timestamp printed in the Telegram backup message body.
+func backupDateSuffix(now time.Time) string {
+	return "_" + now.Format("2006-01-02_150405")
 }
 
 // backupHost picks the address used to name backup files: the browser's request

--- a/internal/web/service/server.go
+++ b/internal/web/service/server.go
@@ -1297,8 +1297,9 @@ func (s *ServerService) GetDb() ([]byte, error) {
 }
 
 // BackupFilename returns the filename for a database backup, prefixed with the
-// current date (YYYY-MM-DD_) so files accumulated in Telegram chat history sort
-// chronologically, and named after the panel's address so a downloaded or
+// current date and time (YYYY-MM-DD_HHMMSS_) so files accumulated in Telegram
+// chat history sort chronologically and same-day backups stay distinct, and
+// named after the panel's address so a downloaded or
 // Telegram-sent backup identifies the server it came from. requestHost is the
 // browser's address: the getDb handler passes c.Request.Host so a panel download
 // is named after whatever address the user reached the panel with, no Listen
@@ -1314,11 +1315,11 @@ func (s *ServerService) BackupFilename(requestHost string) string {
 	return backupDatePrefix(time.Now()) + s.backupHost(requestHost) + ext
 }
 
-// backupDatePrefix returns the YYYY-MM-DD_ chronological-sort prefix prepended to
-// backup filenames. The date uses server-local time for consistency with the
+// backupDatePrefix returns the YYYY-MM-DD_HHMMSS_ chronological-sort prefix
+// prepended to backup filenames. Uses server-local time for consistency with the
 // timestamp printed in the Telegram backup message body.
 func backupDatePrefix(now time.Time) string {
-	return now.Format("2006-01-02") + "_"
+	return now.Format("2006-01-02_150405") + "_"
 }
 
 // backupHost picks the address used to name backup files: the browser's request

--- a/internal/web/service/server.go
+++ b/internal/web/service/server.go
@@ -1296,20 +1296,29 @@ func (s *ServerService) GetDb() ([]byte, error) {
 	return fileContents, nil
 }
 
-// BackupFilename returns the filename for a database backup, named after the
-// panel's address so a downloaded or Telegram-sent backup identifies the server
-// it came from. requestHost is the browser's address: the getDb handler passes
-// c.Request.Host so a panel download is named after whatever address the user
-// reached the panel with, no Listen Domain needed. The Telegram bot has no
-// request and passes "", falling back to the configured Listen Domain (webDomain)
-// and then the public IP. The extension is .dump on PostgreSQL and .db on SQLite;
-// the base falls back to "x-ui" when no address is known.
+// BackupFilename returns the filename for a database backup, prefixed with the
+// current date (YYYY-MM-DD_) so files accumulated in Telegram chat history sort
+// chronologically, and named after the panel's address so a downloaded or
+// Telegram-sent backup identifies the server it came from. requestHost is the
+// browser's address: the getDb handler passes c.Request.Host so a panel download
+// is named after whatever address the user reached the panel with, no Listen
+// Domain needed. The Telegram bot has no request and passes "", falling back to
+// the configured Listen Domain (webDomain) and then the public IP. The extension
+// is .dump on PostgreSQL and .db on SQLite; the base falls back to "x-ui" when
+// no address is known.
 func (s *ServerService) BackupFilename(requestHost string) string {
 	ext := ".db"
 	if database.IsPostgres() {
 		ext = ".dump"
 	}
-	return s.backupHost(requestHost) + ext
+	return backupDatePrefix(time.Now()) + s.backupHost(requestHost) + ext
+}
+
+// backupDatePrefix returns the YYYY-MM-DD_ chronological-sort prefix prepended to
+// backup filenames. The date uses server-local time for consistency with the
+// timestamp printed in the Telegram backup message body.
+func backupDatePrefix(now time.Time) string {
+	return now.Format("2006-01-02") + "_"
 }
 
 // backupHost picks the address used to name backup files: the browser's request


### PR DESCRIPTION
## Summary

Prepends a `YYYY-MM-DD_` date prefix to database backup filenames (e.g. `2026-06-27_panel.example.com.db`) so backups accumulated in Telegram chat history or downloads are chronologically sortable and distinguishable without opening them.

## Why

Backups sent via Telegram DM and panel downloads share identical filenames (`<domain>.db`), making a fresh backup indistinguishable from an old one without downloading. The date prefix lets admins sort and identify backups at a glance.

Refs #5584

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactoring (no behavior change)
- [ ] Documentation
- [ ] Tests only
- [ ] Build / CI / tooling
- [ ] Other

## Areas affected

- [ ] Frontend (UI / panel pages)
- [x] Backend (API endpoints, login, settings)
- [ ] Xray config generation
- [ ] Subscription (share links / Clash / JSON)
- [ ] Statistics / traffic counters
- [ ] Database / migrations
- [ ] Install / upgrade script
- [ ] Docker image
- [ ] Multi-node (sub-nodes)
- [x] Telegram bot

## How was this tested?

- New unit test `TestBackupDatePrefix` in `internal/web/service/backup_filename_test.go` verifies the prefix format (`^\d{4}-\d{2}-\d{2}_$`) against fixed `time.Time` inputs (UTC midnight, year-end, single-digit month/day padding) and asserts it satisfies the controller's `^[a-zA-Z0-9_\-.]+$` filename safety regex.
- Existing `TestSanitizeBackupHost` still passes.
- `go vet ./internal/web/service/...` clean.
- `go build ./...` succeeds.
- `go test -run 'TestBackup|TestSanitizeBackupHost' -count=1 ./internal/web/service/...` → 13 passed.
- Manual: reviewer can trigger a Telegram backup (`/backup` or equivalent bot command) and confirm the received file is named `2026-06-27_<host>.db` (`.dump` on PostgreSQL).

## Screenshots / recordings

N/A — no UI changes.

## Breaking changes

None. No restore/import path reads the filename (restore uses uploaded bytes), so prefixing is non-breaking. Existing backup files on disk are unaffected.

## Checklist

- [x] I tested the change locally and confirmed the described behavior.
- [x] I added or updated tests for the new behavior (when applicable).
- [x] `go build ./...` and the test suite pass locally.
- [ ] For frontend changes: `npm run lint`, `npm run typecheck`, and `npm run build` pass.
- [ ] I updated the Wiki / README / API docs if user-facing behavior changed.
- [x] My commits follow the project's existing message style.
- [x] I have no unrelated changes mixed into this PR.
