### PR TITLE
Fix WireGuard client binding in client manager

### DIFF
--- a/frontend/public/openapi.json
+++ b/frontend/public/openapi.json
@@ -2301,7 +2301,7 @@
     },
     {
       "name": "Inbounds",
-      "description": "Manage inbound configurations and their clients. All endpoints live under /panel/api/inbounds and require a logged-in session or Bearer token. Link-generating endpoints honour forwarded headers only when the request comes from a configured trusted proxy."
+      "description": "Manage inbound configurations and their clients. All endpoints live under /panel/api/inbounds and require a logged-in session or Bearer token. Link-generating endpoints honour forwarded headers only when the request comes from a configured trusted proxy. WireGuard inbounds are peer-based: clients are attached through /panel/api/clients/* and the panel synchronizes binding metadata onto settings.peers[] as clientId, clientEmail, clientSubId, and comment. These peer metadata fields are panel-owned and ignored by xray-core."
     },
     {
       "name": "Server",
@@ -2309,7 +2309,7 @@
     },
     {
       "name": "Clients",
-      "description": "Manage clients as first-class entities that can be attached to one or more inbounds. A single client row drives the settings.clients entry in every inbound it belongs to. Endpoints live under /panel/api/clients."
+      "description": "Manage clients as first-class entities that can be attached to one or more inbounds. A single client row drives the settings.clients entry in client-managed protocols (VMess, VLESS, Trojan, Shadowsocks, Hysteria). WireGuard is peer-managed: attach/detach creates or removes client_inbounds rows and synchronizes the matching peer metadata fields clientId, clientEmail, clientSubId, and comment. Endpoints live under /panel/api/clients."
     },
     {
       "name": "Nodes",
@@ -2541,7 +2541,7 @@
         "tags": [
           "Inbounds"
         ],
-        "summary": "List every inbound owned by the authenticated user, including each inbound’s clientStats traffic counters. settings, streamSettings, and sniffing are returned as nested JSON objects (no escaped strings); legacy callers that send them back as JSON-encoded strings are still accepted on write.",
+        "summary": "List every inbound owned by the authenticated user, including each inbound’s clientStats traffic counters. settings, streamSettings, and sniffing are returned as nested JSON objects (no escaped strings); legacy callers that send them back as JSON-encoded strings are still accepted on write. For WireGuard, settings.peers[] may include panel metadata fields clientId, clientEmail, clientSubId, and comment that bind a peer to a normalized client record.",
         "operationId": "get_panel_api_inbounds_list",
         "responses": {
           "200": {
@@ -2798,7 +2798,7 @@
         "tags": [
           "Inbounds"
         ],
-        "summary": "Create a new inbound. Send the full inbound payload (protocol, port, settings, streamSettings, sniffing, remark, expiryTime, total, enable). settings, streamSettings, and sniffing may be sent as nested JSON objects (preferred) or as JSON-encoded strings (legacy).",
+        "summary": "Create a new inbound. Send the full inbound payload (protocol, port, settings, streamSettings, sniffing, remark, expiryTime, total, enable). settings, streamSettings, and sniffing may be sent as nested JSON objects (preferred) or as JSON-encoded strings (legacy). WireGuard settings use peers[] rather than clients[]; peer clientId/clientEmail/clientSubId/comment metadata is normally managed by the client attach/detach APIs.",
         "operationId": "post_panel_api_inbounds_add",
         "requestBody": {
           "required": true,
@@ -2994,7 +2994,7 @@
         "tags": [
           "Inbounds"
         ],
-        "summary": "Replace an inbound’s configuration. Body shape mirrors /add. Heavy on inbounds with thousands of clients — prefer /setEnable for enable-only flips.",
+        "summary": "Replace an inbound’s configuration. Body shape mirrors /add. Heavy on inbounds with thousands of clients — prefer /setEnable for enable-only flips. Updating a WireGuard inbound preserves the authoritative client_inbounds relation and re-synchronizes settings.peers[] binding metadata instead of treating peers as settings.clients users.",
         "operationId": "post_panel_api_inbounds_update_id",
         "parameters": [
           {
@@ -5394,7 +5394,7 @@
         "tags": [
           "Clients"
         ],
-        "summary": "Attach an existing client to one or more additional inbounds. Body is JSON.",
+        "summary": "Attach an existing client to one or more additional inbounds. Body is JSON. For WireGuard targets this does not create a settings.clients entry; it links the client to the inbound and annotates the next matching/unbound peer with clientId, clientEmail, clientSubId, and comment.",
         "operationId": "post_panel_api_clients_email_attach",
         "parameters": [
           {
@@ -5454,7 +5454,7 @@
         "tags": [
           "Clients"
         ],
-        "summary": "Detach a client from one or more inbounds without deleting the client.",
+        "summary": "Detach a client from one or more inbounds without deleting the client. For WireGuard targets this removes the client_inbounds link and clears that peer’s clientId/clientEmail/clientSubId/clientComment metadata when it belongs to the detached client.",
         "operationId": "post_panel_api_clients_email_detach",
         "parameters": [
           {
@@ -6208,7 +6208,7 @@
         "tags": [
           "Clients"
         ],
-        "summary": "Attach many existing clients to many inbounds in one call. Each client keeps its identity (email/UUID/password/subId) and a shared traffic row; all clients are added to a target inbound in a single AddInboundClient call. Clients already present on a target are reported under skipped. Returns per-email attached/skipped/errors lists and triggers a single Xray restart if any target inbound was running.",
+        "summary": "Attach many existing clients to many inbounds in one call. Each client keeps its identity (email/UUID/password/subId) and a shared traffic row; all clients are added to client-managed targets in a single AddInboundClient call. WireGuard targets use client_inbounds links plus peer binding metadata instead of settings.clients. Clients already present on a target are reported under skipped. Returns per-email attached/skipped/errors lists and triggers a single Xray restart if any target inbound was running.",
         "operationId": "post_panel_api_clients_bulkAttach",
         "requestBody": {
           "required": true,
@@ -6271,7 +6271,7 @@
         "tags": [
           "Clients"
         ],
-        "summary": "Mirror of bulkAttach: detach many existing clients from many inbounds in one call. For each email, intersects the client's current inbounds with the requested set and detaches from those only; (email, inbound) pairs where the client is not currently attached are silently no-ops. Emails not attached to any of the requested inbounds are reported under skipped. Client records are kept even if they become orphaned — use bulkDel for full removal. Returns per-email detached/skipped/errors lists and triggers a single Xray restart if any target inbound was running.",
+        "summary": "Mirror of bulkAttach: detach many existing clients from many inbounds in one call. For each email, intersects the client's current inbounds with the requested set and detaches from those only; (email, inbound) pairs where the client is not currently attached are silently no-ops. WireGuard targets clear peer binding metadata for detached clients. Emails not attached to any of the requested inbounds are reported under skipped. Client records are kept even if they become orphaned — use bulkDel for full removal. Returns per-email detached/skipped/errors lists and triggers a single Xray restart if any target inbound was running.",
         "operationId": "post_panel_api_clients_bulkDetach",
         "requestBody": {
           "required": true,

--- a/frontend/public/openapi.json
+++ b/frontend/public/openapi.json
@@ -2301,7 +2301,7 @@
     },
     {
       "name": "Inbounds",
-      "description": "Manage inbound configurations and their clients. All endpoints live under /panel/api/inbounds and require a logged-in session or Bearer token. Link-generating endpoints honour forwarded headers only when the request comes from a configured trusted proxy. WireGuard inbounds are peer-based: clients are attached through /panel/api/clients/* and the panel synchronizes binding metadata onto settings.peers[] as clientId, clientEmail, clientSubId, and comment. These peer metadata fields are panel-owned and ignored by xray-core."
+      "description": "Manage inbound configurations and their clients. All endpoints live under /panel/api/inbounds and require a logged-in session or Bearer token. Link-generating endpoints honour forwarded headers only when the request comes from a configured trusted proxy. WireGuard inbounds are peer-based: clients are attached through /panel/api/clients/* and the panel synchronizes binding metadata onto settings.peers[] as clientId, clientEmail, clientSubId, clientComment, and clientDetached. These peer metadata fields are panel-owned; runtime Xray config strips them and excludes detached or inactive managed peers."
     },
     {
       "name": "Server",
@@ -2309,7 +2309,7 @@
     },
     {
       "name": "Clients",
-      "description": "Manage clients as first-class entities that can be attached to one or more inbounds. A single client row drives the settings.clients entry in client-managed protocols (VMess, VLESS, Trojan, Shadowsocks, Hysteria). WireGuard is peer-managed: attach/detach creates or removes client_inbounds rows and synchronizes the matching peer metadata fields clientId, clientEmail, clientSubId, and comment. Endpoints live under /panel/api/clients."
+      "description": "Manage clients as first-class entities that can be attached to one or more inbounds. A single client row drives the settings.clients entry in client-managed protocols (VMess, VLESS, Trojan, Shadowsocks, Hysteria). WireGuard is peer-managed: attach/detach creates or removes client_inbounds rows and synchronizes the matching peer metadata fields clientId, clientEmail, clientSubId, clientComment, and clientDetached. Endpoints live under /panel/api/clients."
     },
     {
       "name": "Nodes",
@@ -2541,7 +2541,7 @@
         "tags": [
           "Inbounds"
         ],
-        "summary": "List every inbound owned by the authenticated user, including each inbound’s clientStats traffic counters. settings, streamSettings, and sniffing are returned as nested JSON objects (no escaped strings); legacy callers that send them back as JSON-encoded strings are still accepted on write. For WireGuard, settings.peers[] may include panel metadata fields clientId, clientEmail, clientSubId, and comment that bind a peer to a normalized client record.",
+        "summary": "List every inbound owned by the authenticated user, including each inbound’s clientStats traffic counters. settings, streamSettings, and sniffing are returned as nested JSON objects (no escaped strings); legacy callers that send them back as JSON-encoded strings are still accepted on write. For WireGuard, settings.peers[] may include panel metadata fields clientId, clientEmail, clientSubId, clientComment, and clientDetached; comment remains the peer display note.",
         "operationId": "get_panel_api_inbounds_list",
         "responses": {
           "200": {
@@ -2798,7 +2798,7 @@
         "tags": [
           "Inbounds"
         ],
-        "summary": "Create a new inbound. Send the full inbound payload (protocol, port, settings, streamSettings, sniffing, remark, expiryTime, total, enable). settings, streamSettings, and sniffing may be sent as nested JSON objects (preferred) or as JSON-encoded strings (legacy). WireGuard settings use peers[] rather than clients[]; peer clientId/clientEmail/clientSubId/comment metadata is normally managed by the client attach/detach APIs.",
+        "summary": "Create a new inbound. Send the full inbound payload (protocol, port, settings, streamSettings, sniffing, remark, expiryTime, total, enable). settings, streamSettings, and sniffing may be sent as nested JSON objects (preferred) or as JSON-encoded strings (legacy). WireGuard settings use peers[] rather than clients[]; peer clientId/clientEmail/clientSubId/clientComment/clientDetached metadata is normally managed by the client attach/detach APIs.",
         "operationId": "post_panel_api_inbounds_add",
         "requestBody": {
           "required": true,
@@ -5394,7 +5394,7 @@
         "tags": [
           "Clients"
         ],
-        "summary": "Attach an existing client to one or more additional inbounds. Body is JSON. For WireGuard targets this does not create a settings.clients entry; it links the client to the inbound and annotates the next matching/unbound peer with clientId, clientEmail, clientSubId, and comment.",
+        "summary": "Attach an existing client to one or more additional inbounds. Body is JSON. For WireGuard targets this does not create a settings.clients entry; it links the client to the inbound, reuses the matching peer when present, assigns an unbound peer when available, or creates a new peer with clientId, clientEmail, clientSubId, and clientComment metadata.",
         "operationId": "post_panel_api_clients_email_attach",
         "parameters": [
           {
@@ -5454,7 +5454,7 @@
         "tags": [
           "Clients"
         ],
-        "summary": "Detach a client from one or more inbounds without deleting the client. For WireGuard targets this removes the client_inbounds link and clears that peer’s clientId/clientEmail/clientSubId/clientComment metadata when it belongs to the detached client.",
+        "summary": "Detach a client from one or more inbounds without deleting the client. For WireGuard targets this removes the client_inbounds link and marks that peer clientDetached=true, preserving key material for later reattach while excluding it from runtime Xray config.",
         "operationId": "post_panel_api_clients_email_detach",
         "parameters": [
           {
@@ -6208,7 +6208,7 @@
         "tags": [
           "Clients"
         ],
-        "summary": "Attach many existing clients to many inbounds in one call. Each client keeps its identity (email/UUID/password/subId) and a shared traffic row; all clients are added to client-managed targets in a single AddInboundClient call. WireGuard targets use client_inbounds links plus peer binding metadata instead of settings.clients. Clients already present on a target are reported under skipped. Returns per-email attached/skipped/errors lists and triggers a single Xray restart if any target inbound was running.",
+        "summary": "Attach many existing clients to many inbounds in one call. Each client keeps its identity (email/UUID/password/subId) and a shared traffic row; all clients are added to client-managed targets in a single AddInboundClient call. WireGuard targets use client_inbounds links plus peer binding metadata instead of settings.clients, reusing or creating peers as needed. Clients already present on a target are reported under skipped. Returns per-email attached/skipped/errors lists and triggers a single Xray restart if any target inbound was running.",
         "operationId": "post_panel_api_clients_bulkAttach",
         "requestBody": {
           "required": true,
@@ -6271,7 +6271,7 @@
         "tags": [
           "Clients"
         ],
-        "summary": "Mirror of bulkAttach: detach many existing clients from many inbounds in one call. For each email, intersects the client's current inbounds with the requested set and detaches from those only; (email, inbound) pairs where the client is not currently attached are silently no-ops. WireGuard targets clear peer binding metadata for detached clients. Emails not attached to any of the requested inbounds are reported under skipped. Client records are kept even if they become orphaned — use bulkDel for full removal. Returns per-email detached/skipped/errors lists and triggers a single Xray restart if any target inbound was running.",
+        "summary": "Mirror of bulkAttach: detach many existing clients from many inbounds in one call. For each email, intersects the client's current inbounds with the requested set and detaches from those only; (email, inbound) pairs where the client is not currently attached are silently no-ops. WireGuard targets mark matching peers clientDetached=true and runtime Xray config excludes them. Emails not attached to any of the requested inbounds are reported under skipped. Client records are kept even if they become orphaned — use bulkDel for full removal. Returns per-email detached/skipped/errors lists and triggers a single Xray restart if any target inbound was running.",
         "operationId": "post_panel_api_clients_bulkDetach",
         "requestBody": {
           "required": true,

--- a/frontend/src/pages/api-docs/endpoints.ts
+++ b/frontend/src/pages/api-docs/endpoints.ts
@@ -103,12 +103,12 @@ export const sections: readonly Section[] = [
     id: 'inbounds',
     title: 'Inbounds',
     description:
-      'Manage inbound configurations and their clients. All endpoints live under /panel/api/inbounds and require a logged-in session or Bearer token. Link-generating endpoints honour forwarded headers only when the request comes from a configured trusted proxy.',
+      'Manage inbound configurations and their clients. All endpoints live under /panel/api/inbounds and require a logged-in session or Bearer token. Link-generating endpoints honour forwarded headers only when the request comes from a configured trusted proxy. WireGuard inbounds are peer-based: clients are attached through /panel/api/clients/* and the panel synchronizes binding metadata onto settings.peers[] as clientId, clientEmail, clientSubId, and comment. These peer metadata fields are panel-owned and ignored by xray-core.',
     endpoints: [
       {
         method: 'GET',
         path: '/panel/api/inbounds/list',
-        summary: 'List every inbound owned by the authenticated user, including each inbound’s clientStats traffic counters. settings, streamSettings, and sniffing are returned as nested JSON objects (no escaped strings); legacy callers that send them back as JSON-encoded strings are still accepted on write.',
+        summary: 'List every inbound owned by the authenticated user, including each inbound’s clientStats traffic counters. settings, streamSettings, and sniffing are returned as nested JSON objects (no escaped strings); legacy callers that send them back as JSON-encoded strings are still accepted on write. For WireGuard, settings.peers[] may include panel metadata fields clientId, clientEmail, clientSubId, and comment that bind a peer to a normalized client record.',
         responseSchema: 'Inbound',
         responseSchemaArray: true,
       },
@@ -145,7 +145,7 @@ export const sections: readonly Section[] = [
       {
         method: 'POST',
         path: '/panel/api/inbounds/add',
-        summary: 'Create a new inbound. Send the full inbound payload (protocol, port, settings, streamSettings, sniffing, remark, expiryTime, total, enable). settings, streamSettings, and sniffing may be sent as nested JSON objects (preferred) or as JSON-encoded strings (legacy).',
+        summary: 'Create a new inbound. Send the full inbound payload (protocol, port, settings, streamSettings, sniffing, remark, expiryTime, total, enable). settings, streamSettings, and sniffing may be sent as nested JSON objects (preferred) or as JSON-encoded strings (legacy). WireGuard settings use peers[] rather than clients[]; peer clientId/clientEmail/clientSubId/comment metadata is normally managed by the client attach/detach APIs.',
         body:
           '{\n  "enable": true,\n  "remark": "VLESS-443",\n  "listen": "",\n  "port": 443,\n  "protocol": "vless",\n  "expiryTime": 0,\n  "total": 0,\n  "settings": {\n    "clients": [{ "id": "...", "email": "user1" }],\n    "decryption": "none",\n    "fallbacks": []\n  },\n  "streamSettings": {\n    "network": "tcp",\n    "security": "reality",\n    "realitySettings": { "show": false, "dest": "..." }\n  },\n  "sniffing": {\n    "enabled": true,\n    "destOverride": ["http", "tls"]\n  }\n}',
         errorResponse:
@@ -169,7 +169,7 @@ export const sections: readonly Section[] = [
       {
         method: 'POST',
         path: '/panel/api/inbounds/update/:id',
-        summary: 'Replace an inbound’s configuration. Body shape mirrors /add. Heavy on inbounds with thousands of clients — prefer /setEnable for enable-only flips.',
+        summary: 'Replace an inbound’s configuration. Body shape mirrors /add. Heavy on inbounds with thousands of clients — prefer /setEnable for enable-only flips. Updating a WireGuard inbound preserves the authoritative client_inbounds relation and re-synchronizes settings.peers[] binding metadata instead of treating peers as settings.clients users.',
         params: [
           { name: 'id', in: 'path', type: 'number', desc: 'Inbound ID.' },
         ],
@@ -540,7 +540,7 @@ export const sections: readonly Section[] = [
     id: 'clients',
     title: 'Clients',
     description:
-      'Manage clients as first-class entities that can be attached to one or more inbounds. A single client row drives the settings.clients entry in every inbound it belongs to. Endpoints live under /panel/api/clients.',
+      'Manage clients as first-class entities that can be attached to one or more inbounds. A single client row drives the settings.clients entry in client-managed protocols (VMess, VLESS, Trojan, Shadowsocks, Hysteria). WireGuard is peer-managed: attach/detach creates or removes client_inbounds rows and synchronizes the matching peer metadata fields clientId, clientEmail, clientSubId, and comment. Endpoints live under /panel/api/clients.',
     endpoints: [
       {
         method: 'GET',
@@ -609,7 +609,7 @@ export const sections: readonly Section[] = [
       {
         method: 'POST',
         path: '/panel/api/clients/:email/attach',
-        summary: 'Attach an existing client to one or more additional inbounds. Body is JSON.',
+        summary: 'Attach an existing client to one or more additional inbounds. Body is JSON. For WireGuard targets this does not create a settings.clients entry; it links the client to the inbound and annotates the next matching/unbound peer with clientId, clientEmail, clientSubId, and comment.',
         params: [
           { name: 'email', in: 'path', type: 'string', desc: 'Client email (unique identifier).' },
           { name: 'inboundIds', in: 'body (json)', type: 'integer[]', desc: 'Inbound IDs to attach.' },
@@ -620,7 +620,7 @@ export const sections: readonly Section[] = [
       {
         method: 'POST',
         path: '/panel/api/clients/:email/detach',
-        summary: 'Detach a client from one or more inbounds without deleting the client.',
+        summary: 'Detach a client from one or more inbounds without deleting the client. For WireGuard targets this removes the client_inbounds link and clears that peer’s clientId/clientEmail/clientSubId/clientComment metadata when it belongs to the detached client.',
         params: [
           { name: 'email', in: 'path', type: 'string', desc: 'Client email (unique identifier).' },
           { name: 'inboundIds', in: 'body (json)', type: 'integer[]', desc: 'Inbound IDs to detach.' },
@@ -722,7 +722,7 @@ export const sections: readonly Section[] = [
       {
         method: 'POST',
         path: '/panel/api/clients/bulkAttach',
-        summary: 'Attach many existing clients to many inbounds in one call. Each client keeps its identity (email/UUID/password/subId) and a shared traffic row; all clients are added to a target inbound in a single AddInboundClient call. Clients already present on a target are reported under skipped. Returns per-email attached/skipped/errors lists and triggers a single Xray restart if any target inbound was running.',
+        summary: 'Attach many existing clients to many inbounds in one call. Each client keeps its identity (email/UUID/password/subId) and a shared traffic row; all clients are added to client-managed targets in a single AddInboundClient call. WireGuard targets use client_inbounds links plus peer binding metadata instead of settings.clients. Clients already present on a target are reported under skipped. Returns per-email attached/skipped/errors lists and triggers a single Xray restart if any target inbound was running.',
         params: [
           { name: 'emails', in: 'body (json)', type: 'array', desc: 'Emails of existing clients to attach.' },
           { name: 'inboundIds', in: 'body (json)', type: 'integer[]', desc: 'Target inbound IDs to attach every client to.' },
@@ -733,7 +733,7 @@ export const sections: readonly Section[] = [
       {
         method: 'POST',
         path: '/panel/api/clients/bulkDetach',
-        summary: 'Mirror of bulkAttach: detach many existing clients from many inbounds in one call. For each email, intersects the client\'s current inbounds with the requested set and detaches from those only; (email, inbound) pairs where the client is not currently attached are silently no-ops. Emails not attached to any of the requested inbounds are reported under skipped. Client records are kept even if they become orphaned — use bulkDel for full removal. Returns per-email detached/skipped/errors lists and triggers a single Xray restart if any target inbound was running.',
+        summary: 'Mirror of bulkAttach: detach many existing clients from many inbounds in one call. For each email, intersects the client\'s current inbounds with the requested set and detaches from those only; (email, inbound) pairs where the client is not currently attached are silently no-ops. WireGuard targets clear peer binding metadata for detached clients. Emails not attached to any of the requested inbounds are reported under skipped. Client records are kept even if they become orphaned — use bulkDel for full removal. Returns per-email detached/skipped/errors lists and triggers a single Xray restart if any target inbound was running.',
         params: [
           { name: 'emails', in: 'body (json)', type: 'array', desc: 'Emails of existing clients to detach.' },
           { name: 'inboundIds', in: 'body (json)', type: 'integer[]', desc: 'Inbound IDs to detach the clients from.' },

--- a/frontend/src/pages/api-docs/endpoints.ts
+++ b/frontend/src/pages/api-docs/endpoints.ts
@@ -103,12 +103,12 @@ export const sections: readonly Section[] = [
     id: 'inbounds',
     title: 'Inbounds',
     description:
-      'Manage inbound configurations and their clients. All endpoints live under /panel/api/inbounds and require a logged-in session or Bearer token. Link-generating endpoints honour forwarded headers only when the request comes from a configured trusted proxy. WireGuard inbounds are peer-based: clients are attached through /panel/api/clients/* and the panel synchronizes binding metadata onto settings.peers[] as clientId, clientEmail, clientSubId, and comment. These peer metadata fields are panel-owned and ignored by xray-core.',
+      'Manage inbound configurations and their clients. All endpoints live under /panel/api/inbounds and require a logged-in session or Bearer token. Link-generating endpoints honour forwarded headers only when the request comes from a configured trusted proxy. WireGuard inbounds are peer-based: clients are attached through /panel/api/clients/* and the panel synchronizes binding metadata onto settings.peers[] as clientId, clientEmail, clientSubId, clientComment, and clientDetached. These peer metadata fields are panel-owned; runtime Xray config strips them and excludes detached or inactive managed peers.',
     endpoints: [
       {
         method: 'GET',
         path: '/panel/api/inbounds/list',
-        summary: 'List every inbound owned by the authenticated user, including each inbound’s clientStats traffic counters. settings, streamSettings, and sniffing are returned as nested JSON objects (no escaped strings); legacy callers that send them back as JSON-encoded strings are still accepted on write. For WireGuard, settings.peers[] may include panel metadata fields clientId, clientEmail, clientSubId, and comment that bind a peer to a normalized client record.',
+        summary: 'List every inbound owned by the authenticated user, including each inbound’s clientStats traffic counters. settings, streamSettings, and sniffing are returned as nested JSON objects (no escaped strings); legacy callers that send them back as JSON-encoded strings are still accepted on write. For WireGuard, settings.peers[] may include panel metadata fields clientId, clientEmail, clientSubId, clientComment, and clientDetached; comment remains the peer display note.',
         responseSchema: 'Inbound',
         responseSchemaArray: true,
       },
@@ -145,7 +145,7 @@ export const sections: readonly Section[] = [
       {
         method: 'POST',
         path: '/panel/api/inbounds/add',
-        summary: 'Create a new inbound. Send the full inbound payload (protocol, port, settings, streamSettings, sniffing, remark, expiryTime, total, enable). settings, streamSettings, and sniffing may be sent as nested JSON objects (preferred) or as JSON-encoded strings (legacy). WireGuard settings use peers[] rather than clients[]; peer clientId/clientEmail/clientSubId/comment metadata is normally managed by the client attach/detach APIs.',
+        summary: 'Create a new inbound. Send the full inbound payload (protocol, port, settings, streamSettings, sniffing, remark, expiryTime, total, enable). settings, streamSettings, and sniffing may be sent as nested JSON objects (preferred) or as JSON-encoded strings (legacy). WireGuard settings use peers[] rather than clients[]; peer clientId/clientEmail/clientSubId/clientComment/clientDetached metadata is normally managed by the client attach/detach APIs.',
         body:
           '{\n  "enable": true,\n  "remark": "VLESS-443",\n  "listen": "",\n  "port": 443,\n  "protocol": "vless",\n  "expiryTime": 0,\n  "total": 0,\n  "settings": {\n    "clients": [{ "id": "...", "email": "user1" }],\n    "decryption": "none",\n    "fallbacks": []\n  },\n  "streamSettings": {\n    "network": "tcp",\n    "security": "reality",\n    "realitySettings": { "show": false, "dest": "..." }\n  },\n  "sniffing": {\n    "enabled": true,\n    "destOverride": ["http", "tls"]\n  }\n}',
         errorResponse:
@@ -540,7 +540,7 @@ export const sections: readonly Section[] = [
     id: 'clients',
     title: 'Clients',
     description:
-      'Manage clients as first-class entities that can be attached to one or more inbounds. A single client row drives the settings.clients entry in client-managed protocols (VMess, VLESS, Trojan, Shadowsocks, Hysteria). WireGuard is peer-managed: attach/detach creates or removes client_inbounds rows and synchronizes the matching peer metadata fields clientId, clientEmail, clientSubId, and comment. Endpoints live under /panel/api/clients.',
+      'Manage clients as first-class entities that can be attached to one or more inbounds. A single client row drives the settings.clients entry in client-managed protocols (VMess, VLESS, Trojan, Shadowsocks, Hysteria). WireGuard is peer-managed: attach/detach creates or removes client_inbounds rows and synchronizes the matching peer metadata fields clientId, clientEmail, clientSubId, clientComment, and clientDetached. Endpoints live under /panel/api/clients.',
     endpoints: [
       {
         method: 'GET',
@@ -609,7 +609,7 @@ export const sections: readonly Section[] = [
       {
         method: 'POST',
         path: '/panel/api/clients/:email/attach',
-        summary: 'Attach an existing client to one or more additional inbounds. Body is JSON. For WireGuard targets this does not create a settings.clients entry; it links the client to the inbound and annotates the next matching/unbound peer with clientId, clientEmail, clientSubId, and comment.',
+        summary: 'Attach an existing client to one or more additional inbounds. Body is JSON. For WireGuard targets this does not create a settings.clients entry; it links the client to the inbound, reuses the matching peer when present, assigns an unbound peer when available, or creates a new peer with clientId, clientEmail, clientSubId, and clientComment metadata.',
         params: [
           { name: 'email', in: 'path', type: 'string', desc: 'Client email (unique identifier).' },
           { name: 'inboundIds', in: 'body (json)', type: 'integer[]', desc: 'Inbound IDs to attach.' },
@@ -620,7 +620,7 @@ export const sections: readonly Section[] = [
       {
         method: 'POST',
         path: '/panel/api/clients/:email/detach',
-        summary: 'Detach a client from one or more inbounds without deleting the client. For WireGuard targets this removes the client_inbounds link and clears that peer’s clientId/clientEmail/clientSubId/clientComment metadata when it belongs to the detached client.',
+        summary: 'Detach a client from one or more inbounds without deleting the client. For WireGuard targets this removes the client_inbounds link and marks that peer clientDetached=true, preserving key material for later reattach while excluding it from runtime Xray config.',
         params: [
           { name: 'email', in: 'path', type: 'string', desc: 'Client email (unique identifier).' },
           { name: 'inboundIds', in: 'body (json)', type: 'integer[]', desc: 'Inbound IDs to detach.' },
@@ -722,7 +722,7 @@ export const sections: readonly Section[] = [
       {
         method: 'POST',
         path: '/panel/api/clients/bulkAttach',
-        summary: 'Attach many existing clients to many inbounds in one call. Each client keeps its identity (email/UUID/password/subId) and a shared traffic row; all clients are added to client-managed targets in a single AddInboundClient call. WireGuard targets use client_inbounds links plus peer binding metadata instead of settings.clients. Clients already present on a target are reported under skipped. Returns per-email attached/skipped/errors lists and triggers a single Xray restart if any target inbound was running.',
+        summary: 'Attach many existing clients to many inbounds in one call. Each client keeps its identity (email/UUID/password/subId) and a shared traffic row; all clients are added to client-managed targets in a single AddInboundClient call. WireGuard targets use client_inbounds links plus peer binding metadata instead of settings.clients, reusing or creating peers as needed. Clients already present on a target are reported under skipped. Returns per-email attached/skipped/errors lists and triggers a single Xray restart if any target inbound was running.',
         params: [
           { name: 'emails', in: 'body (json)', type: 'array', desc: 'Emails of existing clients to attach.' },
           { name: 'inboundIds', in: 'body (json)', type: 'integer[]', desc: 'Target inbound IDs to attach every client to.' },
@@ -733,7 +733,7 @@ export const sections: readonly Section[] = [
       {
         method: 'POST',
         path: '/panel/api/clients/bulkDetach',
-        summary: 'Mirror of bulkAttach: detach many existing clients from many inbounds in one call. For each email, intersects the client\'s current inbounds with the requested set and detaches from those only; (email, inbound) pairs where the client is not currently attached are silently no-ops. WireGuard targets clear peer binding metadata for detached clients. Emails not attached to any of the requested inbounds are reported under skipped. Client records are kept even if they become orphaned — use bulkDel for full removal. Returns per-email detached/skipped/errors lists and triggers a single Xray restart if any target inbound was running.',
+        summary: 'Mirror of bulkAttach: detach many existing clients from many inbounds in one call. For each email, intersects the client\'s current inbounds with the requested set and detaches from those only; (email, inbound) pairs where the client is not currently attached are silently no-ops. WireGuard targets mark matching peers clientDetached=true and runtime Xray config excludes them. Emails not attached to any of the requested inbounds are reported under skipped. Client records are kept even if they become orphaned — use bulkDel for full removal. Returns per-email detached/skipped/errors lists and triggers a single Xray restart if any target inbound was running.',
         params: [
           { name: 'emails', in: 'body (json)', type: 'array', desc: 'Emails of existing clients to detach.' },
           { name: 'inboundIds', in: 'body (json)', type: 'integer[]', desc: 'Inbound IDs to detach the clients from.' },

--- a/frontend/src/pages/clients/ClientBulkAddModal.tsx
+++ b/frontend/src/pages/clients/ClientBulkAddModal.tsx
@@ -16,7 +16,7 @@ import { ClientBulkAddFormSchema, type ClientBulkAddFormValues } from '@/schemas
 const FLOW_OPTIONS = Object.values(TLS_FLOW_CONTROL);
 
 const MULTI_CLIENT_PROTOCOLS = new Set([
-  'shadowsocks', 'vless', 'vmess', 'trojan', 'hysteria',
+  'shadowsocks', 'vless', 'vmess', 'trojan', 'hysteria', 'wireguard',
 ]);
 
 interface ClientBulkAddModalProps {

--- a/frontend/src/pages/clients/ClientFormModal.tsx
+++ b/frontend/src/pages/clients/ClientFormModal.tsx
@@ -654,7 +654,7 @@ export default function ClientFormModal({
                       </Row>
                     )}
 
-                    <Form.Item label={t('pages.clients.attachedInbounds')} required={!isEdit}>
+                    <Form.Item className="client-inbounds-field" label={t('pages.clients.attachedInbounds')} required={!isEdit}>
                       <SelectAllClearButtons
                         options={inboundOptions}
                         value={form.inboundIds}

--- a/frontend/src/pages/clients/ClientFormModal.tsx
+++ b/frontend/src/pages/clients/ClientFormModal.tsx
@@ -490,14 +490,15 @@ export default function ClientFormModal({
       <Modal
         open={open}
         title={isEdit ? t('pages.clients.editClient') : t('pages.clients.addClient')}
+        className="client-form-modal"
         destroyOnHidden
-        width={720}
+        width="min(920px, calc(100vw - 32px))"
         zIndex={CLIENT_FORM_MODAL_Z_INDEX}
         style={{ top: 20 }}
         styles={{ body: { maxHeight: 'calc(100vh - 160px)', overflowY: 'auto', overflowX: 'hidden' } }}
         onCancel={close}
         footer={
-          <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+          <div className="client-form-footer">
             {isEdit && resetTraffic && (
               <Popconfirm
                 title={t('pages.inbounds.resetTraffic')}
@@ -512,7 +513,7 @@ export default function ClientFormModal({
                 </Button>
               </Popconfirm>
             )}
-            <div style={{ marginInlineStart: 'auto', display: 'flex', gap: 8 }}>
+            <div className="client-form-footer-actions">
               <Button onClick={close}>{t('cancel')}</Button>
               <Button type="primary" loading={submitting} onClick={onSubmit}>
                 {isEdit ? t('save') : t('create')}

--- a/frontend/src/pages/clients/ClientFormModal.tsx
+++ b/frontend/src/pages/clients/ClientFormModal.tsx
@@ -666,7 +666,6 @@ export default function ClientFormModal({
                         onChange={(v) => update('inboundIds', v)}
                         options={inboundOptions}
                         placeholder={t('pages.clients.selectInbound')}
-                        maxTagCount="responsive"
                         placement="topLeft"
                         listHeight={220}
                         showSearch={{

--- a/frontend/src/pages/clients/ClientFormModal.tsx
+++ b/frontend/src/pages/clients/ClientFormModal.tsx
@@ -35,7 +35,7 @@ const FLOW_OPTIONS = Object.values(TLS_FLOW_CONTROL);
 const VMESS_SECURITY_OPTIONS = ['auto', 'aes-128-gcm', 'chacha20-poly1305', 'none', 'zero'] as const;
 
 const MULTI_CLIENT_PROTOCOLS = new Set([
-  'shadowsocks', 'vless', 'vmess', 'trojan', 'hysteria',
+  'shadowsocks', 'vless', 'vmess', 'trojan', 'hysteria', 'wireguard',
 ]);
 
 const CLIENT_FORM_MODAL_Z_INDEX = 1000;

--- a/frontend/src/pages/clients/ClientsPage.css
+++ b/frontend/src/pages/clients/ClientsPage.css
@@ -76,6 +76,27 @@
   line-height: 18px;
 }
 
+.client-form-modal .ant-modal-footer {
+  margin-top: 18px;
+}
+
+.client-form-footer {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+
+.client-form-footer-actions {
+  display: flex;
+  gap: 8px;
+  margin-inline-start: auto;
+}
+
+.client-inbounds-field {
+  margin-bottom: 24px;
+}
+
 .client-inbounds-field .ant-form-item-control-input-content {
   display: flex;
   flex-direction: column;
@@ -90,21 +111,41 @@
   align-items: flex-start;
   min-height: 40px;
   height: auto;
-  padding-top: 4px;
-  padding-bottom: 4px;
+  padding: 6px 8px;
 }
 
 .client-inbounds-field .ant-select-multiple .ant-select-selection-overflow {
-  row-gap: 6px;
+  gap: 6px;
 }
 
 .client-inbounds-field .ant-select-multiple .ant-select-selection-item {
   max-width: 100%;
+  margin: 0;
 }
 
 .client-inbounds-field .ant-select-multiple .ant-select-selection-item-content {
   white-space: normal;
   line-height: 1.35;
+}
+
+@media (max-width: 640px) {
+  .client-form-footer {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .client-form-footer > .ant-btn,
+  .client-form-footer-actions {
+    width: 100%;
+  }
+
+  .client-form-footer-actions {
+    margin-inline-start: 0;
+  }
+
+  .client-form-footer-actions .ant-btn {
+    flex: 1;
+  }
 }
 
 .card-toolbar {

--- a/frontend/src/pages/clients/ClientsPage.css
+++ b/frontend/src/pages/clients/ClientsPage.css
@@ -76,6 +76,37 @@
   line-height: 18px;
 }
 
+.client-inbounds-field .ant-form-item-control-input-content {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.client-inbounds-field .ant-form-item-control-input-content > div:first-child {
+  margin-bottom: 0 !important;
+}
+
+.client-inbounds-field .ant-select-multiple .ant-select-selector {
+  align-items: flex-start;
+  min-height: 40px;
+  height: auto;
+  padding-top: 4px;
+  padding-bottom: 4px;
+}
+
+.client-inbounds-field .ant-select-multiple .ant-select-selection-overflow {
+  row-gap: 6px;
+}
+
+.client-inbounds-field .ant-select-multiple .ant-select-selection-item {
+  max-width: 100%;
+}
+
+.client-inbounds-field .ant-select-multiple .ant-select-selection-item-content {
+  white-space: normal;
+  line-height: 1.35;
+}
+
 .card-toolbar {
   display: flex;
   align-items: center;

--- a/frontend/src/pages/clients/ClientsPage.css
+++ b/frontend/src/pages/clients/ClientsPage.css
@@ -111,16 +111,18 @@
   align-items: flex-start;
   min-height: 40px;
   height: auto;
-  padding: 6px 8px;
+  padding: 8px 40px 8px 10px;
 }
 
 .client-inbounds-field .ant-select-multiple .ant-select-selection-overflow {
-  gap: 6px;
+  column-gap: 10px;
+  row-gap: 8px;
 }
 
 .client-inbounds-field .ant-select-multiple .ant-select-selection-item {
   max-width: 100%;
   margin: 0;
+  padding-inline: 9px 7px;
 }
 
 .client-inbounds-field .ant-select-multiple .ant-select-selection-item-content {

--- a/frontend/src/pages/inbounds/form/protocols/wireguard.tsx
+++ b/frontend/src/pages/inbounds/form/protocols/wireguard.tsx
@@ -118,6 +118,18 @@ export default function WireguardFields({ wgPubKey, regenInboundWg, regenWgPeerK
                 <Form.Item name={[field.name, 'comment']} label={t('comment')}>
                   <Input placeholder="e.g. Alice's laptop" />
                 </Form.Item>
+                <Form.Item name={[field.name, 'clientId']} hidden>
+                  <InputNumber />
+                </Form.Item>
+                <Form.Item name={[field.name, 'clientEmail']} hidden>
+                  <Input />
+                </Form.Item>
+                <Form.Item name={[field.name, 'clientSubId']} hidden>
+                  <Input />
+                </Form.Item>
+                <Form.Item name={[field.name, 'clientComment']} hidden>
+                  <Input />
+                </Form.Item>
                 <Form.Item label={t('pages.xray.wireguard.secretKey')}>
                   <Space.Compact block>
                     <Form.Item name={[field.name, 'privateKey']} noStyle>

--- a/frontend/src/pages/inbounds/form/protocols/wireguard.tsx
+++ b/frontend/src/pages/inbounds/form/protocols/wireguard.tsx
@@ -130,6 +130,9 @@ export default function WireguardFields({ wgPubKey, regenInboundWg, regenWgPeerK
                 <Form.Item name={[field.name, 'clientComment']} hidden>
                   <Input />
                 </Form.Item>
+                <Form.Item name={[field.name, 'clientDetached']} hidden valuePropName="checked">
+                  <Switch />
+                </Form.Item>
                 <Form.Item label={t('pages.xray.wireguard.secretKey')}>
                   <Space.Compact block>
                     <Form.Item name={[field.name, 'privateKey']} noStyle>

--- a/frontend/src/schemas/protocols/inbound/wireguard.ts
+++ b/frontend/src/schemas/protocols/inbound/wireguard.ts
@@ -34,6 +34,7 @@ export const WireguardInboundPeerSchema = z.object({
   clientEmail: z.string().optional(),
   clientSubId: z.string().optional(),
   clientComment: z.string().optional(),
+  clientDetached: z.boolean().optional(),
 });
 export type WireguardInboundPeer = z.infer<typeof WireguardInboundPeerSchema>;
 

--- a/frontend/src/schemas/protocols/inbound/wireguard.ts
+++ b/frontend/src/schemas/protocols/inbound/wireguard.ts
@@ -30,6 +30,10 @@ export const WireguardInboundPeerSchema = z.object({
   // Rides along in the settings JSON like privateKey does; xray-core ignores
   // unknown peer fields.
   comment: z.string().optional(),
+  clientId: optionalClearedInt(z.number().int().min(1)),
+  clientEmail: z.string().optional(),
+  clientSubId: z.string().optional(),
+  clientComment: z.string().optional(),
 });
 export type WireguardInboundPeer = z.infer<typeof WireguardInboundPeerSchema>;
 

--- a/internal/web/service/client_bulk.go
+++ b/internal/web/service/client_bulk.go
@@ -73,6 +73,10 @@ func (s *ClientService) BulkAttach(inboundSvc *InboundService, emails []string, 
 			continue
 		}
 		if !clientManagedInbound(inbound.Protocol) {
+			if inbound.Protocol != model.WireGuard {
+				recordErr("inbound %d: protocol %s does not support managed clients", ibId, inbound.Protocol)
+				continue
+			}
 			attachedCount := 0
 			for _, rec := range records {
 				var exists int64
@@ -96,6 +100,8 @@ func (s *ClientService) BulkAttach(inboundSvc *InboundService, emails []string, 
 			if attachedCount > 0 {
 				if err := s.syncWireGuardInboundPeerBindings(inboundSvc, ibId); err != nil {
 					recordErr("inbound %d: %v", ibId, err)
+				} else {
+					needRestart = true
 				}
 			}
 			continue
@@ -245,12 +251,14 @@ func (s *ClientService) BulkDetach(inboundSvc *InboundService, emails []string, 
 					failed = true
 				}
 			}
-			if !failed {
+			if !failed && inbound.Protocol == model.WireGuard {
 				if err := s.syncWireGuardInboundPeerBindings(inboundSvc, ibId); err != nil {
 					recordErr("inbound %d: %v", ibId, err)
 					for _, rec := range recs {
 						emailFailed[strings.ToLower(rec.Email)] = true
 					}
+				} else {
+					needRestart = true
 				}
 			}
 			continue
@@ -1238,6 +1246,8 @@ func (s *ClientService) BulkCreate(inboundSvc *InboundService, payloads []Client
 	byInbound := make(map[int][]model.Client)
 	idxByInbound := make(map[int][]int)
 	inboundOrder := make([]int, 0)
+	wgIdxByInbound := make(map[int][]int)
+	wgInboundOrder := make([]int, 0)
 	failed := make([]bool, len(prep))
 	reason := make([]string, len(prep))
 
@@ -1263,6 +1273,15 @@ func (s *ClientService) BulkCreate(inboundSvc *InboundService, payloads []Client
 				ok = false
 				break
 			}
+			if !clientManagedInbound(ib.Protocol) {
+				if ib.Protocol != model.WireGuard {
+					failed[idx] = true
+					reason[idx] = fmt.Sprintf("protocol %s does not support managed clients", ib.Protocol)
+					ok = false
+					break
+				}
+				continue
+			}
 			if e := s.fillProtocolDefaults(&prep[idx].client, ib); e != nil {
 				failed[idx] = true
 				reason[idx] = e.Error()
@@ -1275,6 +1294,13 @@ func (s *ClientService) BulkCreate(inboundSvc *InboundService, payloads []Client
 		}
 		for _, ibId := range prep[idx].inboundIds {
 			ib, _ := getIb(ibId)
+			if ib.Protocol == model.WireGuard {
+				if _, seen := wgIdxByInbound[ibId]; !seen {
+					wgInboundOrder = append(wgInboundOrder, ibId)
+				}
+				wgIdxByInbound[ibId] = append(wgIdxByInbound[ibId], idx)
+				continue
+			}
 			if _, seen := byInbound[ibId]; !seen {
 				inboundOrder = append(inboundOrder, ibId)
 			}
@@ -1299,6 +1325,42 @@ func (s *ClientService) BulkCreate(inboundSvc *InboundService, payloads []Client
 				if reason[idx] == "" {
 					reason[idx] = e.Error()
 				}
+			}
+		}
+	}
+
+	for _, ibId := range wgInboundOrder {
+		changed := false
+		for _, idx := range wgIdxByInbound[ibId] {
+			if failed[idx] {
+				continue
+			}
+			rec, e := s.ensureClientRecord(prep[idx].client)
+			if e == nil {
+				e = ensureClientInboundLink(rec.Id, ibId)
+			}
+			if e != nil {
+				failed[idx] = true
+				if reason[idx] == "" {
+					reason[idx] = e.Error()
+				}
+				continue
+			}
+			changed = true
+		}
+		if changed {
+			if e := s.syncWireGuardInboundPeerBindings(inboundSvc, ibId); e != nil {
+				for _, idx := range wgIdxByInbound[ibId] {
+					if failed[idx] {
+						continue
+					}
+					failed[idx] = true
+					if reason[idx] == "" {
+						reason[idx] = e.Error()
+					}
+				}
+			} else {
+				needRestart = true
 			}
 		}
 	}
@@ -1487,6 +1549,16 @@ func (s *ClientService) bulkSetEnableInboundClients(inboundSvc *InboundService, 
 	if err != nil {
 		for _, e := range emails {
 			res.perEmailSkipped[e] = err.Error()
+		}
+		return res
+	}
+	if oldInbound.Protocol == model.WireGuard {
+		if oldInbound.NodeID == nil {
+			res.needRestart = true
+		} else if dErr := (&NodeService{}).MarkNodeDirty(*oldInbound.NodeID); dErr != nil {
+			for _, e := range emails {
+				res.perEmailSkipped[e] = dErr.Error()
+			}
 		}
 		return res
 	}

--- a/internal/web/service/client_bulk.go
+++ b/internal/web/service/client_bulk.go
@@ -8,7 +8,6 @@ import (
 	"time"
 
 	"github.com/google/uuid"
-
 	"github.com/mhsanaei/3x-ui/v3/internal/database"
 	"github.com/mhsanaei/3x-ui/v3/internal/database/model"
 	"github.com/mhsanaei/3x-ui/v3/internal/logger"
@@ -71,6 +70,34 @@ func (s *ClientService) BulkAttach(inboundSvc *InboundService, emails []string, 
 		inbound, err := inboundSvc.GetInbound(ibId)
 		if err != nil {
 			recordErr("inbound %d: %v", ibId, err)
+			continue
+		}
+		if !clientManagedInbound(inbound.Protocol) {
+			attachedCount := 0
+			for _, rec := range records {
+				var exists int64
+				if err := database.GetDB().Model(&model.ClientInbound{}).
+					Where("client_id = ? AND inbound_id = ?", rec.Id, ibId).
+					Count(&exists).Error; err != nil {
+					recordErr("%s -> inbound %d: %v", rec.Email, ibId, err)
+					continue
+				}
+				if exists > 0 {
+					result.Skipped = append(result.Skipped, rec.Email)
+					continue
+				}
+				if err := ensureClientInboundLink(rec.Id, ibId); err != nil {
+					recordErr("%s -> inbound %d: %v", rec.Email, ibId, err)
+					continue
+				}
+				result.Attached = append(result.Attached, rec.Email)
+				attachedCount++
+			}
+			if attachedCount > 0 {
+				if err := s.syncWireGuardInboundPeerBindings(inboundSvc, ibId); err != nil {
+					recordErr("inbound %d: %v", ibId, err)
+				}
+			}
 			continue
 		}
 		existingClients, err := inboundSvc.GetClients(inbound)
@@ -199,6 +226,35 @@ func (s *ClientService) BulkDetach(inboundSvc *InboundService, emails []string, 
 			continue
 		}
 		delete(recsByInbound, ibId)
+		inbound, getErr := inboundSvc.GetInbound(ibId)
+		if getErr != nil {
+			recordErr("inbound %d: %v", ibId, getErr)
+			for _, rec := range recs {
+				emailFailed[strings.ToLower(rec.Email)] = true
+			}
+			continue
+		}
+		if !clientManagedInbound(inbound.Protocol) {
+			failed := false
+			for _, rec := range recs {
+				if err := database.GetDB().
+					Where("client_id = ? AND inbound_id = ?", rec.Id, ibId).
+					Delete(&model.ClientInbound{}).Error; err != nil {
+					recordErr("%s -> inbound %d: %v", rec.Email, ibId, err)
+					emailFailed[strings.ToLower(rec.Email)] = true
+					failed = true
+				}
+			}
+			if !failed {
+				if err := s.syncWireGuardInboundPeerBindings(inboundSvc, ibId); err != nil {
+					recordErr("inbound %d: %v", ibId, err)
+					for _, rec := range recs {
+						emailFailed[strings.ToLower(rec.Email)] = true
+					}
+				}
+			}
+			continue
+		}
 		nr, err := s.delInboundClients(inboundSvc, ibId, recs, true)
 		if err != nil {
 			recordErr("inbound %d: %v", ibId, err)

--- a/internal/web/service/client_crud.go
+++ b/internal/web/service/client_crud.go
@@ -128,14 +128,17 @@ func (s *ClientService) Create(inboundSvc *InboundService, payload *ClientCreate
 	}
 
 	needRestart := false
-	linkOnlyInboundIds := make([]int, 0)
+	wireGuardInboundIds := make([]int, 0)
 	for _, ibId := range payload.InboundIds {
 		inbound, getErr := inboundSvc.GetInbound(ibId)
 		if getErr != nil {
 			return needRestart, getErr
 		}
 		if !clientManagedInbound(inbound.Protocol) {
-			linkOnlyInboundIds = append(linkOnlyInboundIds, ibId)
+			if inbound.Protocol != model.WireGuard {
+				return needRestart, common.NewError("protocol does not support managed clients:", inbound.Protocol)
+			}
+			wireGuardInboundIds = append(wireGuardInboundIds, ibId)
 			continue
 		}
 		if err := s.fillProtocolDefaults(&client, inbound); err != nil {
@@ -156,18 +159,19 @@ func (s *ClientService) Create(inboundSvc *InboundService, payload *ClientCreate
 			needRestart = true
 		}
 	}
-	if len(linkOnlyInboundIds) > 0 {
+	if len(wireGuardInboundIds) > 0 {
 		rec, recErr := s.ensureClientRecord(client)
 		if recErr != nil {
 			return needRestart, recErr
 		}
-		for _, ibId := range linkOnlyInboundIds {
+		for _, ibId := range wireGuardInboundIds {
 			if err := ensureClientInboundLink(rec.Id, ibId); err != nil {
 				return needRestart, err
 			}
 			if err := s.syncWireGuardInboundPeerBindings(inboundSvc, ibId); err != nil {
 				return needRestart, err
 			}
+			needRestart = true
 		}
 	}
 	return needRestart, nil
@@ -399,6 +403,38 @@ func (s *ClientService) Update(inboundSvc *InboundService, id int, updated model
 		}
 	}
 
+	hasWireGuardTarget := false
+	for _, ibId := range inboundIds {
+		inbound, getErr := inboundSvc.GetInbound(ibId)
+		if getErr == nil && inbound.Protocol == model.WireGuard {
+			hasWireGuardTarget = true
+			break
+		}
+	}
+	if hasWireGuardTarget {
+		if err := database.GetDB().Model(&model.ClientRecord{}).
+			Where("id = ?", id).
+			Updates(map[string]any{
+				"email":       updated.Email,
+				"sub_id":      updated.SubID,
+				"uuid":        updated.ID,
+				"password":    updated.Password,
+				"auth":        updated.Auth,
+				"flow":        updated.Flow,
+				"security":    updated.Security,
+				"limit_ip":    updated.LimitIP,
+				"total_gb":    updated.TotalGB,
+				"expiry_time": updated.ExpiryTime,
+				"enable":      updated.Enable,
+				"tg_id":       updated.TgID,
+				"comment":     updated.Comment,
+				"reset":       updated.Reset,
+				"updated_at":  updated.UpdatedAt,
+			}).Error; err != nil {
+			return false, err
+		}
+	}
+
 	needRestart := false
 	for _, ibId := range inboundIds {
 		inbound, getErr := inboundSvc.GetInbound(ibId)
@@ -417,8 +453,11 @@ func (s *ClientService) Update(inboundSvc *InboundService, id int, updated model
 			continue
 		}
 		if !clientManagedInbound(inbound.Protocol) {
-			if err := s.syncWireGuardInboundPeerBindings(inboundSvc, ibId); err != nil {
-				return needRestart, err
+			if inbound.Protocol == model.WireGuard {
+				if err := s.syncWireGuardInboundPeerBindings(inboundSvc, ibId); err != nil {
+					return needRestart, err
+				}
+				needRestart = true
 			}
 			continue
 		}
@@ -531,6 +570,7 @@ func (s *ClientService) Delete(inboundSvc *InboundService, id int, keepTraffic b
 		if err := s.syncWireGuardInboundPeerBindings(inboundSvc, ibId); err != nil {
 			return needRestart, err
 		}
+		needRestart = true
 	}
 	if err := db.Where("client_id = ?", id).Delete(&model.ClientExternalLink{}).Error; err != nil {
 		return needRestart, err
@@ -584,12 +624,16 @@ func (s *ClientService) Attach(inboundSvc *InboundService, id int, inboundIds []
 			return needRestart, getErr
 		}
 		if !clientManagedInbound(inbound.Protocol) {
+			if inbound.Protocol != model.WireGuard {
+				return needRestart, common.NewError("protocol does not support managed clients:", inbound.Protocol)
+			}
 			if err := ensureClientInboundLink(existing.Id, ibId); err != nil {
 				return needRestart, err
 			}
 			if err := s.syncWireGuardInboundPeerBindings(inboundSvc, ibId); err != nil {
 				return needRestart, err
 			}
+			needRestart = true
 			continue
 		}
 		copyClient := *clientWire
@@ -744,8 +788,11 @@ func (s *ClientService) Detach(inboundSvc *InboundService, id int, inboundIds []
 				Delete(&model.ClientInbound{}).Error; err != nil {
 				return needRestart, err
 			}
-			if err := s.syncWireGuardInboundPeerBindings(inboundSvc, ibId); err != nil {
-				return needRestart, err
+			if inbound.Protocol == model.WireGuard {
+				if err := s.syncWireGuardInboundPeerBindings(inboundSvc, ibId); err != nil {
+					return needRestart, err
+				}
+				needRestart = true
 			}
 			continue
 		}

--- a/internal/web/service/client_crud.go
+++ b/internal/web/service/client_crud.go
@@ -9,7 +9,6 @@ import (
 	"time"
 
 	"github.com/google/uuid"
-
 	"github.com/mhsanaei/3x-ui/v3/internal/database"
 	"github.com/mhsanaei/3x-ui/v3/internal/database/model"
 	"github.com/mhsanaei/3x-ui/v3/internal/util/common"
@@ -40,6 +39,38 @@ func validateClientSubID(subID string) error {
 		return common.NewError("client subId contains an invalid character:", subID)
 	}
 	return nil
+}
+
+func clientManagedInbound(protocol model.Protocol) bool {
+	switch protocol {
+	case model.VMESS, model.VLESS, model.Trojan, model.Shadowsocks, model.Hysteria:
+		return true
+	default:
+		return false
+	}
+}
+
+func ensureClientInboundLink(clientId int, inboundId int) error {
+	return database.GetDB().FirstOrCreate(
+		&model.ClientInbound{},
+		model.ClientInbound{ClientId: clientId, InboundId: inboundId},
+	).Error
+}
+
+func (s *ClientService) ensureClientRecord(client model.Client) (*model.ClientRecord, error) {
+	rec := &model.ClientRecord{}
+	err := database.GetDB().Where("email = ?", client.Email).First(rec).Error
+	if err == nil {
+		return rec, nil
+	}
+	if !errors.Is(err, gorm.ErrRecordNotFound) {
+		return nil, err
+	}
+	rec = client.ToRecord()
+	if err := database.GetDB().Create(rec).Error; err != nil {
+		return nil, err
+	}
+	return rec, nil
 }
 
 func (s *ClientService) Create(inboundSvc *InboundService, payload *ClientCreatePayload) (bool, error) {
@@ -97,10 +128,15 @@ func (s *ClientService) Create(inboundSvc *InboundService, payload *ClientCreate
 	}
 
 	needRestart := false
+	linkOnlyInboundIds := make([]int, 0)
 	for _, ibId := range payload.InboundIds {
 		inbound, getErr := inboundSvc.GetInbound(ibId)
 		if getErr != nil {
 			return needRestart, getErr
+		}
+		if !clientManagedInbound(inbound.Protocol) {
+			linkOnlyInboundIds = append(linkOnlyInboundIds, ibId)
+			continue
 		}
 		if err := s.fillProtocolDefaults(&client, inbound); err != nil {
 			return needRestart, err
@@ -118,6 +154,20 @@ func (s *ClientService) Create(inboundSvc *InboundService, payload *ClientCreate
 		}
 		if nr {
 			needRestart = true
+		}
+	}
+	if len(linkOnlyInboundIds) > 0 {
+		rec, recErr := s.ensureClientRecord(client)
+		if recErr != nil {
+			return needRestart, recErr
+		}
+		for _, ibId := range linkOnlyInboundIds {
+			if err := ensureClientInboundLink(rec.Id, ibId); err != nil {
+				return needRestart, err
+			}
+			if err := s.syncWireGuardInboundPeerBindings(inboundSvc, ibId); err != nil {
+				return needRestart, err
+			}
 		}
 	}
 	return needRestart, nil
@@ -366,6 +416,12 @@ func (s *ClientService) Update(inboundSvc *InboundService, id int, updated model
 		if existing.Email == "" {
 			continue
 		}
+		if !clientManagedInbound(inbound.Protocol) {
+			if err := s.syncWireGuardInboundPeerBindings(inboundSvc, ibId); err != nil {
+				return needRestart, err
+			}
+			continue
+		}
 		if err := s.fillProtocolDefaults(&updated, inbound); err != nil {
 			return needRestart, err
 		}
@@ -430,8 +486,10 @@ func (s *ClientService) Delete(inboundSvc *InboundService, id int, keepTraffic b
 	}
 
 	needRestart := false
+	wireGuardInboundIds := make([]int, 0)
 	for _, ibId := range inboundIds {
-		if _, getErr := inboundSvc.GetInbound(ibId); getErr != nil {
+		inbound, getErr := inboundSvc.GetInbound(ibId)
+		if getErr != nil {
 			if errors.Is(getErr, gorm.ErrRecordNotFound) {
 				continue
 			}
@@ -443,6 +501,12 @@ func (s *ClientService) Delete(inboundSvc *InboundService, id int, keepTraffic b
 		// credential (UUID/password/auth) drifted from the inbound JSON, or a
 		// duplicate entry with the same email exists.
 		if existing.Email == "" {
+			continue
+		}
+		if !clientManagedInbound(inbound.Protocol) {
+			if inbound.Protocol == model.WireGuard {
+				wireGuardInboundIds = append(wireGuardInboundIds, ibId)
+			}
 			continue
 		}
 		nr, delErr := s.DelInboundClientByEmail(inboundSvc, ibId, existing.Email, false)
@@ -462,6 +526,11 @@ func (s *ClientService) Delete(inboundSvc *InboundService, id int, keepTraffic b
 	db := database.GetDB()
 	if err := db.Where("client_id = ?", id).Delete(&model.ClientInbound{}).Error; err != nil {
 		return needRestart, err
+	}
+	for _, ibId := range wireGuardInboundIds {
+		if err := s.syncWireGuardInboundPeerBindings(inboundSvc, ibId); err != nil {
+			return needRestart, err
+		}
 	}
 	if err := db.Where("client_id = ?", id).Delete(&model.ClientExternalLink{}).Error; err != nil {
 		return needRestart, err
@@ -513,6 +582,15 @@ func (s *ClientService) Attach(inboundSvc *InboundService, id int, inboundIds []
 		inbound, getErr := inboundSvc.GetInbound(ibId)
 		if getErr != nil {
 			return needRestart, getErr
+		}
+		if !clientManagedInbound(inbound.Protocol) {
+			if err := ensureClientInboundLink(existing.Id, ibId); err != nil {
+				return needRestart, err
+			}
+			if err := s.syncWireGuardInboundPeerBindings(inboundSvc, ibId); err != nil {
+				return needRestart, err
+			}
+			continue
 		}
 		copyClient := *clientWire
 		if err := s.fillProtocolDefaults(&copyClient, inbound); err != nil {
@@ -652,11 +730,23 @@ func (s *ClientService) Detach(inboundSvc *InboundService, id int, inboundIds []
 		if _, attached := have[ibId]; !attached {
 			continue
 		}
-		if _, getErr := inboundSvc.GetInbound(ibId); getErr != nil {
+		inbound, getErr := inboundSvc.GetInbound(ibId)
+		if getErr != nil {
 			return needRestart, getErr
 		}
 		// Detach by email — the client's stable identity (see Delete).
 		if existing.Email == "" {
+			continue
+		}
+		if !clientManagedInbound(inbound.Protocol) {
+			if err := database.GetDB().
+				Where("client_id = ? AND inbound_id = ?", id, ibId).
+				Delete(&model.ClientInbound{}).Error; err != nil {
+				return needRestart, err
+			}
+			if err := s.syncWireGuardInboundPeerBindings(inboundSvc, ibId); err != nil {
+				return needRestart, err
+			}
 			continue
 		}
 		nr, delErr := s.DelInboundClientByEmail(inboundSvc, ibId, existing.Email, true)

--- a/internal/web/service/inbound.go
+++ b/internal/web/service/inbound.go
@@ -735,7 +735,15 @@ func (s *InboundService) AddInbound(inbound *model.Inbound) (*model.Inbound, boo
 			markDirty = true
 		}
 		if push {
-			if err1 := rt.AddInbound(context.Background(), inbound); err1 == nil {
+			runtimeInbound, err1 := s.buildRuntimeInboundForAPI(tx, inbound)
+			if err1 != nil {
+				logger.Debug("Unable to prepare runtime inbound config:", err1)
+				if inbound.NodeID != nil {
+					markDirty = true
+				} else {
+					needRestart = true
+				}
+			} else if err1 := rt.AddInbound(context.Background(), runtimeInbound); err1 == nil {
 				logger.Debug("New inbound added on", rt.Name(), ":", inbound.Tag)
 			} else {
 				logger.Debug("Unable to add inbound on", rt.Name(), ":", err1)
@@ -921,7 +929,11 @@ func (s *InboundService) SetInboundEnable(id int, enable bool) (bool, error) {
 	// settings/client history and just flips the enable flag.
 	if inbound.NodeID != nil {
 		if push {
-			if err := rt.UpdateInbound(context.Background(), inbound, inbound); err != nil {
+			runtimeInbound, buildErr := s.buildRuntimeInboundForAPI(db, inbound)
+			if buildErr != nil {
+				logger.Warning("SetInboundEnable: build runtime config failed:", buildErr)
+				dirty = true
+			} else if err := rt.UpdateInbound(context.Background(), inbound, runtimeInbound); err != nil {
 				logger.Warning("SetInboundEnable: remote UpdateInbound on", rt.Name(), "failed:", err)
 				dirty = true
 			}
@@ -1154,9 +1166,15 @@ func (s *InboundService) UpdateInbound(inbound *model.Inbound) (*model.Inbound, 
 					logger.Warning("Unable to disable inbound on", rt.Name(), ":", err2)
 					markDirty = true
 				}
-			} else if err2 := rt.UpdateInbound(context.Background(), &oldSnapshot, oldInbound); err2 != nil {
-				logger.Warning("Unable to update inbound on", rt.Name(), ":", err2)
-				markDirty = true
+			} else {
+				runtimeInbound, err2 := s.buildRuntimeInboundForAPI(tx, oldInbound)
+				if err2 != nil {
+					logger.Warning("Unable to prepare runtime inbound config:", err2)
+					markDirty = true
+				} else if err2 := rt.UpdateInbound(context.Background(), &oldSnapshot, runtimeInbound); err2 != nil {
+					logger.Warning("Unable to update inbound on", rt.Name(), ":", err2)
+					markDirty = true
+				}
 			}
 		}
 
@@ -1224,6 +1242,15 @@ func (s *InboundService) buildRuntimeInboundForAPI(tx *gorm.DB, inbound *model.I
 	settings := map[string]any{}
 	if err := json.Unmarshal([]byte(inbound.Settings), &settings); err != nil {
 		return nil, err
+	}
+
+	if inbound.Protocol == model.WireGuard {
+		if runtimeSettings, mutated, err := buildRuntimeWireGuardSettings(tx, inbound); err != nil {
+			return nil, err
+		} else if mutated {
+			runtimeInbound.Settings = runtimeSettings
+		}
+		return &runtimeInbound, nil
 	}
 
 	clients, ok := settings["clients"].([]any)

--- a/internal/web/service/inbound.go
+++ b/internal/web/service/inbound.go
@@ -1172,12 +1172,18 @@ func (s *InboundService) UpdateInbound(inbound *model.Inbound) (*model.Inbound, 
 		if err := tx.Save(oldInbound).Error; err != nil {
 			return err
 		}
-		newClients, gcErr := s.GetClients(oldInbound)
-		if gcErr != nil {
-			return gcErr
-		}
-		if err := s.clientService.SyncInbound(tx, oldInbound.Id, newClients); err != nil {
-			return err
+		if clientManagedInbound(oldInbound.Protocol) {
+			newClients, gcErr := s.GetClients(oldInbound)
+			if gcErr != nil {
+				return gcErr
+			}
+			if err := s.clientService.SyncInbound(tx, oldInbound.Id, newClients); err != nil {
+				return err
+			}
+		} else if oldInbound.Protocol == model.WireGuard {
+			if err := s.clientService.syncWireGuardInboundPeerBindingsTx(tx, s, oldInbound.Id); err != nil {
+				return err
+			}
 		}
 		// (Re)generate the Xray config whenever routing was or is now enabled, so
 		// the egress SOCKS bridge is added, moved, or dropped to match the new

--- a/internal/web/service/inbound_disable.go
+++ b/internal/web/service/inbound_disable.go
@@ -265,7 +265,11 @@ func (s *InboundService) disableRemoteClients(tx *gorm.DB, inboundID int, emails
 	if err != nil {
 		return err
 	}
-	if err := rt.UpdateInbound(context.Background(), oldSnapshot, ib); err != nil {
+	runtimeInbound, err := s.buildRuntimeInboundForAPI(tx, ib)
+	if err != nil {
+		return err
+	}
+	if err := rt.UpdateInbound(context.Background(), oldSnapshot, runtimeInbound); err != nil {
 		return err
 	}
 	return nil

--- a/internal/web/service/wireguard_client_binding.go
+++ b/internal/web/service/wireguard_client_binding.go
@@ -1,0 +1,228 @@
+package service
+
+import (
+	"encoding/json"
+	"strings"
+
+	"github.com/mhsanaei/3x-ui/v3/internal/database"
+	"github.com/mhsanaei/3x-ui/v3/internal/database/model"
+
+	"gorm.io/gorm"
+)
+
+type wireGuardClientBinding struct {
+	id      int
+	email   string
+	subID   string
+	comment string
+}
+
+func jsonInt(v any) (int, bool) {
+	switch n := v.(type) {
+	case int:
+		return n, n > 0
+	case int64:
+		return int(n), n > 0
+	case float64:
+		i := int(n)
+		return i, n == float64(i) && i > 0
+	case json.Number:
+		i, err := n.Int64()
+		return int(i), err == nil && i > 0
+	default:
+		return 0, false
+	}
+}
+
+func setWireGuardPeerClient(peer map[string]any, c wireGuardClientBinding) bool {
+	changed := false
+	set := func(key string, value any) {
+		if peer[key] != value {
+			peer[key] = value
+			changed = true
+		}
+	}
+
+	oldEmail, _ := peer["clientEmail"].(string)
+	comment, _ := peer["comment"].(string)
+
+	set("clientId", c.id)
+	set("clientEmail", c.email)
+	if c.subID != "" {
+		set("clientSubId", c.subID)
+	} else if _, ok := peer["clientSubId"]; ok {
+		delete(peer, "clientSubId")
+		changed = true
+	}
+	if c.comment != "" {
+		set("clientComment", c.comment)
+	} else if _, ok := peer["clientComment"]; ok {
+		delete(peer, "clientComment")
+		changed = true
+	}
+
+	if strings.TrimSpace(comment) == "" || comment == oldEmail {
+		set("comment", c.email)
+	}
+	return changed
+}
+
+func clearWireGuardPeerClient(peer map[string]any) bool {
+	changed := false
+	oldEmail, _ := peer["clientEmail"].(string)
+	comment, _ := peer["comment"].(string)
+	for _, key := range []string{"clientId", "clientEmail", "clientSubId", "clientComment"} {
+		if _, ok := peer[key]; ok {
+			delete(peer, key)
+			changed = true
+		}
+	}
+	if oldEmail != "" && comment == oldEmail {
+		delete(peer, "comment")
+		changed = true
+	}
+	return changed
+}
+
+func (s *ClientService) syncWireGuardInboundPeerBindings(inboundSvc *InboundService, inboundId int) error {
+	return s.syncWireGuardInboundPeerBindingsTx(nil, inboundSvc, inboundId)
+}
+
+func (s *ClientService) syncWireGuardInboundPeerBindingsTx(tx *gorm.DB, inboundSvc *InboundService, inboundId int) error {
+	if tx == nil {
+		tx = database.GetDB()
+	}
+
+	var inbound model.Inbound
+	if err := tx.First(&inbound, inboundId).Error; err != nil {
+		return err
+	}
+	if inbound.Protocol != model.WireGuard {
+		return nil
+	}
+
+	clients, err := s.ListForInbound(tx, inboundId)
+	if err != nil {
+		return err
+	}
+
+	bindings := make([]wireGuardClientBinding, 0, len(clients))
+	byID := make(map[int]wireGuardClientBinding, len(clients))
+	byEmail := make(map[string]wireGuardClientBinding, len(clients))
+	for i := range clients {
+		email := strings.TrimSpace(clients[i].Email)
+		if email == "" {
+			continue
+		}
+		rec, rerr := s.GetRecordByEmail(tx, email)
+		if rerr != nil {
+			return rerr
+		}
+		b := wireGuardClientBinding{
+			id:      rec.Id,
+			email:   rec.Email,
+			subID:   rec.SubID,
+			comment: rec.Comment,
+		}
+		bindings = append(bindings, b)
+		byID[b.id] = b
+		byEmail[strings.ToLower(b.email)] = b
+	}
+
+	var settings map[string]any
+	if err := json.Unmarshal([]byte(inbound.Settings), &settings); err != nil {
+		return err
+	}
+	rawPeers, ok := settings["peers"].([]any)
+	if !ok || len(rawPeers) == 0 {
+		return nil
+	}
+
+	used := make(map[int]struct{}, len(bindings))
+	changed := false
+
+	for _, rawPeer := range rawPeers {
+		peer, ok := rawPeer.(map[string]any)
+		if !ok {
+			continue
+		}
+
+		var binding wireGuardClientBinding
+		matched := false
+		if id, ok := jsonInt(peer["clientId"]); ok {
+			if b, exists := byID[id]; exists {
+				if _, dup := used[b.id]; !dup {
+					binding = b
+					matched = true
+				}
+			}
+		}
+		if !matched {
+			if email, _ := peer["clientEmail"].(string); strings.TrimSpace(email) != "" {
+				if b, exists := byEmail[strings.ToLower(strings.TrimSpace(email))]; exists {
+					if _, dup := used[b.id]; !dup {
+						binding = b
+						matched = true
+					}
+				}
+			}
+		}
+
+		if matched {
+			used[binding.id] = struct{}{}
+			if setWireGuardPeerClient(peer, binding) {
+				changed = true
+			}
+			continue
+		}
+
+		if _, hadID := peer["clientId"]; hadID {
+			if clearWireGuardPeerClient(peer) {
+				changed = true
+			}
+			continue
+		}
+		if _, hadEmail := peer["clientEmail"]; hadEmail {
+			if clearWireGuardPeerClient(peer) {
+				changed = true
+			}
+		}
+	}
+
+	next := 0
+	for _, rawPeer := range rawPeers {
+		peer, ok := rawPeer.(map[string]any)
+		if !ok {
+			continue
+		}
+		if _, ok := jsonInt(peer["clientId"]); ok {
+			continue
+		}
+		if email, _ := peer["clientEmail"].(string); strings.TrimSpace(email) != "" {
+			continue
+		}
+		for next < len(bindings) {
+			b := bindings[next]
+			next++
+			if _, already := used[b.id]; already {
+				continue
+			}
+			used[b.id] = struct{}{}
+			if setWireGuardPeerClient(peer, b) {
+				changed = true
+			}
+			break
+		}
+	}
+
+	if !changed {
+		return nil
+	}
+
+	settings["peers"] = rawPeers
+	newSettings, err := json.MarshalIndent(settings, "", "  ")
+	if err != nil {
+		return err
+	}
+	return tx.Model(&model.Inbound{}).Where("id = ?", inboundId).Update("settings", string(newSettings)).Error
+}

--- a/internal/web/service/wireguard_client_binding.go
+++ b/internal/web/service/wireguard_client_binding.go
@@ -2,13 +2,21 @@ package service
 
 import (
 	"encoding/json"
+	"fmt"
+	"net"
+	"strconv"
 	"strings"
+	"time"
 
 	"github.com/mhsanaei/3x-ui/v3/internal/database"
 	"github.com/mhsanaei/3x-ui/v3/internal/database/model"
+	wgutil "github.com/mhsanaei/3x-ui/v3/internal/util/wireguard"
+	"github.com/mhsanaei/3x-ui/v3/internal/xray"
 
 	"gorm.io/gorm"
 )
+
+const wireGuardPeerDetachedKey = "clientDetached"
 
 type wireGuardClientBinding struct {
 	id      int
@@ -34,10 +42,25 @@ func jsonInt(v any) (int, bool) {
 	}
 }
 
+func jsonBool(v any) bool {
+	b, ok := v.(bool)
+	return ok && b
+}
+
+func sameJSONValue(existing any, want any) bool {
+	switch w := want.(type) {
+	case int:
+		got, ok := jsonInt(existing)
+		return ok && got == w
+	default:
+		return existing == want
+	}
+}
+
 func setWireGuardPeerClient(peer map[string]any, c wireGuardClientBinding) bool {
 	changed := false
 	set := func(key string, value any) {
-		if peer[key] != value {
+		if !sameJSONValue(peer[key], value) {
 			peer[key] = value
 			changed = true
 		}
@@ -48,6 +71,10 @@ func setWireGuardPeerClient(peer map[string]any, c wireGuardClientBinding) bool 
 
 	set("clientId", c.id)
 	set("clientEmail", c.email)
+	if _, ok := peer[wireGuardPeerDetachedKey]; ok {
+		delete(peer, wireGuardPeerDetachedKey)
+		changed = true
+	}
 	if c.subID != "" {
 		set("clientSubId", c.subID)
 	} else if _, ok := peer["clientSubId"]; ok {
@@ -67,21 +94,99 @@ func setWireGuardPeerClient(peer map[string]any, c wireGuardClientBinding) bool 
 	return changed
 }
 
-func clearWireGuardPeerClient(peer map[string]any) bool {
+func detachWireGuardPeerClient(peer map[string]any) bool {
 	changed := false
-	oldEmail, _ := peer["clientEmail"].(string)
-	comment, _ := peer["comment"].(string)
-	for _, key := range []string{"clientId", "clientEmail", "clientSubId", "clientComment"} {
-		if _, ok := peer[key]; ok {
-			delete(peer, key)
-			changed = true
-		}
-	}
-	if oldEmail != "" && comment == oldEmail {
-		delete(peer, "comment")
+	if !jsonBool(peer[wireGuardPeerDetachedKey]) {
+		peer[wireGuardPeerDetachedKey] = true
 		changed = true
 	}
 	return changed
+}
+
+func wireGuardPeerHasClient(peer map[string]any) bool {
+	if _, ok := jsonInt(peer["clientId"]); ok {
+		return true
+	}
+	email, _ := peer["clientEmail"].(string)
+	return strings.TrimSpace(email) != ""
+}
+
+func nextWireGuardPeerAllowedIP(peers []any) (string, error) {
+	const fallback = "10.0.0.2/32"
+	var maxIP uint32
+	prefix := 32
+	found := false
+
+	for _, rawPeer := range peers {
+		peer, ok := rawPeer.(map[string]any)
+		if !ok {
+			continue
+		}
+		rawAllowed, _ := peer["allowedIPs"].([]any)
+		for _, rawIP := range rawAllowed {
+			text, _ := rawIP.(string)
+			addr, bits := parseWireGuardAllowedIPv4(text)
+			if addr == nil {
+				continue
+			}
+			value := uint32(addr[0])<<24 | uint32(addr[1])<<16 | uint32(addr[2])<<8 | uint32(addr[3])
+			if !found || value > maxIP {
+				maxIP = value
+				prefix = bits
+				found = true
+			}
+		}
+	}
+
+	if !found {
+		return fallback, nil
+	}
+	if maxIP == ^uint32(0) {
+		return "", fmt.Errorf("WireGuard address pool exhausted")
+	}
+	next := maxIP + 1
+	return fmt.Sprintf("%d.%d.%d.%d/%d", byte(next>>24), byte(next>>16), byte(next>>8), byte(next), prefix), nil
+}
+
+func parseWireGuardAllowedIPv4(value string) (net.IP, int) {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return nil, 0
+	}
+	addr := value
+	bits := 32
+	if before, after, ok := strings.Cut(value, "/"); ok {
+		addr = strings.TrimSpace(before)
+		n, err := strconv.Atoi(strings.TrimSpace(after))
+		if err != nil || n < 0 || n > 32 {
+			return nil, 0
+		}
+		bits = n
+	}
+	ip := net.ParseIP(addr).To4()
+	if ip == nil {
+		return nil, 0
+	}
+	return ip, bits
+}
+
+func newWireGuardPeerForClient(peers []any, c wireGuardClientBinding) (map[string]any, error) {
+	privateKey, publicKey, err := wgutil.GenerateWireguardKeypair()
+	if err != nil {
+		return nil, err
+	}
+	allowedIP, err := nextWireGuardPeerAllowedIP(peers)
+	if err != nil {
+		return nil, err
+	}
+	peer := map[string]any{
+		"privateKey": privateKey,
+		"publicKey":  publicKey,
+		"allowedIPs": []any{allowedIP},
+		"keepAlive":  0,
+	}
+	setWireGuardPeerClient(peer, c)
+	return peer, nil
 }
 
 func (s *ClientService) syncWireGuardInboundPeerBindings(inboundSvc *InboundService, inboundId int) error {
@@ -133,9 +238,9 @@ func (s *ClientService) syncWireGuardInboundPeerBindingsTx(tx *gorm.DB, inboundS
 	if err := json.Unmarshal([]byte(inbound.Settings), &settings); err != nil {
 		return err
 	}
-	rawPeers, ok := settings["peers"].([]any)
-	if !ok || len(rawPeers) == 0 {
-		return nil
+	rawPeers, _ := settings["peers"].([]any)
+	if rawPeers == nil {
+		rawPeers = []any{}
 	}
 
 	used := make(map[int]struct{}, len(bindings))
@@ -176,14 +281,8 @@ func (s *ClientService) syncWireGuardInboundPeerBindingsTx(tx *gorm.DB, inboundS
 			continue
 		}
 
-		if _, hadID := peer["clientId"]; hadID {
-			if clearWireGuardPeerClient(peer) {
-				changed = true
-			}
-			continue
-		}
-		if _, hadEmail := peer["clientEmail"]; hadEmail {
-			if clearWireGuardPeerClient(peer) {
+		if wireGuardPeerHasClient(peer) {
+			if detachWireGuardPeerClient(peer) {
 				changed = true
 			}
 		}
@@ -195,10 +294,7 @@ func (s *ClientService) syncWireGuardInboundPeerBindingsTx(tx *gorm.DB, inboundS
 		if !ok {
 			continue
 		}
-		if _, ok := jsonInt(peer["clientId"]); ok {
-			continue
-		}
-		if email, _ := peer["clientEmail"].(string); strings.TrimSpace(email) != "" {
+		if wireGuardPeerHasClient(peer) {
 			continue
 		}
 		for next < len(bindings) {
@@ -215,6 +311,19 @@ func (s *ClientService) syncWireGuardInboundPeerBindingsTx(tx *gorm.DB, inboundS
 		}
 	}
 
+	for _, b := range bindings {
+		if _, already := used[b.id]; already {
+			continue
+		}
+		peer, err := newWireGuardPeerForClient(rawPeers, b)
+		if err != nil {
+			return err
+		}
+		rawPeers = append(rawPeers, peer)
+		used[b.id] = struct{}{}
+		changed = true
+	}
+
 	if !changed {
 		return nil
 	}
@@ -225,4 +334,147 @@ func (s *ClientService) syncWireGuardInboundPeerBindingsTx(tx *gorm.DB, inboundS
 		return err
 	}
 	return tx.Model(&model.Inbound{}).Where("id = ?", inboundId).Update("settings", string(newSettings)).Error
+}
+
+func buildRuntimeWireGuardSettings(tx *gorm.DB, inbound *model.Inbound) (string, bool, error) {
+	if inbound == nil || inbound.Protocol != model.WireGuard {
+		return "", false, nil
+	}
+	if tx == nil {
+		tx = database.GetDB()
+	}
+
+	settings := map[string]any{}
+	if err := json.Unmarshal([]byte(inbound.Settings), &settings); err != nil {
+		return "", false, err
+	}
+	rawPeers, ok := settings["peers"].([]any)
+	if !ok {
+		return "", false, nil
+	}
+
+	active, err := activeWireGuardClientMap(tx, inbound.Id)
+	if err != nil {
+		return "", false, err
+	}
+
+	finalPeers := make([]any, 0, len(rawPeers))
+	for _, rawPeer := range rawPeers {
+		peer, ok := rawPeer.(map[string]any)
+		if !ok {
+			continue
+		}
+		if jsonBool(peer[wireGuardPeerDetachedKey]) {
+			continue
+		}
+		managed := wireGuardPeerHasClient(peer)
+		if managed {
+			if !wireGuardPeerClientActive(peer, active) {
+				continue
+			}
+		}
+		finalPeers = append(finalPeers, runtimeWireGuardPeer(peer))
+	}
+
+	settings["peers"] = finalPeers
+	modifiedSettings, err := json.MarshalIndent(settings, "", "  ")
+	if err != nil {
+		return "", false, err
+	}
+	return string(modifiedSettings), true, nil
+}
+
+type wireGuardRuntimeClient struct {
+	id     int
+	email  string
+	active bool
+}
+
+func activeWireGuardClientMap(tx *gorm.DB, inboundId int) (map[int]wireGuardRuntimeClient, error) {
+	var records []model.ClientRecord
+	if err := tx.Model(&model.ClientRecord{}).
+		Joins("JOIN client_inbounds ON client_inbounds.client_id = clients.id").
+		Where("client_inbounds.inbound_id = ?", inboundId).
+		Find(&records).Error; err != nil {
+		return nil, err
+	}
+
+	emails := make([]string, 0, len(records))
+	for _, rec := range records {
+		if strings.TrimSpace(rec.Email) != "" {
+			emails = append(emails, rec.Email)
+		}
+	}
+
+	stats := []xray.ClientTraffic{}
+	if len(emails) > 0 {
+		if err := tx.Model(&xray.ClientTraffic{}).
+			Where("email IN ?", emails).
+			Select("email", "enable", "up", "down", "total", "expiry_time").
+			Find(&stats).Error; err != nil {
+			return nil, err
+		}
+	}
+	statsByEmail := make(map[string]xray.ClientTraffic, len(stats))
+	for _, st := range stats {
+		statsByEmail[strings.ToLower(st.Email)] = st
+	}
+
+	now := time.Now().UnixMilli()
+	active := make(map[int]wireGuardRuntimeClient, len(records))
+	for _, rec := range records {
+		ok := rec.Enable
+		if rec.ExpiryTime > 0 && rec.ExpiryTime < now {
+			ok = false
+		}
+		if rec.TotalGB > 0 {
+			if st, exists := statsByEmail[strings.ToLower(rec.Email)]; exists && st.Up+st.Down >= rec.TotalGB {
+				ok = false
+			}
+		}
+		if st, exists := statsByEmail[strings.ToLower(rec.Email)]; exists {
+			if !st.Enable {
+				ok = false
+			}
+			if st.ExpiryTime > 0 && st.ExpiryTime < now {
+				ok = false
+			}
+			if st.Total > 0 && st.Up+st.Down >= st.Total {
+				ok = false
+			}
+		}
+		active[rec.Id] = wireGuardRuntimeClient{id: rec.Id, email: rec.Email, active: ok}
+	}
+	return active, nil
+}
+
+func wireGuardPeerClientActive(peer map[string]any, active map[int]wireGuardRuntimeClient) bool {
+	if id, ok := jsonInt(peer["clientId"]); ok {
+		client, exists := active[id]
+		return exists && client.active
+	}
+	email, _ := peer["clientEmail"].(string)
+	email = strings.ToLower(strings.TrimSpace(email))
+	if email == "" {
+		return false
+	}
+	for _, client := range active {
+		if strings.ToLower(client.email) == email {
+			return client.active
+		}
+	}
+	return false
+}
+
+func runtimeWireGuardPeer(peer map[string]any) map[string]any {
+	out := make(map[string]any, len(peer))
+	for key, value := range peer {
+		switch key {
+		case "privateKey", "comment", "clientId", "clientEmail", "clientSubId", "clientComment", wireGuardPeerDetachedKey:
+			continue
+		default:
+			out[key] = value
+		}
+	}
+	return out
 }

--- a/internal/web/service/wireguard_client_binding_test.go
+++ b/internal/web/service/wireguard_client_binding_test.go
@@ -1,0 +1,218 @@
+package service
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/mhsanaei/3x-ui/v3/internal/database"
+	"github.com/mhsanaei/3x-ui/v3/internal/database/model"
+)
+
+func wireGuardSettings(t *testing.T, peers []map[string]any) string {
+	t.Helper()
+	rawPeers := make([]any, 0, len(peers))
+	for _, peer := range peers {
+		rawPeers = append(rawPeers, peer)
+	}
+	data, err := json.Marshal(map[string]any{
+		"secretKey":   "server-private-key",
+		"peers":       rawPeers,
+		"noKernelTun": false,
+	})
+	if err != nil {
+		t.Fatalf("marshal wg settings: %v", err)
+	}
+	return string(data)
+}
+
+func loadWireGuardPeers(t *testing.T, inboundID int) []map[string]any {
+	t.Helper()
+	var inbound model.Inbound
+	if err := database.GetDB().First(&inbound, inboundID).Error; err != nil {
+		t.Fatalf("load inbound: %v", err)
+	}
+	var settings map[string]any
+	if err := json.Unmarshal([]byte(inbound.Settings), &settings); err != nil {
+		t.Fatalf("parse settings: %v", err)
+	}
+	rawPeers, _ := settings["peers"].([]any)
+	peers := make([]map[string]any, 0, len(rawPeers))
+	for _, rawPeer := range rawPeers {
+		peer, ok := rawPeer.(map[string]any)
+		if !ok {
+			t.Fatalf("peer has unexpected shape: %#v", rawPeer)
+		}
+		peers = append(peers, peer)
+	}
+	return peers
+}
+
+func TestWireGuardPeerBindingMatchesByClientIDAndEmail(t *testing.T) {
+	setupBulkDB(t)
+	db := database.GetDB()
+	svc := &ClientService{}
+
+	alice := model.ClientRecord{Email: "alice@example.com", SubID: "sub-a", Comment: "Alice", Enable: true}
+	bob := model.ClientRecord{Email: "bob@example.com", SubID: "sub-b", Comment: "Bob", Enable: true}
+	if err := db.Create(&alice).Error; err != nil {
+		t.Fatalf("create alice: %v", err)
+	}
+	if err := db.Create(&bob).Error; err != nil {
+		t.Fatalf("create bob: %v", err)
+	}
+
+	wg := mkInbound(t, 51820, model.WireGuard, wireGuardSettings(t, []map[string]any{
+		{"publicKey": "peer-a", "allowedIPs": []any{"10.0.0.2/32"}, "clientId": float64(alice.Id), "comment": ""},
+		{"publicKey": "peer-b", "allowedIPs": []any{"10.0.0.3/32"}, "clientEmail": "BOB@example.com", "comment": "BOB@example.com"},
+	}))
+	if err := db.Create(&model.ClientInbound{ClientId: alice.Id, InboundId: wg.Id}).Error; err != nil {
+		t.Fatalf("link alice: %v", err)
+	}
+	if err := db.Create(&model.ClientInbound{ClientId: bob.Id, InboundId: wg.Id}).Error; err != nil {
+		t.Fatalf("link bob: %v", err)
+	}
+
+	if err := svc.syncWireGuardInboundPeerBindings(nil, wg.Id); err != nil {
+		t.Fatalf("sync wg: %v", err)
+	}
+
+	peers := loadWireGuardPeers(t, wg.Id)
+	if got, ok := jsonInt(peers[0]["clientId"]); !ok || got != alice.Id {
+		t.Fatalf("alice clientId = %v, want %d", peers[0]["clientId"], alice.Id)
+	}
+	if peers[0]["clientEmail"] != alice.Email || peers[0]["clientSubId"] != alice.SubID || peers[0]["clientComment"] != alice.Comment {
+		t.Fatalf("alice metadata not synced: %#v", peers[0])
+	}
+	if peers[0]["comment"] != alice.Email {
+		t.Fatalf("alice empty comment should become email, got %#v", peers[0]["comment"])
+	}
+	if got, ok := jsonInt(peers[1]["clientId"]); !ok || got != bob.Id {
+		t.Fatalf("bob clientId = %v, want %d", peers[1]["clientId"], bob.Id)
+	}
+	if peers[1]["clientEmail"] != bob.Email || peers[1]["clientSubId"] != bob.SubID || peers[1]["clientComment"] != bob.Comment {
+		t.Fatalf("bob metadata not synced: %#v", peers[1])
+	}
+	if peers[1]["comment"] != bob.Email {
+		t.Fatalf("bob old email comment should normalize to current email, got %#v", peers[1]["comment"])
+	}
+}
+
+func TestWireGuardPeerBindingGeneratesPeerWhenNoSlotExists(t *testing.T) {
+	setupBulkDB(t)
+	db := database.GetDB()
+	svc := &ClientService{}
+	inboundSvc := &InboundService{}
+
+	rec := model.ClientRecord{Email: "alice@example.com", SubID: "sub-a", Enable: true}
+	if err := db.Create(&rec).Error; err != nil {
+		t.Fatalf("create client: %v", err)
+	}
+	wg := mkInbound(t, 51821, model.WireGuard, wireGuardSettings(t, nil))
+
+	needRestart, err := svc.Attach(inboundSvc, rec.Id, []int{wg.Id})
+	if err != nil {
+		t.Fatalf("attach wg: %v", err)
+	}
+	if !needRestart {
+		t.Fatalf("WireGuard attach should request restart")
+	}
+
+	peers := loadWireGuardPeers(t, wg.Id)
+	if len(peers) != 1 {
+		t.Fatalf("generated peers = %d, want 1", len(peers))
+	}
+	peer := peers[0]
+	if peer["privateKey"] == "" || peer["publicKey"] == "" {
+		t.Fatalf("generated peer missing keypair: %#v", peer)
+	}
+	if peer["clientEmail"] != rec.Email {
+		t.Fatalf("generated peer not bound to client: %#v", peer)
+	}
+	allowed, _ := peer["allowedIPs"].([]any)
+	if len(allowed) != 1 || allowed[0] != "10.0.0.2/32" {
+		t.Fatalf("generated allowedIPs = %#v, want 10.0.0.2/32", allowed)
+	}
+}
+
+func TestWireGuardDetachMarksPeerDetachedAndRuntimeFiltersIt(t *testing.T) {
+	setupBulkDB(t)
+	db := database.GetDB()
+	svc := &ClientService{}
+	inboundSvc := &InboundService{}
+
+	rec := model.ClientRecord{Email: "alice@example.com", SubID: "sub-a", Enable: true}
+	if err := db.Create(&rec).Error; err != nil {
+		t.Fatalf("create client: %v", err)
+	}
+	wg := mkInbound(t, 51822, model.WireGuard, wireGuardSettings(t, []map[string]any{
+		{
+			"privateKey":    "client-private",
+			"publicKey":     "client-public",
+			"allowedIPs":    []any{"10.0.0.2/32"},
+			"clientId":      rec.Id,
+			"clientEmail":   rec.Email,
+			"clientSubId":   rec.SubID,
+			"clientComment": "Alice",
+		},
+		{"publicKey": "legacy-public", "allowedIPs": []any{"10.0.0.3/32"}},
+	}))
+	if err := db.Create(&model.ClientInbound{ClientId: rec.Id, InboundId: wg.Id}).Error; err != nil {
+		t.Fatalf("link client: %v", err)
+	}
+
+	needRestart, err := svc.Detach(inboundSvc, rec.Id, []int{wg.Id})
+	if err != nil {
+		t.Fatalf("detach wg: %v", err)
+	}
+	if !needRestart {
+		t.Fatalf("WireGuard detach should request restart")
+	}
+
+	peers := loadWireGuardPeers(t, wg.Id)
+	if peers[0]["clientDetached"] != true {
+		t.Fatalf("detached peer should keep metadata and mark clientDetached: %#v", peers[0])
+	}
+
+	var reloaded model.Inbound
+	if err := db.First(&reloaded, wg.Id).Error; err != nil {
+		t.Fatalf("reload inbound: %v", err)
+	}
+	runtimeInbound, err := inboundSvc.buildRuntimeInboundForAPI(db, &reloaded)
+	if err != nil {
+		t.Fatalf("build runtime inbound: %v", err)
+	}
+	var runtimeSettings map[string]any
+	if err := json.Unmarshal([]byte(runtimeInbound.Settings), &runtimeSettings); err != nil {
+		t.Fatalf("parse runtime settings: %v", err)
+	}
+	runtimePeers, _ := runtimeSettings["peers"].([]any)
+	if len(runtimePeers) != 1 {
+		t.Fatalf("runtime peers = %d, want only legacy unmanaged peer", len(runtimePeers))
+	}
+	runtimePeer := runtimePeers[0].(map[string]any)
+	if runtimePeer["publicKey"] != "legacy-public" {
+		t.Fatalf("unexpected runtime peer: %#v", runtimePeer)
+	}
+	if _, exists := runtimePeer["privateKey"]; exists {
+		t.Fatalf("runtime peer should not include panel privateKey: %#v", runtimePeer)
+	}
+}
+
+func TestWireGuardBindingNonWireGuardNoop(t *testing.T) {
+	setupBulkDB(t)
+	svc := &ClientService{}
+	settings := `{"clients":[],"peers":[{"publicKey":"not-wg","clientEmail":"stale@example.com"}]}`
+	ib := mkInbound(t, 51823, model.VLESS, settings)
+
+	if err := svc.syncWireGuardInboundPeerBindings(nil, ib.Id); err != nil {
+		t.Fatalf("sync non-wg: %v", err)
+	}
+
+	var reloaded model.Inbound
+	if err := database.GetDB().First(&reloaded, ib.Id).Error; err != nil {
+		t.Fatalf("reload inbound: %v", err)
+	}
+	if reloaded.Settings != settings {
+		t.Fatalf("non-WireGuard settings changed:\ngot  %s\nwant %s", reloaded.Settings, settings)
+	}
+}

--- a/internal/web/service/xray.go
+++ b/internal/web/service/xray.go
@@ -142,99 +142,108 @@ func (s *XrayService) GetXrayConfig() (*xray.Config, error) {
 		if inbound.Protocol == model.MTProto {
 			continue
 		}
-		settings := map[string]any{}
-		_ = json.Unmarshal([]byte(inbound.Settings), &settings)
 
-		dbClients, listErr := s.inboundService.clientService.ListForInbound(nil, inbound.Id)
-		if listErr != nil {
-			return nil, listErr
-		}
+		if inbound.Protocol == model.WireGuard {
+			if runtimeSettings, mutated, wgErr := buildRuntimeWireGuardSettings(nil, inbound); wgErr != nil {
+				return nil, wgErr
+			} else if mutated {
+				inbound.Settings = runtimeSettings
+			}
+		} else {
+			settings := map[string]any{}
+			_ = json.Unmarshal([]byte(inbound.Settings), &settings)
 
-		clientStats := inbound.ClientStats
-		enableMap := make(map[string]bool, len(clientStats))
-		for _, clientTraffic := range clientStats {
-			enableMap[clientTraffic.Email] = clientTraffic.Enable
-		}
+			dbClients, listErr := s.inboundService.clientService.ListForInbound(nil, inbound.Id)
+			if listErr != nil {
+				return nil, listErr
+			}
 
-		var finalClients []any
-		for i := range dbClients {
-			c := dbClients[i]
-			if enable, exists := enableMap[c.Email]; exists && !enable {
-				logger.Infof("Remove Inbound User %s due to expiration or traffic limit", c.Email)
-				continue
+			clientStats := inbound.ClientStats
+			enableMap := make(map[string]bool, len(clientStats))
+			for _, clientTraffic := range clientStats {
+				enableMap[clientTraffic.Email] = clientTraffic.Enable
 			}
-			if !c.Enable {
-				continue
-			}
-			flow := c.Flow
-			if flow == "xtls-rprx-vision-udp443" {
-				flow = "xtls-rprx-vision"
-			}
-			entry := map[string]any{"email": c.Email}
-			switch inbound.Protocol {
-			case model.VLESS:
-				if c.ID != "" {
-					entry["id"] = c.ID
-				}
-				if flow != "" {
-					entry["flow"] = flow
-				}
-				if c.Reverse != nil {
-					entry["reverse"] = c.Reverse
-				}
-			case model.VMESS:
-				if c.ID != "" {
-					entry["id"] = c.ID
-				}
-				if c.Security != "" {
-					entry["security"] = c.Security
-				}
-			case model.Trojan:
-				if c.Password != "" {
-					entry["password"] = c.Password
-				}
-				if flow != "" {
-					entry["flow"] = flow
-				}
-			case model.Shadowsocks:
-				if c.Password != "" {
-					entry["password"] = c.Password
-				}
-			case model.Hysteria:
-				if c.Auth != "" {
-					entry["auth"] = c.Auth
-				}
-			}
-			finalClients = append(finalClients, entry)
-		}
 
-		_, hadClients := settings["clients"]
-		mutated := hadClients || len(finalClients) > 0
-		if mutated {
-			settings["clients"] = finalClients
-		}
-
-		if inboundCanHostFallbacks(inbound) {
-			fallbacks, fbErr := s.inboundService.fallbackService.BuildFallbacksJSON(nil, inbound.Id)
-			if fbErr != nil {
-				return nil, fbErr
-			}
-			if len(fallbacks) > 0 {
-				generic := make([]any, 0, len(fallbacks))
-				for _, f := range fallbacks {
-					generic = append(generic, f)
+			var finalClients []any
+			for i := range dbClients {
+				c := dbClients[i]
+				if enable, exists := enableMap[c.Email]; exists && !enable {
+					logger.Infof("Remove Inbound User %s due to expiration or traffic limit", c.Email)
+					continue
 				}
-				settings["fallbacks"] = generic
-				mutated = true
+				if !c.Enable {
+					continue
+				}
+				flow := c.Flow
+				if flow == "xtls-rprx-vision-udp443" {
+					flow = "xtls-rprx-vision"
+				}
+				entry := map[string]any{"email": c.Email}
+				switch inbound.Protocol {
+				case model.VLESS:
+					if c.ID != "" {
+						entry["id"] = c.ID
+					}
+					if flow != "" {
+						entry["flow"] = flow
+					}
+					if c.Reverse != nil {
+						entry["reverse"] = c.Reverse
+					}
+				case model.VMESS:
+					if c.ID != "" {
+						entry["id"] = c.ID
+					}
+					if c.Security != "" {
+						entry["security"] = c.Security
+					}
+				case model.Trojan:
+					if c.Password != "" {
+						entry["password"] = c.Password
+					}
+					if flow != "" {
+						entry["flow"] = flow
+					}
+				case model.Shadowsocks:
+					if c.Password != "" {
+						entry["password"] = c.Password
+					}
+				case model.Hysteria:
+					if c.Auth != "" {
+						entry["auth"] = c.Auth
+					}
+				}
+				finalClients = append(finalClients, entry)
 			}
-		}
 
-		if mutated {
-			modifiedSettings, err := json.MarshalIndent(settings, "", "  ")
-			if err != nil {
-				return nil, err
+			_, hadClients := settings["clients"]
+			mutated := hadClients || len(finalClients) > 0
+			if mutated {
+				settings["clients"] = finalClients
 			}
-			inbound.Settings = string(modifiedSettings)
+
+			if inboundCanHostFallbacks(inbound) {
+				fallbacks, fbErr := s.inboundService.fallbackService.BuildFallbacksJSON(nil, inbound.Id)
+				if fbErr != nil {
+					return nil, fbErr
+				}
+				if len(fallbacks) > 0 {
+					generic := make([]any, 0, len(fallbacks))
+					for _, f := range fallbacks {
+						generic = append(generic, f)
+					}
+					settings["fallbacks"] = generic
+					mutated = true
+				}
+			}
+
+			if mutated {
+				modifiedSettings, err := json.MarshalIndent(settings, "", "  ")
+				if err != nil {
+					return nil, err
+				}
+				inbound.Settings = string(modifiedSettings)
+			}
 		}
 
 		if len(inbound.StreamSettings) > 0 {


### PR DESCRIPTION
## Summary
- Fix WireGuard client attachment so client bindings map to `settings.peers[]` instead of unsupported `settings.clients[]`.
- Generate/reuse WireGuard peers for bound clients and filter inactive/expired/depleted/detached managed peers from runtime Xray config.
- Allow WireGuard in client inbound pickers and improve selected inbound tag layout.
- Update OpenAPI docs and add focused service tests for WireGuard client binding behavior.

## Verification
- `go test ./internal/web/service`
- `go test ./...`
- `npm --prefix frontend run build`
- `git diff --check`
