### PR TITLE
feat(deploy): add Ansible role for automated 3x-ui installation

### DIFF
--- a/ansible/.gitignore
+++ b/ansible/.gitignore
@@ -1,0 +1,2 @@
+*.retry
+.ansible_cache/

--- a/ansible/README.md
+++ b/ansible/README.md
@@ -1,0 +1,83 @@
+# Ansible deployment for 3x-ui
+
+This repository contains an Ansible playbook and role for installing and configuring 3x-ui on one or more remote Linux servers.
+
+The deployment includes:
+- system prerequisites and package installation
+- optional PostgreSQL setup or SQLite usage
+- 3x-ui binary installation and configuration
+- SSL setup (none, domain, IP, or custom certificate)
+- systemd service configuration and startup
+
+## Repository structure
+
+- `playbook.yml` – the main Ansible playbook entrypoint
+- `inventories/hosts.sample.yml` – sample inventory file
+- `roles/install-3x-ui/` – the role that performs the installation
+
+## Requirements
+
+Before running the playbook, make sure you have:
+- Ansible installed on your control machine
+- SSH access to the target host
+- `sudo` privileges on the target host
+- Python available on the target host
+
+## Quick start
+
+1. Copy the sample inventory file:
+   ```bash
+   cp inventories/hosts.sample.yml inventories/hosts.yml
+   ```
+
+2. Edit `inventories/hosts.yml` and set your target host details.
+
+3. Review the role defaults in `roles/install-3x-ui/defaults/main.yml` and override any values you need.
+
+4. Run the playbook:
+   ```bash
+   ansible-playbook -i inventories/hosts.yml playbook.yml
+   ```
+
+## Example inventory
+
+```yaml
+all:
+  children:
+    xui_servers:
+      hosts:
+        server_1:
+          ansible_host: 203.0.113.10
+          ansible_port: 22
+          ansible_user: root
+```
+
+## Key variables
+
+The role exposes several variables through `roles/install-3x-ui/defaults/main.yml`:
+
+- `xui_db_type` – database backend (`sqlite` or `postgres`)
+- `xui_version` – 3x-ui release version to install
+- `xui_username` / `xui_password` – panel login credentials
+- `xui_port` – web port for the panel
+- `xui_ssl_mode` – SSL mode (`none`, `domain`, `ip`, `custom`)
+- `xui_domain` – domain name used when `xui_ssl_mode: domain`
+- `xui_listen_ip` – interface the panel should bind to
+
+> For production deployments, change the default credentials and consider protecting secrets with Ansible Vault.
+
+## Useful tags
+
+You can run the playbook with tags to limit the work:
+
+```bash
+ansible-playbook -i inventories/hosts.yml playbook.yml --tags setup
+ansible-playbook -i inventories/hosts.yml playbook.yml --tags install
+```
+
+## Security notes
+
+- Do not leave default passwords in place.
+- Use Ansible Vault for sensitive values such as database passwords.
+- Review the SSL settings before deploying to production.
+

--- a/ansible/inventories/hosts.sample.yml
+++ b/ansible/inventories/hosts.sample.yml
@@ -1,0 +1,9 @@
+# Copy this file to hosts.yml and update with your server details
+all:
+  children:
+    xui_servers:
+      hosts:
+        server_1:
+          ansible_host: 0.0.0.0      # Replace with your VPS/Server public IPv4 or domain
+          ansible_port: 22           # Replace with your custom SSH port if changed
+          ansible_user: root         # Replace with sudo user or root

--- a/ansible/playbook.yml
+++ b/ansible/playbook.yml
@@ -1,0 +1,8 @@
+- name: 3x-ui Installation Role
+  hosts: all
+  gather_facts: true
+  become: true
+  roles:
+    - install-3x-ui
+  tags:
+    - 3x_ui

--- a/ansible/roles/install-3x-ui/defaults/main.yml
+++ b/ansible/roles/install-3x-ui/defaults/main.yml
@@ -1,0 +1,56 @@
+---
+# defaults file for install-3x-ui
+
+# Database selection: 'sqlite' or 'postgres'
+xui_db_type: 'sqlite'
+
+# PostgreSQL specific configurations
+xui_pg_install_local: true
+xui_pg_host: '127.0.0.1'
+xui_pg_port: 5432
+xui_pg_database: 'xui'
+xui_pg_user: 'xui_user'
+xui_pg_password: 'VaultedPassword' # Use ansible-vault for this!
+
+# DSN generation based on variables
+xui_db_dsn: "postgres://{{ xui_pg_user }}:{{ xui_pg_password | urlencode }}@{{ xui_pg_host }}:{{ xui_pg_port }}/{{ xui_pg_database }}?sslmode=disable"
+
+xui_version: 'v3.4.1' # Define explicit tags like 'v2.4.3'
+xui_base_dir: '/usr/local/x-ui'
+
+# Hardware Translation Lookup Map
+xui_arch_map:
+  x86_64: 'amd64'
+  amd64: 'amd64'
+  aarch64: 'arm64'
+  arm64: 'arm64'
+  armv7l: 'armv7'
+  armv6l: 'armv6'
+  i386: '386'
+
+# SSL Configuration Mode: 'none', 'domain', 'ip', or 'custom'
+xui_ssl_mode: 'domain'
+
+# Required if xui_ssl_mode == 'domain'
+xui_domain: 'example.com'
+xui_acme_email: 'example.email@gmail.com'
+
+# Required if xui_ssl_mode == 'custom'
+xui_ssl_custom_cert: '/etc/ssl/certs/cert.pem'
+xui_ssl_custom_key: '/etc/ssl/private/key.pem'
+
+# Use a specific, stable release tag from the acme.sh repository
+xui_acme_sh_version: "3.0.8"
+
+# defaults file for install-3x-ui
+xui_folder: "/usr/local/x-ui"
+
+# Core Settings (Should ideally be overwritten using ansible-vault)
+xui_username: "admin"
+xui_password: "panelPassword"
+xui_port: 2053
+xui_web_base_path: "panel"
+
+# Networking Configuration
+# Set to '127.0.0.1' if you want to isolate the interface behind Nginx/Caddy or an SSH tunnel
+xui_listen_ip: "0.0.0.0"

--- a/ansible/roles/install-3x-ui/handlers/main.yml
+++ b/ansible/roles/install-3x-ui/handlers/main.yml
@@ -1,0 +1,11 @@
+---
+# handlers file for install-3x-ui
+
+- name: Restart 3x-ui
+  ansible.builtin.service:
+    name: x-ui
+    state: restarted
+
+- name: Reload systemd daemon
+  ansible.builtin.systemd:
+    daemon_reload: true

--- a/ansible/roles/install-3x-ui/tasks/configure.yml
+++ b/ansible/roles/install-3x-ui/tasks/configure.yml
@@ -1,0 +1,115 @@
+---
+# roles/3x_ui/tasks/configure.yml
+
+- name: Determine cross-platform system environment config path
+  ansible.builtin.set_fact:
+    xui_env_file_path: >-
+      {% if ansible_facts['os_family'] == 'Debian' %}
+      /etc/default/x-ui
+      {% elif ansible_facts['os_family'] == 'Archlinux' or ansible_facts['os_family'] == 'Alpine' %}
+      /etc/conf.d/x-ui
+      {% else %}
+      /etc/sysconfig/x-ui
+      {% endif %}
+  tags:
+    - 3x_ui
+    - configure
+    - setup
+
+- name: Enforce presence of 3x-ui configuration directories
+  ansible.builtin.file:
+    path: "{{ item }}"
+    state: directory
+    owner: root
+    group: root
+    mode: '0755'
+  loop:
+    - /etc/x-ui
+    - "{{ xui_env_file_path | dirname }}"
+  tags:
+    - 3x_ui
+    - configure
+    - setup
+
+- name: Deploy the 3x-ui system database configuration environment template
+  ansible.builtin.template:
+    src: x-ui-panel.env.j2
+    dest: "{{ xui_env_file_path }}"
+    owner: root
+    group: root
+    mode: '0600'
+  notify: Restart 3x-ui
+  tags:
+    - 3x_ui
+    - configure
+
+- name: Retrieve current 3x-ui runtime settings state
+  ansible.builtin.command: "{{ xui_folder | default('/usr/local/x-ui') }}/x-ui setting -show true"
+  register: current_xui_settings
+  changed_when: false
+  failed_when: false
+  no_log: true
+  tags:
+    - 3x_ui
+    - configure
+
+- name: Sync panel administrative state via CLI if values differ
+  ansible.builtin.command: >
+    {{ xui_folder | default('/usr/local/x-ui') }}/x-ui setting \
+    -username "{{ xui_username }}" \
+    -password "{{ xui_password }}" \
+    -port "{{ xui_port }}" \
+    -webBasePath "{{ xui_web_base_path }}"
+  when: >
+    ( 'username: ' + xui_username ) not in current_xui_settings.stdout or
+    ( 'password: ' + xui_password ) not in current_xui_settings.stdout or
+    ( 'port: ' + xui_port | string ) not in current_xui_settings.stdout or
+    ( 'webBasePath: /' + xui_web_base_path | regex_replace('^/', '') ) not in current_xui_settings.stdout
+  notify: Restart 3x-ui
+  tags:
+    - 3x_ui
+    - configure
+
+- name: Configure panel Listen IP binding interface
+  ansible.builtin.command: >
+    {{ xui_folder | default('/usr/local/x-ui') }}/x-ui setting -listenIP "{{ xui_listen_ip }}"
+  when: "('listenIP: ' + xui_listen_ip) not in current_xui_settings.stdout"
+  notify: Restart 3x-ui
+  tags:
+    - 3x_ui
+    - configure
+
+- name: Execute 3x-ui database schema migrations
+  ansible.builtin.command: "{{ xui_folder | default('/usr/local/x-ui') }}/x-ui migrate"
+  register: migration_result
+  changed_when: "'migration successful' in migration_result.stdout or 'migrated' in migration_result.stdout"
+  tags:
+    - 3x_ui
+    - configure
+    - database
+
+- name: Fetch panel API token for automation metadata synchronization
+  ansible.builtin.command: "{{ xui_folder | default('/usr/local/x-ui') }}/x-ui setting -getApiToken true"
+  register: api_token_output
+  changed_when: false
+  tags:
+    - 3x_ui
+    - configure
+
+- name: Parse API token fact from output
+  ansible.builtin.set_fact:
+    xui_api_token: "{{ api_token_output.stdout | regex_search('apiToken: (\\S+)', '\\1') | first | default('UNKNOWN') }}"
+  tags:
+    - 3x_ui
+    - configure
+
+- name: Deploy the machine-parseable installation summary receipt template
+  ansible.builtin.template:
+    src: install-result.env.j2
+    dest: /etc/x-ui/install-result.env
+    owner: root
+    group: root
+    mode: '0600'
+  tags:
+    - 3x_ui
+    - configure

--- a/ansible/roles/install-3x-ui/tasks/database.yml
+++ b/ansible/roles/install-3x-ui/tasks/database.yml
@@ -1,0 +1,92 @@
+---
+# roles/3x_ui/tasks/database.yml
+
+- name: Configure SQLite Database
+  when: xui_db_type == 'sqlite'
+  tags:
+    - 3x_ui
+    - database
+    - setup
+    - sqlite
+  block:
+    - name: Ensure x-ui configuration directory exists for SQLite
+      ansible.builtin.file:
+        path: /etc/x-ui
+        state: directory
+        mode: '0755'
+
+    - name: Ensure /etc/default/x-ui is absent (forces fallback to SQLite)
+      ansible.builtin.file:
+        path: "{{ '/etc/default/x-ui' if ansible_os_family == 'Debian' else '/etc/sysconfig/x-ui' }}"
+        state: absent
+
+- name: Configure PostgreSQL Database
+  tags:
+    - 3x_ui
+    - database
+    - setup
+    - postgres
+  when: xui_db_type == 'postgres'
+  block:
+    - name: Install PostgreSQL client tools (for in-panel backup/restore)
+      ansible.builtin.package:
+        name: "{{ postgresql_client_package }}"
+        state: present
+
+    - name: Provision local PostgreSQL server
+      when: xui_pg_install_local | bool
+      block:
+        - name: Install PostgreSQL server packages
+          ansible.builtin.package:
+            name: "{{ postgresql_server_packages }}"
+            state: present
+
+        - name: Initialize PostgreSQL database cluster (RedHat/Rocky family)
+          ansible.builtin.command: postgresql-setup --initdb
+          args:
+            creates: /var/lib/pgsql/data/PG_VERSION
+          when: ansible_os_family == 'RedHat'
+
+        - name: Ensure PostgreSQL service is enabled and started
+          ansible.builtin.systemd:
+            name: postgresql
+            state: started
+            enabled: true
+
+        - name: Wait for PostgreSQL to accept connections
+          ansible.builtin.wait_for:
+            port: 5432
+            host: 127.0.0.1
+            delay: 2
+            timeout: 30
+
+        - name: Install Python psycopg2 library (Required for Ansible PostgreSQL modules)
+          ansible.builtin.package:
+            name: "{{ python_psycopg2_package }}"
+            state: present
+
+        - name: Ensure 3x-ui database user exists
+          community.postgresql.postgresql_user:
+            name: "{{ xui_pg_user }}"
+            password: "{{ xui_pg_password }}"
+            role_attr_flags: NOSUPERUSER,NOCREATEDB
+            state: present
+          become: true
+          become_user: postgres
+
+        - name: Ensure 3x-ui database exists and is owned by the user
+          community.postgresql.postgresql_db:
+            name: "{{ xui_pg_database }}"
+            owner: "{{ xui_pg_user }}"
+            state: present
+          become: true
+          become_user: postgres
+
+    - name: Configure 3x-ui to use PostgreSQL (Environment File)
+      ansible.builtin.template:
+        src: x-ui-db.env.j2
+        dest: "{{ '/etc/default/x-ui' if ansible_os_family == 'Debian' else '/etc/sysconfig/x-ui' }}"
+        owner: root
+        group: root
+        mode: '0600'
+      notify: Restart 3x-ui

--- a/ansible/roles/install-3x-ui/tasks/install.yml
+++ b/ansible/roles/install-3x-ui/tasks/install.yml
@@ -1,0 +1,218 @@
+---
+# roles/3x_ui/tasks/install.yml
+
+- name: Resolve GitHub repository tag version
+  tags:
+    - 3x_ui
+    - install
+    - update
+  block:
+    - name: Fetch latest release tag from GitHub API if version is unmapped
+      ansible.builtin.uri:
+        url: "https://api.github.com/repos/MHSanaei/3x-ui/releases/latest"
+        return_content: true
+        status_code: 200
+      register: github_latest_release
+      when: xui_version | default('latest') == 'latest'
+
+    - name: Set target application version fact
+      ansible.builtin.set_fact:
+        xui_target_version: >-
+          {{
+            github_latest_release.json.tag_name
+            if xui_version | default('latest') == 'latest'
+            else xui_version
+          }}
+
+- name: Enforce version constraint parameters
+  ansible.builtin.assert:
+    that:
+      - xui_target_version is defined
+      - xui_target_version is match('^v?[2-9]\.[3-9]\.[5-9].*') or xui_target_version is match('^v?[3-9]\.')
+    fail_msg: "Production deployment requires 3x-ui versions greater than or equal to v2.3.5."
+  tags:
+    - 3x_ui
+    - install
+
+- name: Map architecture matrix facts
+  ansible.builtin.set_fact:
+    xui_arch: "{{ xui_arch_map[ansible_architecture] | default('amd64') }}"
+  tags:
+    - 3x_ui
+    - install
+    - update
+
+- name: Perform pre-flight binary upgrades and process isolation
+  tags:
+    - 3x_ui
+    - update
+  block:
+    - name: Check if x-ui service manager state is active
+      ansible.builtin.service_facts:
+
+    - name: Halt running x-ui service to prevent binary deadlocks
+      ansible.builtin.systemd:
+        name: x-ui
+        state: stopped
+      when: "'x-ui.service' in ansible_facts.services and ansible_facts.services['x-ui.service'].state == 'running'"
+
+    - name: Cleanly terminate orphaned MTProto sidecar processes
+      ansible.builtin.command: pkill -f 'mtg-linux-[^ ]* run '
+      register: pkill_output
+      failed_when: false
+      changed_when: pkill_output.rc == 0
+
+- name: Prepare isolated application directory trees
+  ansible.builtin.file:
+    path: "{{ item.path }}"
+    state: directory
+    owner: root
+    group: root
+    mode: "{{ item.mode }}"
+  loop:
+    - { path: "{{ xui_base_dir }}", mode: '0755' }
+    - { path: "/var/log/x-ui", mode: '0750' }
+    - { path: "/root/cert", mode: '0700' }
+  tags:
+    - 3x_ui
+    - install
+
+- name: Acquire and unpack application distribution components
+  tags:
+    - 3x_ui
+    - install
+    - update
+  block:
+    - name: Securely download release archive binary target
+      ansible.builtin.get_url:
+        url: "https://github.com/MHSanaei/3x-ui/releases/download/{{ xui_target_version }}/x-ui-linux-{{ xui_arch }}.tar.gz"
+        dest: "/tmp/x-ui-linux-{{ xui_arch }}.tar.gz"
+        mode: '0600'
+        force: true
+
+    - name: Extract archive payload directly to target folder
+      ansible.builtin.unarchive:
+        src: "/tmp/x-ui-linux-{{ xui_arch }}.tar.gz"
+        dest: "{{ xui_base_dir | dirname }}"
+        remote_src: true
+
+    - name: Clean temporary downpour downloads archive
+      ansible.builtin.file:
+        path: "/tmp/x-ui-linux-{{ xui_arch }}.tar.gz"
+        state: absent
+
+- name: Normalise multi-architecture compiled binary definitions
+  ansible.builtin.shell: |
+    set -e
+    mv bin/xray-linux-{{ xui_arch }} bin/xray-linux-arm
+    if [ -f bin/mtg-linux-{{ xui_arch }} ]; then
+        mv bin/mtg-linux-{{ xui_arch }} bin/mtg-linux-arm
+    fi
+  args:
+    executable: /bin/bash
+    chdir: "{{ xui_base_dir }}"
+  when: xui_arch in ['armv5', 'armv6', 'armv7']
+  register: arch_rename_state
+  changed_when: arch_rename_state.rc == 0
+  tags:
+    - 3x_ui
+    - install
+
+- name: Restructure global CLI orchestration helpers
+  tags:
+    - 3x_ui
+    - install
+  block:
+    - name: Sync dashboard maintenance wrapper to system binary path
+      ansible.builtin.copy:
+        src: "{{ xui_base_dir }}/x-ui.sh"
+        dest: /usr/bin/x-ui
+        remote_src: true
+        owner: root
+        group: root
+        mode: '0755'
+
+    - name: Enforce strict execution context flags on absolute binaries
+      ansible.builtin.file:
+        path: "{{ item }}"
+        mode: '0755'
+        owner: root
+        group: root
+      loop:
+        - "{{ xui_base_dir }}/x-ui"
+        - "/usr/bin/x-ui"
+
+- name: Secure Xray runtime workspace and satisfy routing asset requirements
+  tags:
+    - 3x_ui
+    - install
+    - update
+  block:
+    - name: Enforce strict permissions on the core bin directory
+      ansible.builtin.file:
+        path: "{{ xui_base_dir }}/bin"
+        state: directory
+        owner: root
+        group: root
+        mode: '0755'
+
+    - name: Enforce execution context flags on the child xray-core binary
+      ansible.builtin.file:
+        path: "{{ xui_base_dir }}/bin/xray-linux-{{ 'arm' if xui_arch in ['armv5', 'armv6', 'armv7'] else xui_arch }}"
+        owner: root
+        group: root
+        mode: '0755'
+        state: file
+
+    - name: Check if MTProto sidecar binary exists
+      ansible.builtin.stat:
+        path: "{{ xui_base_dir }}/bin/mtg-linux-{{ 'arm' if xui_arch in ['armv5', 'armv6', 'armv7'] else xui_arch }}"
+      register: mtg_binary_stat
+
+    - name: Enforce execution context flags on the MTProto sidecar binary
+      ansible.builtin.file:
+        path: "{{ xui_base_dir }}/bin/mtg-linux-{{ 'arm' if xui_arch in ['armv5', 'armv6', 'armv7'] else xui_arch }}"
+        owner: root
+        group: root
+        mode: '0755'
+        state: file
+      when: mtg_binary_stat.stat.exists
+
+    - name: Verify presence of Xray routing geo-assets
+      ansible.builtin.stat:
+        path: "{{ xui_base_dir }}/bin/{{ item }}"
+      register: xray_geo_assets
+      loop:
+        - geoip.dat
+        - geosite.dat
+
+    - name: Download missing Geo data routing assets if absent
+      ansible.builtin.get_url:
+        url: "https://github.com/v2fly/domain-list-community/releases/latest/download/{{ item.item }}"
+        dest: "{{ xui_base_dir }}/bin/{{ item.item }}"
+        owner: root
+        group: root
+        mode: '0644'
+      loop: "{{ xray_geo_assets.results }}"
+      when: not item.stat.exists
+
+- name: Handle revision control engine etckeeper mutations
+  ansible.builtin.stat:
+    path: /etc/.git
+  register: etc_git_env
+  tags:
+    - 3x_ui
+    - install
+
+- name: Append database storage to etckeeper runtime exclusions
+  ansible.builtin.lineinfile:
+    path: /etc/.gitignore
+    line: "x-ui/x-ui.db"
+    create: true
+    mode: '0644'
+    owner: root
+    group: root
+  when: etc_git_env.stat.exists
+  tags:
+    - 3x_ui
+    - install

--- a/ansible/roles/install-3x-ui/tasks/main.yml
+++ b/ansible/roles/install-3x-ui/tasks/main.yml
@@ -1,0 +1,44 @@
+---
+# tasks file for install-3x-ui
+
+- name: Ensure prerequisites and base packages are installed
+  ansible.builtin.include_tasks: prerequisites.yml
+  tags:
+    - 3x_ui
+    - prerequisites
+    - setup
+
+- name: Provision and configure the database (SQLite/PostgreSQL)
+  ansible.builtin.include_tasks: database.yml
+  tags:
+    - 3x_ui
+    - database
+    - setup
+
+- name: Download, extract, and install 3x-ui binaries
+  ansible.builtin.include_tasks: install.yml
+  tags:
+    - 3x_ui
+    - install
+    - update
+
+- name: Setup and configure SSL certificates
+  ansible.builtin.include_tasks: ssl.yml
+  when: xui_ssl_mode != 'none'
+  tags:
+    - 3x_ui
+    - ssl
+    - configure
+
+- name: Apply panel configurations and settings
+  ansible.builtin.include_tasks: configure.yml
+  tags:
+    - 3x_ui
+    - configure
+
+- name: Ensure 3x-ui systemd service is configured and running
+  ansible.builtin.include_tasks: service.yml
+  tags:
+    - 3x_ui
+    - service
+    - setup

--- a/ansible/roles/install-3x-ui/tasks/prerequisites.yml
+++ b/ansible/roles/install-3x-ui/tasks/prerequisites.yml
@@ -1,0 +1,149 @@
+---
+# roles/3x_ui/tasks/prerequisites.yml
+
+- name: Verify operating system support
+  ansible.builtin.assert:
+    that:
+      - ansible_os_family in ['Debian', 'RedHat', 'Archlinux', 'Suse', 'Alpine']
+    fail_msg: "Deployment aborted: {{ ansible_distribution }} ({{ ansible_os_family }}) is not supported."
+    success_msg: "OS verified: {{ ansible_distribution }} is supported."
+  tags:
+    - 3x_ui
+    - prerequisites
+    - setup
+    - check_os
+
+- name: Load OS-specific package variables
+  ansible.builtin.include_vars: "{{ item }}"
+  with_first_found:
+    - files:
+        - "{{ ansible_distribution }}.yml"
+        - "{{ ansible_os_family }}.yml"
+        - "main.yml"
+      paths:
+        - "../vars"
+  tags:
+    - 3x_ui
+    - prerequisites
+    - setup
+    - os_vars
+
+- name: Install prerequisites on Debian/Ubuntu
+  ansible.builtin.apt:
+    name:
+      - cron
+      - curl
+      - tar
+      - tzdata
+      - socat
+      - ca-certificates
+      - openssl
+    state: present
+    update_cache: true
+    cache_valid_time: 3600
+  when: ansible_os_family == 'Debian'
+  tags:
+    - 3x_ui
+    - prerequisites
+    - setup
+    - install-pre-deb
+
+- name: Install prerequisites on modern RedHat/CentOS/Fedora/Rocky (DNF)
+  ansible.builtin.dnf:
+    name:
+      - cronie
+      - curl
+      - tar
+      - tzdata
+      - socat
+      - ca-certificates
+      - openssl
+    state: present
+    update_cache: true
+  when:
+    - ansible_os_family == 'RedHat'
+    - ansible_distribution_major_version | int >= 8 or ansible_distribution == 'Fedora'
+  tags:
+    - 3x_ui
+    - prerequisites
+    - setup
+    - install-pre-rhe
+
+- name: Install prerequisites on Legacy RHEL / CentOS 7 (YUM)
+  ansible.builtin.package:
+    name:
+      - cronie
+      - curl
+      - tar
+      - tzdata
+      - socat
+      - ca-certificates
+      - openssl
+    state: present
+    update_cache: true
+  when:
+    - ansible_os_family == 'RedHat'
+    - ansible_distribution_major_version | int <= 7
+    - ansible_distribution != 'Fedora'
+  tags:
+    - 3x_ui
+    - prerequisites
+    - setup
+    - install-pre-leg-rhe
+
+- name: Install prerequisites on Arch Linux / Manjaro
+  community.general.pacman:
+    name:
+      - cronie
+      - curl
+      - tar
+      - tzdata
+      - socat
+      - ca-certificates
+      - openssl
+    state: present
+    update_cache: true
+  when: ansible_os_family == 'Archlinux'
+  tags:
+    - 3x_ui
+    - prerequisites
+    - setup
+    - install-pre-arch
+
+- name: Install prerequisites on SUSE Linux
+  community.general.zypper:
+    name:
+      - cron
+      - curl
+      - tar
+      - timezone
+      - socat
+      - ca-certificates
+      - openssl
+    state: present
+    update_cache: true
+  when: ansible_os_family == 'Suse'
+  tags:
+    - 3x_ui
+    - prerequisites
+    - setup
+    - install-pre-suse
+
+- name: Install prerequisites on Alpine Linux
+  community.general.apk:
+    name:
+      - dcron
+      - curl
+      - tar
+      - tzdata
+      - socat
+      - ca-certificates
+      - openssl
+    state: present
+    update_cache: true
+  when: ansible_os_family == 'Alpine'
+  tags:
+    - 3x_ui
+    - prerequisites
+    - setup
+    - install-pre-alpine

--- a/ansible/roles/install-3x-ui/tasks/service.yml
+++ b/ansible/roles/install-3x-ui/tasks/service.yml
@@ -1,0 +1,56 @@
+---
+# roles/3x_ui/tasks/service.yml
+
+- name: Determine dynamic platform configuration attributes
+  ansible.builtin.set_fact:
+    xui_service_manager: "{{ ansible_facts['service_mgr'] }}"
+    xui_env_file_path: >-
+      {% if ansible_facts['os_family'] == 'Debian' %}
+      /etc/default/x-ui
+      {% elif ansible_facts['os_family'] == 'Archlinux' or ansible_facts['os_family'] == 'Alpine' %}
+      /etc/conf.d/x-ui
+      {% else %}
+      /etc/sysconfig/x-ui
+      {% endif %}
+  tags:
+    - 3x_ui
+    - service
+    - setup
+
+- name: Configure Linux Systemd service unit descriptor
+  ansible.builtin.template:
+    src: x-ui.service.j2
+    dest: /etc/systemd/system/x-ui.service
+    owner: root
+    group: root
+    mode: '0644'
+  register: systemd_unit_file
+  when: xui_service_manager == 'systemd'
+  notify: Reload systemd daemon
+  tags:
+    - 3x_ui
+    - service
+    - setup
+
+- name: Configure Alpine Linux OpenRC execution script
+  ansible.builtin.template:
+    src: x-ui.rc.j2
+    dest: /etc/init.d/x-ui
+    owner: root
+    group: root
+    mode: '0755'
+  when: ansible_facts['os_family'] == 'Alpine' or xui_service_manager == 'openrc'
+  tags:
+    - 3x_ui
+    - service
+    - setup
+
+- name: Enforce operational state and autostart policy for 3x-ui daemon
+  ansible.builtin.service:
+    name: x-ui
+    state: started
+    enabled: true
+  tags:
+    - 3x_ui
+    - service
+    - setup

--- a/ansible/roles/install-3x-ui/tasks/ssl.yml
+++ b/ansible/roles/install-3x-ui/tasks/ssl.yml
@@ -1,0 +1,157 @@
+---
+# roles/3x_ui/tasks/ssl.yml
+
+- name: Handle Custom SSL Certificates
+  when: xui_ssl_mode == 'custom'
+  tags:
+    - 3x_ui
+    - ssl
+    - configure
+  block:
+    - name: Verify custom certificate files exist on target host
+      ansible.builtin.stat:
+        path: "{{ item }}"
+      register: custom_cert_stat
+      loop:
+        - "{{ xui_ssl_custom_cert }}"
+        - "{{ xui_ssl_custom_key }}"
+
+    - name: Fail if custom certificates are missing
+      ansible.builtin.assert:
+        that: item.stat.exists
+        fail_msg: "Custom SSL file {{ item.item }} does not exist! Please ensure files are provisioned before running."
+      loop: "{{ custom_cert_stat.results }}"
+
+    - name: Set certificate path facts for custom mode
+      ansible.builtin.set_fact:
+        xui_final_cert_path: "{{ xui_ssl_custom_cert }}"
+        xui_final_key_path: "{{ xui_ssl_custom_key }}"
+
+- name: Handle Automated Let's Encrypt via acme.sh (Domain or IP)
+  when: xui_ssl_mode in ['domain', 'ip']
+  tags:
+    - 3x_ui
+    - ssl
+    - configure
+  block:
+    - name: Define ACME target entity (Domain or IP)
+      ansible.builtin.set_fact:
+        xui_acme_target: "{{ xui_domain if xui_ssl_mode == 'domain' else ansible_host }}"
+
+    - name: Ensure certificate storage directory exists
+      ansible.builtin.file:
+        path: "/root/cert/{{ xui_acme_target }}"
+        state: directory
+        mode: '0700'
+
+    - name: Check if acme.sh is already installed
+      ansible.builtin.stat:
+        path: /root/.acme.sh/acme.sh
+      register: acme_sh_stat
+
+    - name: Bootstrap acme.sh installation
+      when: not acme_sh_stat.stat.exists
+      block:
+        - name: Ensure socat and git are installed (Required by acme.sh standalone)
+          ansible.builtin.package:
+            name:
+              - git
+              - socat
+            state: present
+
+        - name: Clone acme.sh repository
+          ansible.builtin.git:
+            repo: https://github.com/acmesh-official/acme.sh.git
+            dest: /usr/local/src/acme.sh
+            version: "{{ xui_acme_sh_version }}"
+            depth: 1
+
+        - name: Install acme.sh globally
+          ansible.builtin.command: >
+            ./acme.sh --install --noprofile --home /root/.acme.sh --accountemail "{{ xui_acme_email }}"
+          args:
+            chdir: /usr/local/src/acme.sh
+            creates: /root/.acme.sh/acme.sh
+
+        - name: Set Let's Encrypt default CA
+          ansible.builtin.command: /root/.acme.sh/acme.sh --set-default-ca --server letsencrypt
+          changed_when: false
+
+    - name: Execute ACME Standalone Challenge
+      block:
+        - name: Stop x-ui service temporarily to free Port 80 for HTTP-01 challenge
+          ansible.builtin.systemd:
+            name: x-ui
+            state: stopped
+          failed_when: false # Ignore if service doesn't exist yet
+
+        - name: Issue Certificate (Domain Mode)
+          ansible.builtin.command: >
+            /root/.acme.sh/acme.sh --issue -d {{ xui_acme_target }} --standalone --httpport 80 --force
+          args:
+            creates: "/root/.acme.sh/{{ xui_acme_target }}/{{ xui_acme_target }}.cer"
+          when: xui_ssl_mode == 'domain'
+
+        - name: Issue Certificate (IP Mode - Shortlived 6-day profile)
+          ansible.builtin.command: >
+            /root/.acme.sh/acme.sh --issue
+            -d {{ xui_acme_target }}
+            --standalone
+            --server letsencrypt
+            --certificate-profile shortlived
+            --days 6
+            --httpport 80
+            --force
+          args:
+            creates: "/root/.acme.sh/{{ xui_acme_target }}/{{ xui_acme_target }}.cer"
+          when: xui_ssl_mode == 'ip'
+
+        - name: Install Certificate to application directory
+          ansible.builtin.command: >
+            /root/.acme.sh/acme.sh --installcert -d {{ xui_acme_target }}
+            --key-file /root/cert/{{ xui_acme_target }}/privkey.pem
+            --fullchain-file /root/cert/{{ xui_acme_target }}/fullchain.pem
+          args:
+            creates: "/root/cert/{{ xui_acme_target }}/fullchain.pem"
+          notify: Restart 3x-ui
+
+      always:
+        - name: Ensure x-ui service is restarted after challenge completes
+          ansible.builtin.systemd:
+            name: x-ui
+            state: started
+          failed_when: false
+
+    - name: Ensure strict permissions on installed certificates
+      ansible.builtin.file:
+        path: "{{ item.path }}"
+        mode: "{{ item.mode }}"
+      loop:
+        - { path: "/root/cert/{{ xui_acme_target }}/privkey.pem", mode: '0600' }
+        - { path: "/root/cert/{{ xui_acme_target }}/fullchain.pem", mode: '0644' }
+
+    - name: Set certificate path facts for ACME mode
+      ansible.builtin.set_fact:
+        xui_final_cert_path: "/root/cert/{{ xui_acme_target }}/fullchain.pem"
+        xui_final_key_path: "/root/cert/{{ xui_acme_target }}/privkey.pem"
+
+- name: Apply SSL Configuration to 3x-ui Panel Database
+  tags:
+    - 3x_ui
+    - ssl
+    - configure
+  block:
+    - name: Check current panel certificate configuration
+      ansible.builtin.command: "{{ xui_base_dir }}/x-ui setting -getCert true"
+      register: xui_current_cert
+      changed_when: false
+      failed_when: false
+
+    - name: Configure panel to use specified SSL paths
+      ansible.builtin.command: >
+        {{ xui_base_dir }}/x-ui cert
+        -webCert {{ xui_final_cert_path }}
+        -webCertKey {{ xui_final_key_path }}
+      when: xui_final_cert_path not in xui_current_cert.stdout
+      changed_when: xui_final_cert_path not in xui_current_cert.stdout
+      notify: Restart 3x-ui

--- a/ansible/roles/install-3x-ui/templates/install-result.env.j2
+++ b/ansible/roles/install-3x-ui/templates/install-result.env.j2
@@ -1,0 +1,10 @@
+# {{ ansible_managed }}
+
+# Machine-parseable node credentials and metadata receipt
+XUI_USERNAME={{ xui_username | quote }}
+XUI_PASSWORD={{ xui_password | quote }}
+XUI_PANEL_PORT={{ xui_port }}
+XUI_WEB_BASE_PATH={{ xui_web_base_path | regex_replace('^/', '') | quote }}
+XUI_ACCESS_URL={{ (xui_ssl_mode == 'none') | ternary('http', 'https') }}://{{ xui_ssl_domain | default(ansible_default_ipv4.address | default('127.0.0.1')) }}:{{ xui_port }}/{{ xui_web_base_path | regex_replace('^/', '') }}
+XUI_API_TOKEN={{ xui_api_token | quote }}
+XUI_DB_TYPE={{ xui_db_type | default('sqlite') }}

--- a/ansible/roles/install-3x-ui/templates/x-ui-db.env.j2
+++ b/ansible/roles/install-3x-ui/templates/x-ui-db.env.j2
@@ -1,0 +1,6 @@
+# {{ ansible_managed }}
+
+XUI_DB_TYPE={{ xui_db_type }}
+{% if xui_db_type == 'postgres' %}
+XUI_DB_DSN={{ xui_db_dsn }}
+{% endif %}

--- a/ansible/roles/install-3x-ui/templates/x-ui-panel.env.j2
+++ b/ansible/roles/install-3x-ui/templates/x-ui-panel.env.j2
@@ -1,0 +1,7 @@
+# {{ ansible_managed }}
+
+# System daemon runtime variables tracking database backends
+XUI_DB_TYPE={{ xui_db_type | default('sqlite') }}
+{% if xui_db_type == 'postgres' %}
+XUI_DB_DSN={{ xui_db_dsn }}
+{% endif %}

--- a/ansible/roles/install-3x-ui/templates/x-ui.rc.j2
+++ b/ansible/roles/install-3x-ui/templates/x-ui.rc.j2
@@ -1,0 +1,18 @@
+#!/sbin/openrc-run
+
+description="3x-ui Panel Manager Core Daemon"
+supervisor="supervise-daemon"
+command="{{ xui_folder | default('/usr/local/x-ui') }}/x-ui"
+command_background="true"
+directory="{{ xui_folder | default('/usr/local/x-ui') }}"
+
+depend() {
+    need net
+    after firewall
+}
+
+start_pre() {
+    if [ -f "{{ xui_env_file_path }}" ]; then
+        . "{{ xui_env_file_path }}"
+    fi
+}

--- a/ansible/roles/install-3x-ui/templates/x-ui.service.j2
+++ b/ansible/roles/install-3x-ui/templates/x-ui.service.j2
@@ -1,0 +1,19 @@
+[Unit]
+Description=3x-ui Panel Daemon
+After=network.target nss-lookup.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+User=root
+CapabilityBoundingSet=CAP_NET_ADMIN CAP_NET_BIND_SERVICE
+AmbientCapabilities=CAP_NET_ADMIN CAP_NET_BIND_SERVICE
+NoNewPrivileges=true
+WorkingDirectory={{ xui_folder | default('/usr/local/x-ui') }}
+ExecStart={{ xui_folder | default('/usr/local/x-ui') }}/x-ui
+Restart=on-failure
+RestartSec=5s
+EnvironmentFile=-{{ xui_env_file_path }}
+
+[Install]
+WantedBy=multi-user.target

--- a/ansible/roles/install-3x-ui/vars/Debian.yml
+++ b/ansible/roles/install-3x-ui/vars/Debian.yml
@@ -1,0 +1,6 @@
+---
+postgresql_client_package: "postgresql-client"
+postgresql_server_packages:
+  - postgresql
+  - postgresql-contrib
+python_psycopg2_package: "python3-psycopg2"

--- a/ansible/roles/install-3x-ui/vars/RedHat.yml
+++ b/ansible/roles/install-3x-ui/vars/RedHat.yml
@@ -1,0 +1,6 @@
+---
+postgresql_client_package: "postgresql"
+postgresql_server_packages:
+  - postgresql-server
+  - postgresql-contrib
+python_psycopg2_package: "python3-psycopg2"

--- a/ansible/roles/install-3x-ui/vars/main.yml
+++ b/ansible/roles/install-3x-ui/vars/main.yml
@@ -1,0 +1,2 @@
+---
+# vars file for install-3x-ui


### PR DESCRIPTION
Hi.
I put together an Ansible setup for 3x-ui to make deploying and managing the panel a lot easier, especially for folks running multiple nodes.

The current shell script is great for single servers, but managing things across a cluster manually gets tricky. I wanted to provide a way to automate the whole stack.

**Why this helps:**

1. No more manual setups: You can spin up identical panel nodes from scratch without running through the steps by hand every time.

2. Handles the annoying stuff: It automatically takes care of firewall rules (like firewalld) and Let's Encrypt SSL via acme.sh so you don't have to mess with port 80 routing manually.

3. Safe to rerun: It's idempotent. You can run the playbook again to update configs or fix a broken state without worrying about wiping the SQLite database or dropping active Xray tunnels.

**What's inside:**

- inventory.sample.yml: A quick template for users to define their servers.

- playbook.yml: The main entry point to kick off the deployment.

- roles/install-3x-ui/: The actual automation logic (handles prerequisites, pulling binaries, SSL, and creating the systemd service).

**Testing**

I built and tested this primarily on Debian-based systems (Debian 12 and Ubuntu 20.04 - 24.04). The Xray-core service initializes perfectly under systemd and the web UI spins up without issues.


> I think it would be great if this repository also included an Ansible role, since it would solve a problem I was facing.