### PR TITLE
fix(wireguard): restore client config UX

### DIFF
--- a/frontend/public/openapi.json
+++ b/frontend/public/openapi.json
@@ -1854,6 +1854,12 @@
           "tlsFlowCapable": {
             "example": true,
             "type": "boolean"
+          },
+          "wgMtu": {
+            "type": "integer"
+          },
+          "wgPublicKey": {
+            "type": "string"
           }
         },
         "required": [
@@ -2751,7 +2757,9 @@
                       "remark": "VLESS-443",
                       "ssMethod": "",
                       "tag": "in-443-tcp",
-                      "tlsFlowCapable": true
+                      "tlsFlowCapable": true,
+                      "wgMtu": 0,
+                      "wgPublicKey": ""
                     }
                   ]
                 }

--- a/frontend/src/generated/examples.ts
+++ b/frontend/src/generated/examples.ts
@@ -406,7 +406,9 @@ export const EXAMPLES: Record<string, unknown> = {
     "remark": "VLESS-443",
     "ssMethod": "",
     "tag": "in-443-tcp",
-    "tlsFlowCapable": true
+    "tlsFlowCapable": true,
+    "wgMtu": 0,
+    "wgPublicKey": ""
   },
   "Msg": {
     "msg": "",

--- a/frontend/src/generated/schemas.ts
+++ b/frontend/src/generated/schemas.ts
@@ -1828,6 +1828,12 @@ export const SCHEMAS: Record<string, unknown> = {
       "tlsFlowCapable": {
         "example": true,
         "type": "boolean"
+      },
+      "wgMtu": {
+        "type": "integer"
+      },
+      "wgPublicKey": {
+        "type": "string"
       }
     },
     "required": [

--- a/frontend/src/generated/types.ts
+++ b/frontend/src/generated/types.ts
@@ -401,6 +401,8 @@ export interface InboundOption {
   ssMethod: string;
   tag: string;
   tlsFlowCapable: boolean;
+  wgMtu?: number;
+  wgPublicKey?: string;
 }
 
 export interface Msg {

--- a/frontend/src/generated/zod.ts
+++ b/frontend/src/generated/zod.ts
@@ -428,6 +428,8 @@ export const InboundOptionSchema = z.object({
   ssMethod: z.string(),
   tag: z.string(),
   tlsFlowCapable: z.boolean(),
+  wgMtu: z.number().int().optional(),
+  wgPublicKey: z.string().optional(),
 });
 export type InboundOption = z.infer<typeof InboundOptionSchema>;
 

--- a/frontend/src/hooks/useClients.ts
+++ b/frontend/src/hooks/useClients.ts
@@ -47,6 +47,7 @@ interface SubSettings {
   subJsonEnable: boolean;
   subClashURI: string;
   subClashEnable: boolean;
+  publicHost: string;
 }
 
 export interface ClientQueryParams {
@@ -240,6 +241,7 @@ export function useClients() {
     subJsonEnable: !!defaults.subJsonEnable,
     subClashURI: (defaults.subClashURI as string) || '',
     subClashEnable: !!defaults.subClashEnable,
+    publicHost: (defaults.subDomain as string) || (defaults.webDomain as string) || '',
   }), [
     defaults.subEnable,
     defaults.subURI,
@@ -247,6 +249,8 @@ export function useClients() {
     defaults.subJsonEnable,
     defaults.subClashURI,
     defaults.subClashEnable,
+    defaults.subDomain,
+    defaults.webDomain,
   ]);
 
   const ipLimitEnable = !!defaults.ipLimitEnable;

--- a/frontend/src/pages/clients/ClientFormModal.tsx
+++ b/frontend/src/pages/clients/ClientFormModal.tsx
@@ -19,10 +19,10 @@ import {
   Typography,
   message,
 } from 'antd';
-import { DeleteOutlined, EyeOutlined, PlusOutlined, ReloadOutlined, RetweetOutlined } from '@ant-design/icons';
+import { CopyOutlined, DeleteOutlined, DownloadOutlined, EyeOutlined, PlusOutlined, ReloadOutlined, RetweetOutlined } from '@ant-design/icons';
 import dayjs from 'dayjs';
 import type { Dayjs } from 'dayjs';
-import { HttpUtil, RandomUtil, Wireguard } from '@/utils';
+import { ClipboardManager, FileManager, HttpUtil, RandomUtil, Wireguard } from '@/utils';
 import { formatInboundLabel } from '@/lib/inbounds/label';
 import { normalizeClientIps, type ClientIpInfo } from '@/lib/clients/ip-log';
 import { DateTimePicker, SelectAllClearButtons } from '@/components/form';
@@ -30,6 +30,7 @@ import { TLS_FLOW_CONTROL } from '@/schemas/primitives';
 import type { ClientRecord, InboundOption, ExternalLink, ExternalLinkInput } from '@/hooks/useClients';
 import { useFail2banStatusQuery, getLimitIpNotice } from '@/api/queries/useFail2banStatusQuery';
 import { ClientFormSchema, ClientCreateFormSchema } from '@/schemas/client';
+import { buildWireguardClientConfig } from './wireguardConfig';
 
 const FLOW_OPTIONS = Object.values(TLS_FLOW_CONTROL);
 const VMESS_SECURITY_OPTIONS = ['auto', 'aes-128-gcm', 'chacha20-poly1305', 'none', 'zero'] as const;
@@ -344,6 +345,26 @@ export default function ClientFormModal({
     () => (form.inboundIds || []).some((id) => wireguardIds.has(id)),
     [form.inboundIds, wireguardIds],
   );
+
+  const wgInbound = useMemo(
+    () => (form.inboundIds || [])
+      .map((id) => (inbounds || []).find((row) => row.id === id))
+      .find((row) => row?.protocol === 'wireguard'),
+    [form.inboundIds, inbounds],
+  );
+
+  const wgConfigText = useMemo(() => {
+    if (!showWireguard) return '';
+    return buildWireguardClientConfig({
+      email: form.email,
+      comment: form.comment,
+      privateKey: form.wgPrivateKey,
+      publicKey: form.wgPublicKey,
+      allowedIPs: form.wgAllowedIPs || '10.0.0.2/32',
+      preSharedKey: form.wgPreSharedKey,
+      inboundIds: form.inboundIds,
+    } as ClientRecord, wgInbound);
+  }, [showWireguard, form.email, form.comment, form.wgPrivateKey, form.wgPublicKey, form.wgAllowedIPs, form.wgPreSharedKey, form.inboundIds, wgInbound]);
 
   function regenerateWireguardKeys() {
     const kp = Wireguard.generateKeypair();
@@ -863,6 +884,35 @@ export default function ClientFormModal({
                   </>
                 ),
               },
+              ...(showWireguard ? [{
+                key: 'wg-config',
+                label: 'WireGuard config',
+                children: (
+                  <div>
+                    <div style={{ display: 'flex', justifyContent: 'flex-end', gap: 8, marginBottom: 8 }}>
+                      <Tooltip title={t('copy')}>
+                        <Button size="small" icon={<CopyOutlined />} onClick={() => ClipboardManager.copyText(wgConfigText)} />
+                      </Tooltip>
+                      <Tooltip title={t('download')}>
+                        <Button size="small" icon={<DownloadOutlined />} onClick={() => FileManager.downloadTextFile(wgConfigText, `${form.email || 'peer'}.conf`)} />
+                      </Tooltip>
+                    </div>
+                    <pre style={{
+                      background: 'var(--ant-color-fill-quaternary, #f5f5f5)',
+                      borderRadius: 6,
+                      padding: '10px 14px',
+                      margin: 0,
+                      maxHeight: 320,
+                      overflow: 'auto',
+                      fontSize: 12,
+                      whiteSpace: 'pre-wrap',
+                      userSelect: 'all',
+                    }}>
+                      {wgConfigText}
+                    </pre>
+                  </div>
+                ),
+              }] : []),
             ]}
           />
         </Form>

--- a/frontend/src/pages/clients/ClientFormModal.tsx
+++ b/frontend/src/pages/clients/ClientFormModal.tsx
@@ -81,6 +81,7 @@ interface ClientFormModalProps {
   mode: Mode;
   client: ClientRecord | null;
   inbounds: InboundOption[];
+  publicHost?: string;
   attachedExternalLinks?: ExternalLink[];
   attachedIds?: number[];
   tgBotEnable?: boolean;
@@ -173,6 +174,7 @@ export default function ClientFormModal({
   mode,
   client,
   inbounds,
+  publicHost = '',
   attachedExternalLinks = [],
   attachedIds = [],
   tgBotEnable = false,
@@ -363,8 +365,8 @@ export default function ClientFormModal({
       allowedIPs: form.wgAllowedIPs || '10.0.0.2/32',
       preSharedKey: form.wgPreSharedKey,
       inboundIds: form.inboundIds,
-    } as ClientRecord, wgInbound);
-  }, [showWireguard, form.email, form.comment, form.wgPrivateKey, form.wgPublicKey, form.wgAllowedIPs, form.wgPreSharedKey, form.inboundIds, wgInbound]);
+    } as ClientRecord, wgInbound, window.location.hostname, publicHost);
+  }, [showWireguard, form.email, form.comment, form.wgPrivateKey, form.wgPublicKey, form.wgAllowedIPs, form.wgPreSharedKey, form.inboundIds, wgInbound, publicHost]);
 
   function regenerateWireguardKeys() {
     const kp = Wireguard.generateKeypair();
@@ -886,7 +888,7 @@ export default function ClientFormModal({
               },
               ...(showWireguard ? [{
                 key: 'wg-config',
-                label: 'WireGuard config',
+                label: t('pages.clients.wireguardConfig'),
                 children: (
                   <div>
                     <div style={{ display: 'flex', justifyContent: 'flex-end', gap: 8, marginBottom: 8 }}>

--- a/frontend/src/pages/clients/ClientInfoModal.css
+++ b/frontend/src/pages/clients/ClientInfoModal.css
@@ -129,6 +129,11 @@
   white-space: nowrap;
 }
 
+.link-row-title--wrap {
+  word-break: break-all;
+  white-space: normal;
+}
+
 .link-row-actions {
   display: flex;
   gap: 4px;

--- a/frontend/src/pages/clients/ClientInfoModal.tsx
+++ b/frontend/src/pages/clients/ClientInfoModal.tsx
@@ -36,6 +36,7 @@ interface SubSettings {
   subJsonEnable: boolean;
   subClashURI: string;
   subClashEnable: boolean;
+  publicHost?: string;
 }
 
 interface ClientInfoModalProps {
@@ -59,6 +60,7 @@ const DEFAULT_SUB: SubSettings = {
   subJsonEnable: false,
   subClashURI: '',
   subClashEnable: false,
+  publicHost: '',
 };
 
 export default function ClientInfoModal({
@@ -136,8 +138,8 @@ export default function ClientInfoModal({
   const wgInbound = useMemo(() => findWireguardInbound(client, inboundsById), [client, inboundsById]);
   const wgConfigText = useMemo(() => {
     if (!client || !isWireguardClient(client)) return '';
-    return buildWireguardClientConfig(client, wgInbound);
-  }, [client, wgInbound]);
+    return buildWireguardClientConfig(client, wgInbound, window.location.hostname, subSettings?.publicHost ?? '');
+  }, [client, wgInbound, subSettings?.publicHost]);
 
   async function copyValue(text: string) {
     if (!text) return;
@@ -358,9 +360,9 @@ export default function ClientInfoModal({
 
             {wgConfigText && client && (
               <>
-                <Divider>WireGuard config</Divider>
+                <Divider>{t('pages.clients.wireguardConfig')}</Divider>
                 <div className="link-row" style={{ alignItems: 'flex-start' }}>
-                  <Tag color="gold" className="link-row-tag" style={{ marginTop: 2 }}>CONF</Tag>
+                  <Tag color="gold" className="link-row-tag" style={{ marginTop: 2 }}>{t('pages.clients.conf')}</Tag>
                   <span className="link-row-title link-row-title--wrap">{wgConfigText}</span>
                   <div className="link-row-actions" style={{ marginTop: 2 }}>
                     <Tooltip title={t('copy')}>

--- a/frontend/src/pages/clients/ClientInfoModal.tsx
+++ b/frontend/src/pages/clients/ClientInfoModal.tsx
@@ -1,9 +1,9 @@
 import { useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Button, Divider, Modal, Popover, Tag, Tooltip, message } from 'antd';
-import { CopyOutlined, EyeOutlined, QrcodeOutlined, ReloadOutlined } from '@ant-design/icons';
+import { CopyOutlined, DownloadOutlined, EyeOutlined, QrcodeOutlined, ReloadOutlined } from '@ant-design/icons';
 
-import { ClipboardManager, HttpUtil, IntlUtil, SizeFormatter } from '@/utils';
+import { ClipboardManager, FileManager, HttpUtil, IntlUtil, SizeFormatter } from '@/utils';
 import { formatInboundLabel } from '@/lib/inbounds/label';
 import { normalizeClientIps, type ClientIpInfo } from '@/lib/clients/ip-log';
 import { useDatepicker } from '@/hooks/useDatepicker';
@@ -11,6 +11,7 @@ import type { ClientRecord, InboundOption } from '@/hooks/useClients';
 import { isPostQuantumLink } from '@/lib/xray/inbound-link';
 import { LinkTags, linkMetaText, parseLinkParts } from '@/lib/xray/link-label';
 import { QrPanel } from '@/pages/inbounds/qr';
+import { buildWireguardClientConfig, findWireguardInbound, isWireguardClient } from './wireguardConfig';
 import './ClientInfoModal.css';
 
 const INBOUND_PROTOCOL_COLORS: Record<string, string> = {
@@ -132,6 +133,11 @@ export default function ClientInfoModal({
   }, [client?.subId, subSettings?.subClashEnable, subSettings?.subClashURI]);
 
   const showSubscription = !!(subSettings?.enable && client?.subId);
+  const wgInbound = useMemo(() => findWireguardInbound(client, inboundsById), [client, inboundsById]);
+  const wgConfigText = useMemo(() => {
+    if (!client || !isWireguardClient(client)) return '';
+    return buildWireguardClientConfig(client, wgInbound);
+  }, [client, wgInbound]);
 
   async function copyValue(text: string) {
     if (!text) return;
@@ -350,6 +356,34 @@ export default function ClientInfoModal({
               </tbody>
             </table>
 
+            {wgConfigText && client && (
+              <>
+                <Divider>WireGuard config</Divider>
+                <div className="link-row" style={{ alignItems: 'flex-start' }}>
+                  <Tag color="gold" className="link-row-tag" style={{ marginTop: 2 }}>CONF</Tag>
+                  <span className="link-row-title link-row-title--wrap">{wgConfigText}</span>
+                  <div className="link-row-actions" style={{ marginTop: 2 }}>
+                    <Tooltip title={t('copy')}>
+                      <Button size="small" icon={<CopyOutlined />} onClick={() => copyValue(wgConfigText)} />
+                    </Tooltip>
+                    <Tooltip title={t('download')}>
+                      <Button size="small" icon={<DownloadOutlined />} onClick={() => FileManager.downloadTextFile(wgConfigText, `${client.email}.conf`)} />
+                    </Tooltip>
+                    <Popover
+                      trigger="click"
+                      placement="left"
+                      destroyOnHidden
+                      content={<QrPanel value={wgConfigText} remark={client.email || 'peer'} size={220} />}
+                    >
+                      <Tooltip title={t('pages.clients.qrCode')}>
+                        <Button size="small" icon={<QrcodeOutlined />} />
+                      </Tooltip>
+                    </Popover>
+                  </div>
+                </div>
+              </>
+            )}
+
             {links.length > 0 && (
               <>
                 <Divider>{t('pages.inbounds.copyLink')}</Divider>
@@ -358,14 +392,17 @@ export default function ClientInfoModal({
                   const fallback = `${t('pages.clients.link')} ${idx + 1}`;
                   const rowTitle = (parts && linkMetaText(parts)) || fallback;
                   const qrRemark = parts?.remark || rowTitle;
-                  const canQr = !isPostQuantumLink(link);
+                  const isWireguardLink = link.startsWith('wireguard://') || link.startsWith('wg://');
+                  const canQr = !isWireguardLink && !isPostQuantumLink(link);
                   return (
-                    <div key={idx} className="link-row">
+                    <div key={idx} className="link-row" style={isWireguardLink ? { alignItems: 'flex-start' } : undefined}>
                       {parts
                         ? <LinkTags parts={parts} />
                         : <Tag className="link-row-tag">LINK</Tag>}
-                      <span className="link-row-title" title={rowTitle}>{rowTitle}</span>
-                      <div className="link-row-actions">
+                      <span className={`link-row-title${isWireguardLink ? ' link-row-title--wrap' : ''}`} title={isWireguardLink ? link : rowTitle}>
+                        {isWireguardLink ? link : rowTitle}
+                      </span>
+                      <div className="link-row-actions" style={isWireguardLink ? { marginTop: 2 } : undefined}>
                         <Tooltip title={t('copy')}>
                           <Button size="small" icon={<CopyOutlined />} onClick={() => copyValue(link)} />
                         </Tooltip>

--- a/frontend/src/pages/clients/ClientQrModal.tsx
+++ b/frontend/src/pages/clients/ClientQrModal.tsx
@@ -13,6 +13,7 @@ interface SubSettings {
   subURI: string;
   subJsonURI: string;
   subJsonEnable: boolean;
+  publicHost?: string;
 }
 
 interface ClientQrModalProps {
@@ -28,7 +29,7 @@ interface ApiMsg<T = unknown> {
   obj?: T;
 }
 
-const DEFAULT_SUB: SubSettings = { enable: false, subURI: '', subJsonURI: '', subJsonEnable: false };
+const DEFAULT_SUB: SubSettings = { enable: false, subURI: '', subJsonURI: '', subJsonEnable: false, publicHost: '' };
 
 export default function ClientQrModal({
   open,
@@ -55,8 +56,8 @@ export default function ClientQrModal({
   const wgInbound = useMemo(() => findWireguardInbound(client, inboundsById), [client, inboundsById]);
   const wgConfigText = useMemo(() => {
     if (!client || !isWireguardClient(client)) return '';
-    return buildWireguardClientConfig(client, wgInbound);
-  }, [client, wgInbound]);
+    return buildWireguardClientConfig(client, wgInbound, window.location.hostname, subSettings?.publicHost ?? '');
+  }, [client, wgInbound, subSettings?.publicHost]);
 
   const hasAnything = !!subLink || !!subJsonLink || !!wgConfigText || links.length > 0;
 
@@ -89,7 +90,7 @@ export default function ClientQrModal({
     if (wgConfigText) {
       out.push({
         key: 'wg-config',
-        label: 'WireGuard config',
+        label: t('pages.clients.wireguardConfig'),
         children: (
           <QrPanel
             value={wgConfigText}

--- a/frontend/src/pages/clients/ClientQrModal.tsx
+++ b/frontend/src/pages/clients/ClientQrModal.tsx
@@ -5,7 +5,8 @@ import { HttpUtil } from '@/utils';
 import { isPostQuantumLink } from '@/lib/xray/inbound-link';
 import { LinkTags, linkMetaText, parseLinkParts } from '@/lib/xray/link-label';
 import { QrPanel } from '@/pages/inbounds/qr';
-import type { ClientRecord } from '@/hooks/useClients';
+import type { ClientRecord, InboundOption } from '@/hooks/useClients';
+import { buildWireguardClientConfig, findWireguardInbound, isWireguardClient } from './wireguardConfig';
 
 interface SubSettings {
   enable: boolean;
@@ -17,6 +18,7 @@ interface SubSettings {
 interface ClientQrModalProps {
   open: boolean;
   client: ClientRecord | null;
+  inboundsById: Record<number, InboundOption>;
   subSettings?: SubSettings;
   onOpenChange: (open: boolean) => void;
 }
@@ -31,6 +33,7 @@ const DEFAULT_SUB: SubSettings = { enable: false, subURI: '', subJsonURI: '', su
 export default function ClientQrModal({
   open,
   client,
+  inboundsById,
   subSettings = DEFAULT_SUB,
   onOpenChange,
 }: ClientQrModalProps) {
@@ -49,7 +52,13 @@ export default function ClientQrModal({
     return subSettings.subJsonURI + client.subId;
   }, [client?.subId, subSettings?.enable, subSettings?.subJsonEnable, subSettings?.subJsonURI]);
 
-  const hasAnything = !!subLink || !!subJsonLink || links.length > 0;
+  const wgInbound = useMemo(() => findWireguardInbound(client, inboundsById), [client, inboundsById]);
+  const wgConfigText = useMemo(() => {
+    if (!client || !isWireguardClient(client)) return '';
+    return buildWireguardClientConfig(client, wgInbound);
+  }, [client, wgInbound]);
+
+  const hasAnything = !!subLink || !!subJsonLink || !!wgConfigText || links.length > 0;
 
   useEffect(() => {
     if (!open || !client?.subId) {
@@ -77,6 +86,19 @@ export default function ClientQrModal({
 
   const items = useMemo(() => {
     const out: { key: string; label: React.ReactNode; children: React.ReactNode }[] = [];
+    if (wgConfigText) {
+      out.push({
+        key: 'wg-config',
+        label: 'WireGuard config',
+        children: (
+          <QrPanel
+            value={wgConfigText}
+            remark={client?.email || 'peer'}
+            downloadName={`${client?.email || 'peer'}.conf`}
+          />
+        ),
+      });
+    }
     if (subLink) {
       out.push({
         key: 'sub',
@@ -94,6 +116,7 @@ export default function ClientQrModal({
     links.forEach((link, idx) => {
       const parts = parseLinkParts(link);
       const meta = parts ? linkMetaText(parts) : '';
+      const isWireguardLink = link.startsWith('wireguard://') || link.startsWith('wg://');
       const label: React.ReactNode = parts ? (
         <span style={{ display: 'inline-flex', alignItems: 'center', gap: 6, flexWrap: 'wrap' }}>
           <LinkTags parts={parts} />
@@ -107,13 +130,13 @@ export default function ClientQrModal({
           <QrPanel
             value={link}
             remark={parts?.remark || `${client?.email || ''} #${idx + 1}`}
-            showQr={!isPostQuantumLink(link)}
+            showQr={!isWireguardLink && !isPostQuantumLink(link)}
           />
         ),
       });
     });
     return out;
-  }, [subLink, subJsonLink, links, client?.email, t]);
+  }, [subLink, subJsonLink, wgConfigText, links, client?.email, t]);
 
   useEffect(() => {
     if (!open) {

--- a/frontend/src/pages/clients/ClientsPage.tsx
+++ b/frontend/src/pages/clients/ClientsPage.tsx
@@ -1459,6 +1459,7 @@ export default function ClientsPage() {
           <ClientQrModal
             open={qrOpen}
             client={qrClient}
+            inboundsById={inboundsById}
             subSettings={subSettings}
             onOpenChange={setQrOpen}
           />

--- a/frontend/src/pages/clients/ClientsPage.tsx
+++ b/frontend/src/pages/clients/ClientsPage.tsx
@@ -1438,6 +1438,7 @@ export default function ClientsPage() {
             attachedIds={editingAttachedIds}
             attachedExternalLinks={editingExternalLinks}
             inbounds={inbounds}
+            publicHost={subSettings.publicHost}
             tgBotEnable={tgBotEnable}
             groups={allGroups}
             save={onSave}

--- a/frontend/src/pages/clients/wireguardConfig.ts
+++ b/frontend/src/pages/clients/wireguardConfig.ts
@@ -1,0 +1,40 @@
+import { formatInboundLabel } from '@/lib/inbounds/label';
+import type { ClientRecord, InboundOption } from '@/hooks/useClients';
+
+export function isWireguardClient(client: ClientRecord | null | undefined): boolean {
+  if (!client) return false;
+  return !!(client.privateKey || client.publicKey || client.allowedIPs || client.preSharedKey || client.keepAlive);
+}
+
+export function findWireguardInbound(
+  client: ClientRecord | null | undefined,
+  inboundsById: Record<number, InboundOption>,
+): InboundOption | undefined {
+  return (client?.inboundIds || [])
+    .map((id) => inboundsById[id])
+    .find((ib) => ib?.protocol === 'wireguard');
+}
+
+export function buildWireguardClientConfig(
+  client: ClientRecord,
+  inbound: InboundOption | undefined,
+  host = window.location.hostname,
+): string {
+  const address = client.allowedIPs || '10.0.0.2/32';
+  const endpoint = `${host}:${inbound?.port || ''}`;
+  const inboundName = inbound ? formatInboundLabel(inbound.tag, inbound.remark) : '';
+  const remark = [inboundName, client.email, client.comment].filter(Boolean).join(' - ');
+  const lines = [
+    '[Interface]',
+    `PrivateKey = ${client.privateKey || client.password || ''}`,
+    `Address = ${address}`,
+    'DNS = 1.1.1.1, 8.8.8.8',
+  ];
+  if (inbound?.wgMtu && inbound.wgMtu > 0) lines.push(`MTU = ${inbound.wgMtu}`);
+  if (remark) lines.push('', `# ${remark}`);
+  lines.push('', '[Peer]', `PublicKey = ${inbound?.wgPublicKey || ''}`);
+  if (client.preSharedKey) lines.push(`PreSharedKey = ${client.preSharedKey}`);
+  lines.push('AllowedIPs = 0.0.0.0/0, ::/0', `Endpoint = ${endpoint}`);
+  if (client.keepAlive && client.keepAlive > 0) lines.push(`PersistentKeepalive = ${client.keepAlive}`);
+  return lines.join('\n');
+}

--- a/frontend/src/pages/clients/wireguardConfig.ts
+++ b/frontend/src/pages/clients/wireguardConfig.ts
@@ -1,4 +1,5 @@
 import { formatInboundLabel } from '@/lib/inbounds/label';
+import { preferPublicHost } from '@/lib/xray/inbound-link';
 import type { ClientRecord, InboundOption } from '@/hooks/useClients';
 
 export function isWireguardClient(client: ClientRecord | null | undefined): boolean {
@@ -19,9 +20,11 @@ export function buildWireguardClientConfig(
   client: ClientRecord,
   inbound: InboundOption | undefined,
   host = window.location.hostname,
+  publicHost = '',
 ): string {
+  const endpointHost = preferPublicHost(host, publicHost);
   const address = client.allowedIPs || '10.0.0.2/32';
-  const endpoint = `${host}:${inbound?.port || ''}`;
+  const endpoint = `${endpointHost}:${inbound?.port || ''}`;
   const inboundName = inbound ? formatInboundLabel(inbound.tag, inbound.remark) : '';
   const remark = [inboundName, client.email, client.comment].filter(Boolean).join(' - ');
   const lines = [

--- a/frontend/src/pages/inbounds/info/InboundInfoModal.tsx
+++ b/frontend/src/pages/inbounds/info/InboundInfoModal.tsx
@@ -3,7 +3,7 @@ import { useTranslation } from 'react-i18next';
 import { Button, Divider, Modal, Space, Tabs, Tag, Tooltip } from 'antd';
 import { CopyOutlined, SyncOutlined, DeleteOutlined, DownloadOutlined } from '@ant-design/icons';
 
-import { HttpUtil, IntlUtil, SizeFormatter, ColorUtils } from '@/utils';
+import { HttpUtil, IntlUtil, SizeFormatter, ColorUtils, Wireguard } from '@/utils';
 import { Protocols } from '@/schemas/primitives';
 import { InfinityIcon } from '@/components/ui';
 import { useDatepicker } from '@/hooks/useDatepicker';
@@ -207,6 +207,11 @@ export default function InboundInfoModal({
     const remained = clientStats.total - clientStats.up - clientStats.down;
     return remained > 0 ? SizeFormatter.sizeFormat(remained) : '-';
   }, [clientStats, clientSettings]);
+
+  const wgPubKey = useMemo(() => {
+    if (!dbInbound?.isWireguard || !inbound?.settings?.secretKey) return '';
+    return Wireguard.generateKeypair(inbound.settings.secretKey as string).publicKey;
+  }, [dbInbound?.isWireguard, inbound?.settings?.secretKey]);
 
   const formatLastOnline = useCallback(
     (email: string) => {
@@ -791,7 +796,7 @@ export default function InboundInfoModal({
             </div>
             <div className="info-row">
               <dt>{t('pages.xray.wireguard.publicKey')}</dt>
-              <dd><Tag className="value-tag">{inbound.settings.pubKey as string}</Tag></dd>
+              <dd><Tag className="value-tag">{wgPubKey}</Tag></dd>
             </div>
             <div className="info-row">
               <dt>{t('pages.inbounds.info.mtu')}</dt>

--- a/frontend/src/pages/inbounds/list/useInboundColumns.tsx
+++ b/frontend/src/pages/inbounds/list/useInboundColumns.tsx
@@ -7,6 +7,7 @@ import { SizeFormatter, IntlUtil, ColorUtils } from '@/utils';
 import { InfinityIcon } from '@/components/ui';
 import { useDatepicker } from '@/hooks/useDatepicker';
 import type { NodeRecord } from '@/api/queries/useNodesQuery';
+import { coerceInboundJsonField } from '@/models/dbinbound';
 
 import { RowActionsCell } from './RowActions';
 import { InboundSpeedTag, isActiveSpeed } from './InboundSpeedTag';
@@ -51,6 +52,29 @@ export function useInboundColumns({
   const { datepicker } = useDatepicker();
 
   return useMemo(() => {
+    const fallbackClientCount = (record: DBInboundRecord): ClientCountEntry | null => {
+      const settings = coerceInboundJsonField(record.settings) as {
+        clients?: { email?: string; enable?: boolean }[];
+      };
+      const clients = Array.isArray(settings.clients) ? settings.clients : [];
+      if (clients.length === 0) return null;
+      const active = clients
+        .filter((client) => client.email && client.enable !== false)
+        .map((client) => client.email!);
+      const deactive = clients
+        .filter((client) => client.email && client.enable === false)
+        .map((client) => client.email!);
+      return {
+        clients: clients.length,
+        active,
+        deactive,
+        depleted: [],
+        expiring: [],
+        online: [],
+        comments: new Map(),
+      };
+    };
+
     const cols: TableColumnType<DBInboundRecord>[] = [
       {
         title: 'ID',
@@ -174,14 +198,14 @@ export function useInboundColumns({
         align: 'left',
         width: 200,
         render: (_, record) => {
-          const cc = clientCount[record.id];
+          const cc = clientCount[record.id] || fallbackClientCount(record);
           if (!cc) return null;
           return (
             <>
               <Tag className="client-count-tag" style={{ margin: 0, marginRight: 4, padding: '0 2px' }}>
                 <TeamOutlined /> {cc.clients}
               </Tag>
-              {cc.active.length > 0 && (
+              {cc.active.length > 0 ? (
                 <Popover
                   title={t('subscription.active')}
                   content={(
@@ -192,6 +216,8 @@ export function useInboundColumns({
                 >
                   <Tag color="green" className="client-count-tag" style={{ margin: 0, marginRight: 4, padding: '0 2px' }}>{cc.active.length}</Tag>
                 </Popover>
+              ) : (
+                <Tag color="green" className="client-count-tag" style={{ margin: 0, marginRight: 4, padding: '0 2px' }}>0</Tag>
               )}
               {cc.deactive.length > 0 && (
                 <Popover

--- a/frontend/src/pages/inbounds/list/useInboundColumns.tsx
+++ b/frontend/src/pages/inbounds/list/useInboundColumns.tsx
@@ -71,7 +71,6 @@ export function useInboundColumns({
         depleted: [],
         expiring: [],
         online: [],
-        comments: new Map(),
       };
     };
 

--- a/frontend/src/pages/inbounds/qr/QrCodeModal.tsx
+++ b/frontend/src/pages/inbounds/qr/QrCodeModal.tsx
@@ -35,6 +35,7 @@ interface QrItem {
   header: string;
   value: string;
   downloadName?: string;
+  showQr?: boolean;
 }
 
 export default function QrCodeModal({
@@ -122,7 +123,7 @@ export default function QrCodeModal({
         downloadName: `peer-${idx + 1}.conf`,
       });
       if (wireguardLinks[idx]) {
-        items.push({ key: `wl${idx}`, header: `Peer ${idx + 1} link`, value: wireguardLinks[idx] });
+        items.push({ key: `wl${idx}`, header: `Peer ${idx + 1} link`, value: wireguardLinks[idx], showQr: false });
       }
     });
     return items;
@@ -137,7 +138,7 @@ export default function QrCodeModal({
           value={item.value}
           remark={item.header}
           downloadName={item.downloadName || ''}
-          showQr={!isPostQuantumLink(item.value)}
+          showQr={item.showQr !== false && !isPostQuantumLink(item.value)}
         />
       ),
     })),

--- a/frontend/src/schemas/client.ts
+++ b/frontend/src/schemas/client.ts
@@ -49,6 +49,8 @@ export const InboundOptionSchema = z.object({
   port: z.number().optional(),
   tlsFlowCapable: z.boolean().optional(),
   ssMethod: z.string().optional(),
+  wgPublicKey: z.string().optional(),
+  wgMtu: z.number().optional(),
   // Hosting node id; absent/null for this panel's own inbounds (#4997).
   nodeId: z.number().nullable().optional(),
 }).loose();

--- a/internal/web/service/inbound.go
+++ b/internal/web/service/inbound.go
@@ -18,6 +18,7 @@ import (
 	"github.com/mhsanaei/3x-ui/v3/internal/mtproto"
 	"github.com/mhsanaei/3x-ui/v3/internal/util/common"
 	"github.com/mhsanaei/3x-ui/v3/internal/util/netsafe"
+	wgutil "github.com/mhsanaei/3x-ui/v3/internal/util/wireguard"
 	"github.com/mhsanaei/3x-ui/v3/internal/xray"
 
 	"gorm.io/gorm"
@@ -298,6 +299,8 @@ type InboundOption struct {
 	Port           int    `json:"port" example:"443"`
 	TlsFlowCapable bool   `json:"tlsFlowCapable" example:"true"`
 	SsMethod       string `json:"ssMethod"`
+	WgPublicKey    string `json:"wgPublicKey,omitempty"`
+	WgMtu          int    `json:"wgMtu,omitempty"`
 	// Hosting node; nil for this panel's own inbounds. Lets the clients
 	// page map a node filter onto inbound IDs (#4997).
 	NodeId *int `json:"nodeId,omitempty"`
@@ -325,6 +328,7 @@ func (s *InboundService) GetInboundOptions(userId int) ([]InboundOption, error) 
 	}
 	out := make([]InboundOption, 0, len(rows))
 	for _, r := range rows {
+		wgPublicKey, wgMtu := inboundWireguardHints(r.Protocol, r.Settings)
 		out = append(out, InboundOption{
 			Id:             r.Id,
 			Remark:         r.Remark,
@@ -333,10 +337,37 @@ func (s *InboundService) GetInboundOptions(userId int) ([]InboundOption, error) 
 			Port:           r.Port,
 			TlsFlowCapable: inboundCanEnableTlsFlow(r.Protocol, r.StreamSettings, r.Settings),
 			SsMethod:       inboundShadowsocksMethod(r.Protocol, r.Settings),
+			WgPublicKey:    wgPublicKey,
+			WgMtu:          wgMtu,
 			NodeId:         r.NodeId,
 		})
 	}
 	return out, nil
+}
+
+func inboundWireguardHints(protocol string, settings string) (string, int) {
+	if protocol != string(model.WireGuard) || strings.TrimSpace(settings) == "" {
+		return "", 0
+	}
+	var parsed struct {
+		PublicKey string `json:"publicKey"`
+		PubKey    string `json:"pubKey"`
+		SecretKey string `json:"secretKey"`
+		MTU       int    `json:"mtu"`
+	}
+	if err := json.Unmarshal([]byte(settings), &parsed); err != nil {
+		return "", 0
+	}
+	publicKey := parsed.PublicKey
+	if publicKey == "" {
+		publicKey = parsed.PubKey
+	}
+	if publicKey == "" && parsed.SecretKey != "" {
+		if derived, err := wgutil.PublicKeyFromPrivate(parsed.SecretKey); err == nil {
+			publicKey = derived
+		}
+	}
+	return publicKey, parsed.MTU
 }
 
 // GetAllInbounds retrieves all inbounds with client stats.

--- a/internal/web/translation/en-US.json
+++ b/internal/web/translation/en-US.json
@@ -718,6 +718,8 @@
       "tabBasics": "Basics",
       "tabCredentials": "Credentials",
       "tabLinks": "Links",
+      "wireguardConfig": "WireGuard config",
+      "conf": "CONF",
       "linksHint": "Add third-party share links and remote subscription URLs to include in this client's subscription.",
       "addExternalLink": "Add External Link",
       "addExternalSubscription": "Add External Subscription",


### PR DESCRIPTION
## Summary

This PR restores several WireGuard client UX pieces on top of the upstream multi-client implementation:

- show an always-visible active client count beside the total client count for inbounds, including `0` active clients;
- add a direct `settings.clients[]` fallback in the inbound list so WireGuard counts render even when the async rollup has not populated `clientCount` yet;
- show the WireGuard inbound server public key in the inbound info modal by deriving it from `secretKey` when needed;
- expose WireGuard `.conf` client config in the client create/edit form, client info modal, and client QR modal, with copy/download/QR actions;
- keep `wireguard://` peer links copy-only instead of rendering QR codes that are not useful for standard WireGuard clients;
- include lightweight WireGuard hints (`wgPublicKey`, `wgMtu`) in inbound options so client views can render complete configs.

## Why

After testing the current upstream WireGuard multi-client flow, the data model works, but several UX pieces from the earlier implementation were missing. This made it hard to inspect/copy client configs and caused peer-link QR codes to appear even though they do not lead to a usable WireGuard import.

This is a focused follow-up to the earlier WireGuard client work and review iterations:

- #5631
- #5623
- #5607
- #5466

## Validation

- `npm run build` from `frontend` using Node 22
- `go test ./internal/web/service`
- deployed and smoke-tested on a test NL server: panel/sub ports active, Xray started, WireGuard client UX checked manually