### PR TITLE
refactor(xray): extract minimum eligible release tag for filtering

### DIFF
--- a/internal/web/service/server.go
+++ b/internal/web/service/server.go
@@ -769,7 +769,38 @@ const (
 	// maxXrayDigestBytes caps the .dgst checksum sidecar read; it is a few
 	// hundred bytes in practice.
 	maxXrayDigestBytes = 64 << 10
+	minEligibleXrayTag = "v26.6.27"
 )
+
+func isEligibleXrayReleaseTag(tag string) bool {
+	tagVersion := strings.TrimPrefix(tag, "v")
+	tagParts := strings.Split(tagVersion, ".")
+	if len(tagParts) != 3 {
+		return false
+	}
+
+	minVersion := strings.TrimPrefix(minEligibleXrayTag, "v")
+	minParts := strings.Split(minVersion, ".")
+	if len(minParts) != 3 {
+		return false
+	}
+
+	for i := range 3 {
+		got, err1 := strconv.Atoi(tagParts[i])
+		want, err2 := strconv.Atoi(minParts[i])
+		if err1 != nil || err2 != nil {
+			return false
+		}
+		if got > want {
+			return true
+		}
+		if got < want {
+			return false
+		}
+	}
+
+	return true
+}
 
 func (s *ServerService) GetXrayVersions() ([]string, error) {
 	const (
@@ -812,20 +843,7 @@ func (s *ServerService) GetXrayVersions() ([]string, error) {
 
 	var versions []string
 	for _, release := range releases {
-		tagVersion := strings.TrimPrefix(release.TagName, "v")
-		tagParts := strings.Split(tagVersion, ".")
-		if len(tagParts) != 3 {
-			continue
-		}
-
-		major, err1 := strconv.Atoi(tagParts[0])
-		minor, err2 := strconv.Atoi(tagParts[1])
-		patch, err3 := strconv.Atoi(tagParts[2])
-		if err1 != nil || err2 != nil || err3 != nil {
-			continue
-		}
-
-		if major > 26 || (major == 26 && minor > 6) || (major == 26 && minor == 6 && patch >= 27) {
+		if isEligibleXrayReleaseTag(release.TagName) {
 			versions = append(versions, release.TagName)
 		}
 	}

--- a/internal/web/service/server_xray_checksum_test.go
+++ b/internal/web/service/server_xray_checksum_test.go
@@ -85,8 +85,10 @@ func TestIsEligibleXrayReleaseTag(t *testing.T) {
 		{tag: "main", want: false},
 		{tag: "v26.6", want: false},
 	} {
-		if got := isEligibleXrayReleaseTag(tc.tag); got != tc.want {
-			t.Fatalf("isEligibleXrayReleaseTag(%q) = %v, want %v", tc.tag, got, tc.want)
-		}
+		t.Run(tc.tag, func(t *testing.T) {
+			if got := isEligibleXrayReleaseTag(tc.tag); got != tc.want {
+				t.Errorf("isEligibleXrayReleaseTag(%q) = %v, want %v", tc.tag, got, tc.want)
+			}
+		})
 	}
 }

--- a/internal/web/service/server_xray_checksum_test.go
+++ b/internal/web/service/server_xray_checksum_test.go
@@ -70,3 +70,23 @@ func TestFetchXrayDigestSHA256_HTTPError(t *testing.T) {
 		t.Fatal("expected an error on HTTP 404")
 	}
 }
+
+func TestIsEligibleXrayReleaseTag(t *testing.T) {
+	for _, tc := range []struct {
+		tag  string
+		want bool
+	}{
+		{tag: "v26.4.25", want: false},
+		{tag: "v26.6.26", want: false},
+		{tag: "v26.6.27", want: true},
+		{tag: "v26.6.28", want: true},
+		{tag: "v26.7.0", want: true},
+		{tag: "v27.0.0", want: true},
+		{tag: "main", want: false},
+		{tag: "v26.6", want: false},
+	} {
+		if got := isEligibleXrayReleaseTag(tc.tag); got != tc.want {
+			t.Fatalf("isEligibleXrayReleaseTag(%q) = %v, want %v", tc.tag, got, tc.want)
+		}
+	}
+}


### PR DESCRIPTION

## Summary

Extract the minimum eligible Xray release tag into a named constant and reuse it in the GitHub release filtering logic. This keeps the threshold defined in one place instead of hardcoding the version inline.

## Why

The previous comparison duplicated the minimum supported release threshold directly in the filtering condition, which made the intent harder to read and future updates more error-prone. A named constant makes the compatibility boundary explicit and simpler to maintain.

Previous implementation:

```go
if major > 26 || (major == 26 && minor > 6) || (major == 26 && minor == 6 && patch >= 27) {
    versions = append(versions, release.TagName)
}
```

Reference:
- [internal/web/service/server.go#L813-L832](https://github.com/MHSanaei/3x-ui/blob/bbfbd7eba624e49b5ccfc20c22e80d016b7facc3/internal/web/service/server.go#L813-L832)

## Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Refactoring (no behavior change)
- [ ] Documentation
- [ ] Tests only
- [ ] Build / CI / tooling
- [ ] Other

## Areas affected

- [ ] Frontend (UI / panel pages)
- [x] Backend (API endpoints, login, settings)
- [ ] Xray config generation
- [ ] Subscription (share links / Clash / JSON)
- [ ] Statistics / traffic counters
- [ ] Database / migrations
- [ ] Install / upgrade script
- [ ] Docker image
- [ ] Multi-node (sub-nodes)
- [ ] Telegram bot

## How was this tested?

- Ran the backend unit tests covering release-tag filtering and checksum parsing.
- Verified that tags below `v26.6.27` are excluded and `v26.6.27` and newer tags are included.
- Confirmed the refactor does not change behavior and only centralizes the minimum-version value.

## Screenshots / recordings

N/A

## Breaking changes

None

## Checklist

- [x] I tested the change locally and confirmed the described behavior.
- [x] I added or updated tests for the new behavior (when applicable).
- [x] `go build ./...` and the test suite pass locally.
- [ ] For frontend changes: `npm run lint`, `npm run typecheck`, and `npm run build` pass.
- [ ] I updated the Wiki / README / API docs if user-facing behavior changed.
- [x] My commits follow the project's existing message style.
- [x] I have no unrelated changes mixed into this PR.
```