### PR TITLE
feat(clients): writable per-(client,inbound) XTLS flow override (#5689)

### DIFF
--- a/frontend/public/openapi.json
+++ b/frontend/public/openapi.json
@@ -5634,6 +5634,64 @@
         }
       }
     },
+    "/panel/api/clients/{email}/flow": {
+      "post": {
+        "tags": [
+          "Clients"
+        ],
+        "summary": "Override a client's XTLS flow on a single inbound, bypassing the per-inbound capability clamp — so a client can keep xtls-rprx-vision on one flow-capable inbound and clear it on another in the same subscription. Clearing (\"\" or \"none\") is always allowed; a non-empty flow must be a recognized value and is only accepted on a flow-capable inbound.",
+        "operationId": "post_panel_api_clients_email_flow",
+        "parameters": [
+          {
+            "name": "email",
+            "in": "path",
+            "required": true,
+            "description": "Client email (unique identifier).",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object"
+              },
+              "example": {
+                "inboundId": 7,
+                "flow": ""
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean"
+                    },
+                    "msg": {
+                      "type": "string"
+                    },
+                    "obj": {}
+                  }
+                },
+                "example": {
+                  "success": true
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/panel/api/clients/resetAllTraffics": {
       "post": {
         "tags": [

--- a/frontend/public/openapi.json
+++ b/frontend/public/openapi.json
@@ -1126,6 +1126,9 @@
             "description": "Flow control (XTLS)",
             "type": "string"
           },
+          "flowLock": {
+            "type": "boolean"
+          },
           "group": {
             "description": "Logical grouping label",
             "type": "string"

--- a/frontend/src/generated/examples.ts
+++ b/frontend/src/generated/examples.ts
@@ -224,6 +224,7 @@ export const EXAMPLES: Record<string, unknown> = {
     "enable": false,
     "expiryTime": 0,
     "flow": "",
+    "flowLock": false,
     "group": "",
     "id": "",
     "keepAlive": 0,

--- a/frontend/src/generated/schemas.ts
+++ b/frontend/src/generated/schemas.ts
@@ -1100,6 +1100,9 @@ export const SCHEMAS: Record<string, unknown> = {
         "description": "Flow control (XTLS)",
         "type": "string"
       },
+      "flowLock": {
+        "type": "boolean"
+      },
       "group": {
         "description": "Logical grouping label",
         "type": "string"

--- a/frontend/src/generated/types.ts
+++ b/frontend/src/generated/types.ts
@@ -232,6 +232,7 @@ export interface Client {
   enable: boolean;
   expiryTime: number;
   flow?: string;
+  flowLock?: boolean;
   group?: string;
   id?: string;
   keepAlive?: number;

--- a/frontend/src/generated/zod.ts
+++ b/frontend/src/generated/zod.ts
@@ -248,6 +248,7 @@ export const ClientSchema = z.object({
   enable: z.boolean(),
   expiryTime: z.number().int(),
   flow: z.string().optional(),
+  flowLock: z.boolean().optional(),
   group: z.string().optional(),
   id: z.string().optional(),
   keepAlive: z.number().int().optional(),

--- a/frontend/src/pages/api-docs/endpoints.ts
+++ b/frontend/src/pages/api-docs/endpoints.ts
@@ -641,6 +641,18 @@ export const sections: readonly Section[] = [
       },
       {
         method: 'POST',
+        path: '/panel/api/clients/:email/flow',
+        summary: 'Override a client\'s XTLS flow on a single inbound, bypassing the per-inbound capability clamp — so a client can keep xtls-rprx-vision on one flow-capable inbound and clear it on another in the same subscription. Clearing ("" or "none") is always allowed; a non-empty flow must be a recognized value and is only accepted on a flow-capable inbound.',
+        params: [
+          { name: 'email', in: 'path', type: 'string', desc: 'Client email (unique identifier).' },
+          { name: 'inboundId', in: 'body (json)', type: 'integer', desc: 'Inbound to set the flow on.' },
+          { name: 'flow', in: 'body (json)', type: 'string', desc: 'XTLS flow: "xtls-rprx-vision" / "xtls-rprx-vision-udp443" to set (flow-capable inbounds only), or "" / "none" to clear.' },
+        ],
+        body: '{\n  "inboundId": 7,\n  "flow": ""\n}',
+        response: '{\n  "success": true\n}',
+      },
+      {
+        method: 'POST',
         path: '/panel/api/clients/resetAllTraffics',
         summary: 'Reset the up/down counters for every client globally. Quotas and expiry are not affected. Triggers an Xray restart if any counter actually moved.',
         response: '{\n  "success": true\n}',

--- a/frontend/src/pages/inbounds/info/InboundInfoModal.tsx
+++ b/frontend/src/pages/inbounds/info/InboundInfoModal.tsx
@@ -1,9 +1,11 @@
 import { Fragment, useCallback, useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { Button, Divider, Modal, Space, Tabs, Tag, Tooltip } from 'antd';
+import { useQueryClient } from '@tanstack/react-query';
+import { Button, Divider, Modal, Select, Space, Tabs, Tag, Tooltip } from 'antd';
 import { CopyOutlined, SyncOutlined, DeleteOutlined, DownloadOutlined } from '@ant-design/icons';
 
 import { HttpUtil, IntlUtil, SizeFormatter, ColorUtils, Wireguard } from '@/utils';
+import { keys } from '@/api/queryKeys';
 import { Protocols } from '@/schemas/primitives';
 import { InfinityIcon } from '@/components/ui';
 import { useDatepicker } from '@/hooks/useDatepicker';
@@ -41,8 +43,10 @@ export default function InboundInfoModal({
 }: InboundInfoModalProps) {
   const { t } = useTranslation();
   const { datepicker } = useDatepicker();
+  const queryClient = useQueryClient();
 
   const [inbound, setInbound] = useState<InboundInfo | null>(null);
+  const [flowSaving, setFlowSaving] = useState(false);
   const [clientSettings, setClientSettings] = useState<ClientSetting | null>(null);
   const [clientStats, setClientStats] = useState<ClientStats | null>(null);
   const [links, setLinks] = useState<{ remark?: string; link: string }[]>([]);
@@ -97,6 +101,21 @@ export default function InboundInfoModal({
       setClientIpsText(t('tgbot.noIpRecord'));
     }
   }, [clientStats, t]);
+
+  const setClientFlow = useCallback(async (flow: string) => {
+    const email = clientSettings?.email;
+    if (!email || !dbInbound) return;
+    setFlowSaving(true);
+    const msg = await HttpUtil.post(`/panel/api/clients/${email}/flow`, {
+      inboundId: dbInbound.id,
+      flow,
+    });
+    setFlowSaving(false);
+    if (msg?.success) {
+      setClientSettings((prev) => (prev ? { ...prev, flow: flow === 'none' ? '' : flow } : prev));
+      void queryClient.invalidateQueries({ queryKey: keys.inbounds.root() });
+    }
+  }, [clientSettings, dbInbound, queryClient]);
 
   useEffect(() => {
     if (!open || !dbInbound) return;
@@ -256,11 +275,22 @@ export default function InboundInfoModal({
           {dbInbound.isVMess && (
             <tr><td>{t('security')}</td><td><Tag>{clientSettings?.security}</Tag></td></tr>
           )}
-          {inbound.isVlessTlsFlow && (
+          {inbound.isVlessTlsFlow && clientSettings?.email && (
             <tr>
               <td>{t('pages.clients.flow')}</td>
               <td>
-                {clientSettings?.flow ? <Tag>{clientSettings.flow}</Tag> : <Tag color="orange">{t('none')}</Tag>}
+                <Select
+                  size="small"
+                  style={{ minWidth: 220 }}
+                  loading={flowSaving}
+                  disabled={flowSaving}
+                  value={clientSettings?.flow ? clientSettings.flow : 'none'}
+                  onChange={setClientFlow}
+                  options={[
+                    { value: 'xtls-rprx-vision', label: 'xtls-rprx-vision' },
+                    { value: 'none', label: t('none') },
+                  ]}
+                />
               </td>
             </tr>
           )}

--- a/internal/database/model/model.go
+++ b/internal/database/model/model.go
@@ -596,8 +596,9 @@ type Client struct {
 	Security     string         `json:"security"`           // Security method (e.g., "auto", "aes-128-gcm")
 	Password     string         `json:"password,omitempty"` // Client password
 	Flow         string         `json:"flow,omitempty"`     // Flow control (XTLS)
-	Reverse      *ClientReverse `json:"reverse,omitempty"`  // VLESS simple reverse proxy settings
-	Auth         string         `json:"auth,omitempty"`     // Auth password (Hysteria)
+	FlowLock     bool           `json:"flowLock,omitempty"`
+	Reverse      *ClientReverse `json:"reverse,omitempty"` // VLESS simple reverse proxy settings
+	Auth         string         `json:"auth,omitempty"`    // Auth password (Hysteria)
 	PrivateKey   string         `json:"privateKey,omitempty"`
 	PublicKey    string         `json:"publicKey,omitempty"`
 	AllowedIPs   []string       `json:"allowedIPs,omitempty"`

--- a/internal/web/controller/client.go
+++ b/internal/web/controller/client.go
@@ -58,6 +58,7 @@ func (a *ClientController) initRouter(g *gin.RouterGroup) {
 	g.POST("/:email/attach", a.attach)
 	g.POST("/:email/detach", a.detach)
 	g.POST("/:email/externalLinks", a.setExternalLinks)
+	g.POST("/:email/flow", a.setInboundFlow)
 	g.GET("/export", a.export)
 	g.POST("/import", a.importClients)
 	g.POST("/delOrphans", a.delOrphans)
@@ -170,6 +171,33 @@ func (a *ClientController) update(c *gin.Context) {
 		return
 	}
 	jsonMsgObj(c, I18nWeb(c, "pages.inbounds.toasts.inboundClientUpdateSuccess"), pendingNodeObj(a.clientService.HasPendingNode(&a.inboundService, email)), nil)
+	if needRestart {
+		a.xrayService.SetToNeedRestart()
+	}
+	notifyClientsChanged()
+}
+
+type setFlowBody struct {
+	InboundId int    `json:"inboundId"`
+	Flow      string `json:"flow"`
+}
+
+// setInboundFlow overrides the XTLS flow for one client on a single inbound,
+// bypassing the capability clamp so the client can keep Vision on its other
+// flow-capable inbounds in the same subscription (approach 1 of #5689).
+func (a *ClientController) setInboundFlow(c *gin.Context) {
+	email := c.Param("email")
+	var body setFlowBody
+	if err := c.ShouldBindJSON(&body); err != nil {
+		jsonMsg(c, I18nWeb(c, "somethingWentWrong"), err)
+		return
+	}
+	needRestart, err := a.clientService.SetInboundClientFlow(&a.inboundService, body.InboundId, email, body.Flow)
+	if err != nil {
+		jsonMsg(c, I18nWeb(c, "somethingWentWrong"), err)
+		return
+	}
+	jsonMsg(c, I18nWeb(c, "pages.inbounds.toasts.inboundClientUpdateSuccess"), nil)
 	if needRestart {
 		a.xrayService.SetToNeedRestart()
 	}

--- a/internal/web/controller/client.go
+++ b/internal/web/controller/client.go
@@ -182,9 +182,6 @@ type setFlowBody struct {
 	Flow      string `json:"flow"`
 }
 
-// setInboundFlow overrides the XTLS flow for one client on a single inbound,
-// bypassing the capability clamp so the client can keep Vision on its other
-// flow-capable inbounds in the same subscription (approach 1 of #5689).
 func (a *ClientController) setInboundFlow(c *gin.Context) {
 	email := c.Param("email")
 	var body setFlowBody

--- a/internal/web/service/client_crud.go
+++ b/internal/web/service/client_crud.go
@@ -153,6 +153,19 @@ func clientWithInboundFlow(c model.Client, ib *model.Inbound) model.Client {
 	return c
 }
 
+func clientForInboundEdit(svc *InboundService, updated model.Client, ib *model.Inbound) model.Client {
+	if existing, err := svc.GetClients(ib); err == nil {
+		for i := range existing {
+			if existing[i].FlowLock && strings.EqualFold(existing[i].Email, updated.Email) {
+				updated.Flow = existing[i].Flow
+				updated.FlowLock = true
+				return updated
+			}
+		}
+	}
+	return clientWithInboundFlow(updated, ib)
+}
+
 func shadowsocksMethodFromSettings(settings string) string {
 	if settings == "" {
 		return ""
@@ -369,7 +382,7 @@ func (s *ClientService) Update(inboundSvc *InboundService, id int, updated model
 		if err := s.fillProtocolDefaults(&updated, inbound); err != nil {
 			return needRestart, err
 		}
-		settingsPayload, mErr := json.Marshal(map[string][]model.Client{"clients": {clientWithInboundFlow(updated, inbound)}})
+		settingsPayload, mErr := json.Marshal(map[string][]model.Client{"clients": {clientForInboundEdit(inboundSvc, updated, inbound)}})
 		if mErr != nil {
 			return needRestart, mErr
 		}

--- a/internal/web/service/client_flow_override.go
+++ b/internal/web/service/client_flow_override.go
@@ -7,29 +7,18 @@ import (
 	"github.com/mhsanaei/3x-ui/v3/internal/util/common"
 )
 
-// clientWithFlow returns a copy of the client matching email with its Flow set
-// verbatim, plus whether a match was found. Pure (no DB) so the override is
-// unit-testable; unlike clientWithInboundFlow it does not clamp the value.
 func clientWithFlow(clients []model.Client, email, flow string) (model.Client, bool) {
 	for i := range clients {
 		if clients[i].Email == email {
 			c := clients[i]
 			c.Flow = flow
+			c.FlowLock = true
 			return c, true
 		}
 	}
 	return model.Client{}, false
 }
 
-// SetInboundClientFlow overrides the XTLS flow for one client on a single
-// inbound, so a client can keep Vision on some flow-capable inbounds and clear
-// it on another within the same subscription (#5689, approach 1).
-//
-// Clearing (""/"none") is always allowed; a non-empty flow must be a recognized
-// value (bulkFlowAllowed) and is only accepted on a flow-capable inbound, so an
-// invalid value or a flow on a non-capable transport can't reach the Xray
-// config. Persists via UpdateInboundClient, whose SyncInbound recreates the
-// client_inbounds.flow_override row from the written settings flow.
 func (s *ClientService) SetInboundClientFlow(inboundSvc *InboundService, inboundId int, email, flow string) (bool, error) {
 	if _, ok := bulkFlowAllowed[flow]; !ok {
 		return false, common.NewError("unsupported flow value:", flow)

--- a/internal/web/service/client_flow_override.go
+++ b/internal/web/service/client_flow_override.go
@@ -1,0 +1,81 @@
+package service
+
+import (
+	"encoding/json"
+
+	"github.com/mhsanaei/3x-ui/v3/internal/database"
+	"github.com/mhsanaei/3x-ui/v3/internal/database/model"
+	"github.com/mhsanaei/3x-ui/v3/internal/logger"
+	"github.com/mhsanaei/3x-ui/v3/internal/util/common"
+)
+
+// clientWithFlow returns a copy of the client matching email from clients, with
+// its Flow set verbatim, plus whether a match was found. Pure (no DB) so the
+// per-inbound flow override is unit-testable. Unlike clientWithInboundFlow it
+// does NOT clamp the value against the inbound's capability — applying an empty
+// flow to a flow-capable inbound is exactly the point of a per-(client, inbound)
+// override (#5689, approach 1).
+func clientWithFlow(clients []model.Client, email, flow string) (model.Client, bool) {
+	for i := range clients {
+		if clients[i].Email == email {
+			c := clients[i]
+			c.Flow = flow
+			return c, true
+		}
+	}
+	return model.Client{}, false
+}
+
+// SetInboundClientFlow overrides the XTLS flow for one client on ONE inbound,
+// bypassing the capability clamp. It lets a client carry Vision on some
+// flow-capable inbounds and an empty flow on others within the same
+// subscription (#5689, approach 1) — e.g. Vision on a Reality inbound but not on
+// a tunneled XHTTP+vlessenc inbound the same client is delivered on.
+//
+// It writes the inbound settings.clients[].flow (read by subscription
+// generation) via UpdateInboundClient, then mirrors the value onto the
+// per-membership client_inbounds.flow_override (read by EffectiveFlow and the
+// clients UI).
+//
+// NOTE for reviewers: an explicit empty flow can be re-populated by
+// restoreVisionFlowForEligibleInbound (#4792) if the inbound is later edited
+// into a newly flow-eligible state, since that path treats an empty settings
+// flow as "restore the intended Vision from a sibling". Making an explicit clear
+// durable across such edits needs a small marker (e.g. a sentinel flow_override
+// value or a per-membership lock) — a design decision deferred to maintainers;
+// see #5689.
+func (s *ClientService) SetInboundClientFlow(inboundSvc *InboundService, inboundId int, email, flow string) (bool, error) {
+	inbound, err := inboundSvc.GetInbound(inboundId)
+	if err != nil {
+		return false, err
+	}
+	clients, err := inboundSvc.GetClients(inbound)
+	if err != nil {
+		return false, err
+	}
+	target, found := clientWithFlow(clients, email, flow)
+	if !found {
+		return false, common.NewError("client not found on inbound:", email)
+	}
+	settingsPayload, err := json.Marshal(map[string][]model.Client{"clients": {target}})
+	if err != nil {
+		return false, err
+	}
+	needRestart, err := s.UpdateInboundClient(inboundSvc, &model.Inbound{
+		Id:       inboundId,
+		Settings: string(settingsPayload),
+	}, email)
+	if err != nil {
+		return needRestart, err
+	}
+	// Mirror onto the relational per-membership override so EffectiveFlow and the
+	// clients UI agree with what the subscription now emits.
+	if rec, rErr := s.GetRecordByEmail(nil, email); rErr == nil {
+		if uErr := database.GetDB().Model(&model.ClientInbound{}).
+			Where("client_id = ? AND inbound_id = ?", rec.Id, inboundId).
+			Update("flow_override", flow).Error; uErr != nil {
+			logger.Warning("SetInboundClientFlow: flow_override update failed:", uErr)
+		}
+	}
+	return needRestart, nil
+}

--- a/internal/web/service/client_flow_override.go
+++ b/internal/web/service/client_flow_override.go
@@ -3,18 +3,13 @@ package service
 import (
 	"encoding/json"
 
-	"github.com/mhsanaei/3x-ui/v3/internal/database"
 	"github.com/mhsanaei/3x-ui/v3/internal/database/model"
-	"github.com/mhsanaei/3x-ui/v3/internal/logger"
 	"github.com/mhsanaei/3x-ui/v3/internal/util/common"
 )
 
-// clientWithFlow returns a copy of the client matching email from clients, with
-// its Flow set verbatim, plus whether a match was found. Pure (no DB) so the
-// per-inbound flow override is unit-testable. Unlike clientWithInboundFlow it
-// does NOT clamp the value against the inbound's capability — applying an empty
-// flow to a flow-capable inbound is exactly the point of a per-(client, inbound)
-// override (#5689, approach 1).
+// clientWithFlow returns a copy of the client matching email with its Flow set
+// verbatim, plus whether a match was found. Pure (no DB) so the override is
+// unit-testable; unlike clientWithInboundFlow it does not clamp the value.
 func clientWithFlow(clients []model.Client, email, flow string) (model.Client, bool) {
 	for i := range clients {
 		if clients[i].Email == email {
@@ -26,28 +21,28 @@ func clientWithFlow(clients []model.Client, email, flow string) (model.Client, b
 	return model.Client{}, false
 }
 
-// SetInboundClientFlow overrides the XTLS flow for one client on ONE inbound,
-// bypassing the capability clamp. It lets a client carry Vision on some
-// flow-capable inbounds and an empty flow on others within the same
-// subscription (#5689, approach 1) — e.g. Vision on a Reality inbound but not on
-// a tunneled XHTTP+vlessenc inbound the same client is delivered on.
+// SetInboundClientFlow overrides the XTLS flow for one client on a single
+// inbound, so a client can keep Vision on some flow-capable inbounds and clear
+// it on another within the same subscription (#5689, approach 1).
 //
-// It writes the inbound settings.clients[].flow (read by subscription
-// generation) via UpdateInboundClient, then mirrors the value onto the
-// per-membership client_inbounds.flow_override (read by EffectiveFlow and the
-// clients UI).
-//
-// NOTE for reviewers: an explicit empty flow can be re-populated by
-// restoreVisionFlowForEligibleInbound (#4792) if the inbound is later edited
-// into a newly flow-eligible state, since that path treats an empty settings
-// flow as "restore the intended Vision from a sibling". Making an explicit clear
-// durable across such edits needs a small marker (e.g. a sentinel flow_override
-// value or a per-membership lock) — a design decision deferred to maintainers;
-// see #5689.
+// Clearing (""/"none") is always allowed; a non-empty flow must be a recognized
+// value (bulkFlowAllowed) and is only accepted on a flow-capable inbound, so an
+// invalid value or a flow on a non-capable transport can't reach the Xray
+// config. Persists via UpdateInboundClient, whose SyncInbound recreates the
+// client_inbounds.flow_override row from the written settings flow.
 func (s *ClientService) SetInboundClientFlow(inboundSvc *InboundService, inboundId int, email, flow string) (bool, error) {
+	if _, ok := bulkFlowAllowed[flow]; !ok {
+		return false, common.NewError("unsupported flow value:", flow)
+	}
+	if flow == bulkFlowClear {
+		flow = ""
+	}
 	inbound, err := inboundSvc.GetInbound(inboundId)
 	if err != nil {
 		return false, err
+	}
+	if flow != "" && !inboundCanEnableTlsFlow(string(inbound.Protocol), inbound.StreamSettings, inbound.Settings) {
+		return false, common.NewError("inbound is not flow-capable:", inboundId)
 	}
 	clients, err := inboundSvc.GetClients(inbound)
 	if err != nil {
@@ -61,21 +56,8 @@ func (s *ClientService) SetInboundClientFlow(inboundSvc *InboundService, inbound
 	if err != nil {
 		return false, err
 	}
-	needRestart, err := s.UpdateInboundClient(inboundSvc, &model.Inbound{
+	return s.UpdateInboundClient(inboundSvc, &model.Inbound{
 		Id:       inboundId,
 		Settings: string(settingsPayload),
 	}, email)
-	if err != nil {
-		return needRestart, err
-	}
-	// Mirror onto the relational per-membership override so EffectiveFlow and the
-	// clients UI agree with what the subscription now emits.
-	if rec, rErr := s.GetRecordByEmail(nil, email); rErr == nil {
-		if uErr := database.GetDB().Model(&model.ClientInbound{}).
-			Where("client_id = ? AND inbound_id = ?", rec.Id, inboundId).
-			Update("flow_override", flow).Error; uErr != nil {
-			logger.Warning("SetInboundClientFlow: flow_override update failed:", uErr)
-		}
-	}
-	return needRestart, nil
 }

--- a/internal/web/service/client_flow_override_durability_test.go
+++ b/internal/web/service/client_flow_override_durability_test.go
@@ -1,0 +1,224 @@
+package service
+
+import (
+	"encoding/json"
+	"path/filepath"
+	"testing"
+
+	"github.com/mhsanaei/3x-ui/v3/internal/database"
+	"github.com/mhsanaei/3x-ui/v3/internal/database/model"
+
+	"gorm.io/gorm"
+)
+
+const visionDur = "xtls-rprx-vision"
+
+const encDur = `"decryption":"mlkem768x25519plus.native.0rtt.KEY","encryption":"mlkem768x25519plus.native.0rtt.KEY"`
+
+func initDurDB(t *testing.T) *gorm.DB {
+	t.Helper()
+	dbDir := t.TempDir()
+	t.Setenv("XUI_DB_FOLDER", dbDir)
+	if err := database.InitDB(filepath.Join(dbDir, "x-ui.db")); err != nil {
+		t.Fatalf("InitDB: %v", err)
+	}
+	t.Cleanup(func() { _ = database.CloseDB() })
+	return database.GetDB()
+}
+
+func settingsFlow(t *testing.T, ibSvc *InboundService, id int, email string) (string, bool) {
+	t.Helper()
+	ib, err := ibSvc.GetInbound(id)
+	if err != nil {
+		t.Fatalf("GetInbound(%d): %v", id, err)
+	}
+	var parsed map[string]any
+	if err := json.Unmarshal([]byte(ib.Settings), &parsed); err != nil {
+		t.Fatalf("parse settings: %v", err)
+	}
+	clients, _ := parsed["clients"].([]any)
+	for _, c := range clients {
+		cm, ok := c.(map[string]any)
+		if !ok {
+			continue
+		}
+		if cm["email"] == email {
+			flow, _ := cm["flow"].(string)
+			lock, _ := cm["flowLock"].(bool)
+			return flow, lock
+		}
+	}
+	t.Fatalf("client %s not found on inbound %d", email, id)
+	return "", false
+}
+
+func overrideFlow(t *testing.T, cs *ClientService, id int, email string) string {
+	t.Helper()
+	list, err := cs.ListForInbound(nil, id)
+	if err != nil {
+		t.Fatalf("ListForInbound(%d): %v", id, err)
+	}
+	for i := range list {
+		if list[i].Email == email {
+			return list[i].Flow
+		}
+	}
+	t.Fatalf("client %s not in ListForInbound(%d)", email, id)
+	return ""
+}
+
+func TestSetInboundClientFlow_ClearedOverrideSurvivesRestoreAndEdit(t *testing.T) {
+	db := initDurDB(t)
+	ibSvc := &InboundService{}
+	cs := &ClientService{}
+
+	const email = "mixed@x"
+	const uid = "ce8d33df-3a64-4f10-8f9b-91c3a8e0e001"
+
+	reality := &model.Inbound{
+		Tag: "reality", Enable: true, Port: 53001, Protocol: model.VLESS,
+		StreamSettings: `{"network":"tcp","security":"reality"}`,
+		Settings:       `{"clients":[{"id":"` + uid + `","email":"` + email + `","flow":"` + visionDur + `","subId":"s1","enable":true}]}`,
+	}
+	if err := db.Create(reality).Error; err != nil {
+		t.Fatalf("create reality: %v", err)
+	}
+	rc, _ := ibSvc.GetClients(reality)
+	if err := cs.SyncInbound(nil, reality.Id, rc); err != nil {
+		t.Fatalf("sync reality: %v", err)
+	}
+
+	xhttp := &model.Inbound{
+		Tag: "xhttp", Enable: true, Port: 53002, Protocol: model.VLESS,
+		StreamSettings: `{"network":"xhttp","security":"reality"}`,
+		Settings:       `{` + encDur + `,"clients":[{"id":"` + uid + `","email":"` + email + `","flow":"` + visionDur + `","subId":"s1","enable":true}]}`,
+	}
+	if err := db.Create(xhttp).Error; err != nil {
+		t.Fatalf("create xhttp: %v", err)
+	}
+	xc, _ := ibSvc.GetClients(xhttp)
+	if err := cs.SyncInbound(nil, xhttp.Id, xc); err != nil {
+		t.Fatalf("sync xhttp: %v", err)
+	}
+
+	if f := overrideFlow(t, cs, xhttp.Id, email); f != visionDur {
+		t.Fatalf("precondition: xhttp flow_override = %q, want Vision", f)
+	}
+
+	if _, err := cs.SetInboundClientFlow(ibSvc, xhttp.Id, email, "none"); err != nil {
+		t.Fatalf("SetInboundClientFlow clear: %v", err)
+	}
+
+	assertState := func(stage string) {
+		if f, lock := settingsFlow(t, ibSvc, xhttp.Id, email); f != "" || !lock {
+			t.Errorf("[%s] xhttp settings flow=%q lock=%v, want \"\"/true", stage, f, lock)
+		}
+		if f := overrideFlow(t, cs, xhttp.Id, email); f != "" {
+			t.Errorf("[%s] xhttp flow_override = %q, want empty", stage, f)
+		}
+		if f := overrideFlow(t, cs, reality.Id, email); f != visionDur {
+			t.Errorf("[%s] reality flow_override = %q, want Vision preserved", stage, f)
+		}
+	}
+	assertState("after clear")
+
+	ibSvc.MigrationRestoreVisionFlow()
+	assertState("after MigrationRestoreVisionFlow")
+
+	rec, err := cs.GetRecordByEmail(nil, email)
+	if err != nil {
+		t.Fatalf("GetRecordByEmail: %v", err)
+	}
+	if _, err := cs.Update(ibSvc, rec.Id, model.Client{
+		Email: email, ID: uid, Flow: visionDur, SubID: "s1", Enable: true, Comment: "edited",
+	}); err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+	assertState("after whole-client edit")
+}
+
+func TestRestoreVisionFlow_SkipsFlowLockedClient(t *testing.T) {
+	db := initDurDB(t)
+	ibSvc := &InboundService{}
+	cs := &ClientService{}
+
+	const email = "pinned@x"
+	const uid = "ce8d33df-3a64-4f10-8f9b-91c3a8e0e002"
+
+	sib := &model.Inbound{
+		Tag: "sib", Enable: true, Port: 53101, Protocol: model.VLESS,
+		StreamSettings: `{"network":"tcp","security":"reality"}`,
+		Settings:       `{"clients":[{"id":"` + uid + `","email":"` + email + `","flow":"` + visionDur + `","subId":"s1","enable":true}]}`,
+	}
+	if err := db.Create(sib).Error; err != nil {
+		t.Fatalf("create sib: %v", err)
+	}
+	sc, _ := ibSvc.GetClients(sib)
+	if err := cs.SyncInbound(nil, sib.Id, sc); err != nil {
+		t.Fatalf("sync sib: %v", err)
+	}
+
+	target := `{` + encDur + `,"clients":[{"id":"` + uid + `","email":"` + email + `","flow":"","flowLock":true,"subId":"s1","enable":true}]}`
+	out, changed := ibSvc.restoreVisionFlowForEligibleInbound(nil, target, `{"network":"xhttp","security":"reality"}`, model.VLESS)
+	if changed {
+		t.Errorf("flow-locked client must not be restored; got changed=true, out=%s", out)
+	}
+
+	unpinned := `{` + encDur + `,"clients":[{"id":"` + uid + `","email":"` + email + `","flow":"","subId":"s1","enable":true}]}`
+	if _, ch := ibSvc.restoreVisionFlowForEligibleInbound(nil, unpinned, `{"network":"xhttp","security":"reality"}`, model.VLESS); !ch {
+		t.Error("control: un-pinned empty-flow client with Vision intent should be restored")
+	}
+}
+
+func TestSetInboundClientFlow_Validation(t *testing.T) {
+	db := initDurDB(t)
+	ibSvc := &InboundService{}
+	cs := &ClientService{}
+
+	const email = "v@x"
+	const uid = "ce8d33df-3a64-4f10-8f9b-91c3a8e0e003"
+
+	reality := &model.Inbound{
+		Tag: "reality", Enable: true, Port: 53201, Protocol: model.VLESS,
+		StreamSettings: `{"network":"tcp","security":"reality"}`,
+		Settings:       `{"clients":[{"id":"` + uid + `","email":"` + email + `","flow":"","subId":"s1","enable":true}]}`,
+	}
+	if err := db.Create(reality).Error; err != nil {
+		t.Fatalf("create reality: %v", err)
+	}
+	rc, _ := ibSvc.GetClients(reality)
+	if err := cs.SyncInbound(nil, reality.Id, rc); err != nil {
+		t.Fatalf("sync reality: %v", err)
+	}
+	ws := &model.Inbound{
+		Tag: "ws", Enable: true, Port: 53202, Protocol: model.VLESS,
+		StreamSettings: `{"network":"ws","security":"tls"}`,
+		Settings:       `{"clients":[{"id":"` + uid + `","email":"` + email + `","flow":"","subId":"s1","enable":true}]}`,
+	}
+	if err := db.Create(ws).Error; err != nil {
+		t.Fatalf("create ws: %v", err)
+	}
+	wc, _ := ibSvc.GetClients(ws)
+	if err := cs.SyncInbound(nil, ws.Id, wc); err != nil {
+		t.Fatalf("sync ws: %v", err)
+	}
+
+	if _, err := cs.SetInboundClientFlow(ibSvc, reality.Id, email, "bogus-flow"); err == nil {
+		t.Error("expected error for unsupported flow value")
+	}
+	if _, err := cs.SetInboundClientFlow(ibSvc, ws.Id, email, visionDur); err == nil {
+		t.Error("expected error setting Vision on a non-flow-capable inbound")
+	}
+	if _, err := cs.SetInboundClientFlow(ibSvc, reality.Id, "ghost@x", "none"); err == nil {
+		t.Error("expected client-not-found error")
+	}
+	if _, err := cs.SetInboundClientFlow(ibSvc, reality.Id, email, visionDur); err != nil {
+		t.Fatalf("SetInboundClientFlow vision: %v", err)
+	}
+	if f, lock := settingsFlow(t, ibSvc, reality.Id, email); f != visionDur || !lock {
+		t.Errorf("reality settings flow=%q lock=%v, want Vision/true", f, lock)
+	}
+	if f := overrideFlow(t, cs, reality.Id, email); f != visionDur {
+		t.Errorf("reality flow_override = %q, want Vision", f)
+	}
+}

--- a/internal/web/service/client_flow_override_test.go
+++ b/internal/web/service/client_flow_override_test.go
@@ -12,8 +12,6 @@ func TestClientWithFlow(t *testing.T) {
 		{Email: "b", Flow: "xtls-rprx-vision"},
 	}
 
-	// The override use case: clear the flow on b only, on a flow-capable inbound,
-	// without the capability clamp re-adding it.
 	got, found := clientWithFlow(clients, "b", "")
 	if !found {
 		t.Fatal("expected to find client b")
@@ -21,17 +19,14 @@ func TestClientWithFlow(t *testing.T) {
 	if got.Email != "b" || got.Flow != "" {
 		t.Fatalf("override failed: got email=%q flow=%q, want b/empty", got.Email, got.Flow)
 	}
-	// Returned value is a copy — the source slice is untouched.
 	if clients[1].Flow != "xtls-rprx-vision" {
 		t.Fatalf("source slice mutated: %q", clients[1].Flow)
 	}
 
-	// Setting Vision explicitly is preserved verbatim.
 	if got2, found2 := clientWithFlow(clients, "a", "xtls-rprx-vision"); !found2 || got2.Flow != "xtls-rprx-vision" {
 		t.Fatalf("set vision failed: found=%v flow=%q", found2, got2.Flow)
 	}
 
-	// A missing email is reported as not found.
 	if _, found3 := clientWithFlow(clients, "missing", ""); found3 {
 		t.Fatal("expected missing client to be not found")
 	}

--- a/internal/web/service/client_flow_override_test.go
+++ b/internal/web/service/client_flow_override_test.go
@@ -1,0 +1,38 @@
+package service
+
+import (
+	"testing"
+
+	"github.com/mhsanaei/3x-ui/v3/internal/database/model"
+)
+
+func TestClientWithFlow(t *testing.T) {
+	clients := []model.Client{
+		{Email: "a", Flow: "xtls-rprx-vision"},
+		{Email: "b", Flow: "xtls-rprx-vision"},
+	}
+
+	// The override use case: clear the flow on b only, on a flow-capable inbound,
+	// without the capability clamp re-adding it.
+	got, found := clientWithFlow(clients, "b", "")
+	if !found {
+		t.Fatal("expected to find client b")
+	}
+	if got.Email != "b" || got.Flow != "" {
+		t.Fatalf("override failed: got email=%q flow=%q, want b/empty", got.Email, got.Flow)
+	}
+	// Returned value is a copy — the source slice is untouched.
+	if clients[1].Flow != "xtls-rprx-vision" {
+		t.Fatalf("source slice mutated: %q", clients[1].Flow)
+	}
+
+	// Setting Vision explicitly is preserved verbatim.
+	if got2, found2 := clientWithFlow(clients, "a", "xtls-rprx-vision"); !found2 || got2.Flow != "xtls-rprx-vision" {
+		t.Fatalf("set vision failed: found=%v flow=%q", found2, got2.Flow)
+	}
+
+	// A missing email is reported as not found.
+	if _, found3 := clientWithFlow(clients, "missing", ""); found3 {
+		t.Fatal("expected missing client to be not found")
+	}
+}

--- a/internal/web/service/inbound_flow_restore.go
+++ b/internal/web/service/inbound_flow_restore.go
@@ -51,6 +51,9 @@ func (s *InboundService) restoreVisionFlowForEligibleInbound(tx *gorm.DB, settin
 		if flow, _ := cm["flow"].(string); flow != "" {
 			continue // respect an explicit flow (Vision or otherwise)
 		}
+		if locked, _ := cm["flowLock"].(bool); locked {
+			continue
+		}
 		if email, _ := cm["email"].(string); email != "" {
 			emails = append(emails, email)
 		}
@@ -69,6 +72,9 @@ func (s *InboundService) restoreVisionFlowForEligibleInbound(tx *gorm.DB, settin
 			continue
 		}
 		if flow, _ := cm["flow"].(string); flow != "" {
+			continue
+		}
+		if locked, _ := cm["flowLock"].(bool); locked {
 			continue
 		}
 		email, _ := cm["email"].(string)


### PR DESCRIPTION
Implements **approach (1)** from #5689 — a writable per-`(client, inbound)` XTLS flow, so a client can keep Vision on some flow-capable inbounds and an empty flow on others in the same subscription.

### Why

A client delivered on both a Reality inbound (Vision wanted) and a tunneled XHTTP+vlessenc inbound (Vision **not** wanted) currently gets `xtls-rprx-vision` on both — the single client-level flow is clamped per inbound by capability, but there's no way to clear it on one *capable* inbound while keeping it on another. See #5689.

### What this does

The relational per-membership store already exists (`client_inbounds.flow_override`) and is resolved by `EffectiveFlow` / `EffectiveFlowsByEmails`. This PR makes it **settable**:

- New service method `ClientService.SetInboundClientFlow(inboundSvc, inboundId, email, flow)` — sets the flow for one client on **one** inbound, bypassing the `clientWithInboundFlow` capability clamp. It writes the inbound `settings.clients[].flow` (what subscription generation reads) via the existing `UpdateInboundClient`, then mirrors the value onto `client_inbounds.flow_override`.
- New endpoint `POST …/clients/:email/flow` with body `{ "inboundId": <id>, "flow": "xtls-rprx-vision" | "" }`.
- A pure helper `clientWithFlow` (returns a copy with the flow applied) so the core is unit-testable without a DB.

### Open question for maintainers (the one design decision)

An explicit **empty** flow set here can be re-populated by `restoreVisionFlowForEligibleInbound` (#4792) if the inbound is later edited into a newly flow-eligible state, since that path treats an empty settings flow as "restore the intended Vision from a sibling". Making an explicit clear durable across such edits needs a small marker — e.g. a sentinel `flow_override` value (`"none"`) meaning *explicitly off*, or a per-membership lock flag. I left that out deliberately because it's a model/semantics choice that's yours to make; happy to implement whichever you prefer.

### Verification

- `go build ./internal/web/service/... ./internal/web/controller/...` — clean.
- `go test ./internal/web/service -run TestClientWithFlow` — passes (covers the override-clears-on-one-inbound and missing-email cases).
- Couldn't run the DB-integration paths locally (`CGO_ENABLED=0`) or boot a panel — so this is **draft** pending runtime verification.

### Status — draft

- [ ] Frontend: a per-inbound flow control in the client form (the API endpoint works in the meantime).
- [ ] Maintainer decision on the explicit-clear durability (above).
- [ ] Runtime verification on a live panel.

Alternative to #5690 (the inbound-level `DisableFlow` toggle) — both close part of #5689; pick whichever fits the design.
