### PR TITLE
Avoid RPM system upgrades before installing script dependencies

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -101,13 +101,13 @@ install_base() {
             apt-get update && apt-get install -y -q cron curl tar tzdata socat ca-certificates openssl
             ;;
         fedora | amzn | virtuozzo | rhel | almalinux | rocky | ol)
-            dnf -y update && dnf install -y -q cronie curl tar tzdata socat ca-certificates openssl
+            dnf makecache -y && dnf install -y -q cronie curl tar tzdata socat ca-certificates openssl
             ;;
         centos)
             if [[ "${VERSION_ID}" =~ ^7 ]]; then
-                yum -y update && yum install -y cronie curl tar tzdata socat ca-certificates openssl
+                yum makecache -y && yum install -y cronie curl tar tzdata socat ca-certificates openssl
             else
-                dnf -y update && dnf install -y -q cronie curl tar tzdata socat ca-certificates openssl
+                dnf makecache -y && dnf install -y -q cronie curl tar tzdata socat ca-certificates openssl
             fi
             ;;
         arch | manjaro | parch)

--- a/update.sh
+++ b/update.sh
@@ -187,7 +187,7 @@ install_base() {
             ;;
         centos)
             if [[ "${VERSION_ID}" =~ ^7 ]]; then
-                yum -y update > /dev/null 2>&1 && yum install -y -q cronie curl tar tzdata socat openssl > /dev/null 2>&1
+                yum makecache -y > /dev/null 2>&1 && yum install -y -q cronie curl tar tzdata socat openssl > /dev/null 2>&1
             else
                 dnf makecache -y > /dev/null 2>&1 && dnf install -y -q cronie curl tar tzdata socat openssl > /dev/null 2>&1
             fi

--- a/x-ui.sh
+++ b/x-ui.sh
@@ -1583,13 +1583,13 @@ ssl_cert_issue_for_ip() {
             apt-get update > /dev/null 2>&1 && apt-get install socat -y > /dev/null 2>&1
             ;;
         fedora | amzn | virtuozzo | rhel | almalinux | rocky | ol)
-            dnf -y update > /dev/null 2>&1 && dnf -y install socat > /dev/null 2>&1
+            dnf makecache -y > /dev/null 2>&1 && dnf -y install socat > /dev/null 2>&1
             ;;
         centos)
             if [[ "${VERSION_ID}" =~ ^7 ]]; then
-                yum -y update > /dev/null 2>&1 && yum -y install socat > /dev/null 2>&1
+                yum makecache -y > /dev/null 2>&1 && yum -y install socat > /dev/null 2>&1
             else
-                dnf -y update > /dev/null 2>&1 && dnf -y install socat > /dev/null 2>&1
+                dnf makecache -y > /dev/null 2>&1 && dnf -y install socat > /dev/null 2>&1
             fi
             ;;
         arch | manjaro | parch)
@@ -1749,13 +1749,13 @@ ssl_cert_issue() {
             apt-get update > /dev/null 2>&1 && apt-get install socat -y > /dev/null 2>&1
             ;;
         fedora | amzn | virtuozzo | rhel | almalinux | rocky | ol)
-            dnf -y update > /dev/null 2>&1 && dnf -y install socat > /dev/null 2>&1
+            dnf makecache -y > /dev/null 2>&1 && dnf -y install socat > /dev/null 2>&1
             ;;
         centos)
             if [[ "${VERSION_ID}" =~ ^7 ]]; then
-                yum -y update > /dev/null 2>&1 && yum -y install socat > /dev/null 2>&1
+                yum makecache -y > /dev/null 2>&1 && yum -y install socat > /dev/null 2>&1
             else
-                dnf -y update > /dev/null 2>&1 && dnf -y install socat > /dev/null 2>&1
+                dnf makecache -y > /dev/null 2>&1 && dnf -y install socat > /dev/null 2>&1
             fi
             ;;
         arch | manjaro | parch)
@@ -2286,14 +2286,14 @@ setup_fail2ban_iplimit() {
                 apt-get update && apt-get install fail2ban nftables -y
                 ;;
             fedora | amzn | virtuozzo | rhel | almalinux | rocky | ol)
-                dnf -y update && dnf -y install fail2ban nftables
+                dnf makecache -y && dnf -y install fail2ban nftables
                 ;;
             centos)
                 if [[ "${VERSION_ID}" =~ ^7 ]]; then
-                    yum update -y && yum install epel-release -y
+                    yum makecache -y && yum install epel-release -y
                     yum -y install fail2ban nftables
                 else
-                    dnf -y update && dnf -y install fail2ban nftables
+                    dnf makecache -y && dnf -y install fail2ban nftables
                 fi
                 ;;
             arch | manjaro | parch)


### PR DESCRIPTION
## Summary

Follow up on #5717 by replacing the remaining `dnf update` / `yum update` calls that run before installing specific script dependencies with `dnf makecache` / `yum makecache`.

## Why

PR #5717 fixed the update path for dnf-based systems in `update.sh`, and that change is correct. While reviewing the same behavior more broadly, there were still similar full-system-upgrade calls in `install.sh`, the CentOS 7 branch of `update.sh`, and a few dependency-install paths in `x-ui.sh`.

Those commands are used only to prepare for installing specific dependencies such as `cronie`, `curl`, `socat`, `fail2ban`, and `nftables`. They should refresh repository metadata, not upgrade unrelated system packages like the kernel, systemd, networking components, or other installed packages.

`dnf makecache` and `yum makecache` refresh package metadata without performing a full system upgrade. This keeps install/update/helper flows focused on the packages they actually need.

References:
- DNF `makecache`: https://dnf.readthedocs.io/en/latest/command_ref.html#makecache-command
- DNF `--refresh`: https://man7.org/linux/man-pages/man8/dnf.8.html
- Yum cache docs: https://docs.redhat.com/en/documentation/red_hat_enterprise_linux/6/html/deployment_guide/sec-working_with_yum_cache

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactoring (no behavior change)
- [ ] Documentation
- [ ] Tests only
- [ ] Build / CI / tooling
- [ ] Other

## Areas affected

- [ ] Frontend (UI / panel pages)
- [ ] Backend (API endpoints, login, settings)
- [ ] Xray config generation
- [ ] Subscription (share links / Clash / JSON)
- [ ] Statistics / traffic counters
- [ ] Database / migrations
- [x] Install / upgrade script
- [ ] Docker image
- [ ] Multi-node (sub-nodes)
- [ ] Telegram bot

## How was this tested?

- Ran `bash -n install.sh`
- Ran `bash -n update.sh`
- Ran `bash -n x-ui.sh`
- Ran `git diff --check`
- Verified no remaining `dnf/yum update` calls are present in the repository

## Screenshots / recordings

N/A

## Breaking changes

None

## Checklist

- [x] I tested the change locally and confirmed the described behavior.
- [x] I added or updated tests for the new behavior (when applicable).
- [ ] `go build ./...` and the test suite pass locally.
- [ ] For frontend changes: `npm run lint`, `npm run typecheck`, and `npm run build` pass.
- [ ] I updated the Wiki / README / API docs if user-facing behavior changed.
- [x] My commits follow the project's existing message style.
- [x] I have no unrelated changes mixed into this PR.
