### PR TITLE
refactor: use the built-in max/min to simplify the code

### DIFF
--- a/internal/web/service/client_groups.go
+++ b/internal/web/service/client_groups.go
@@ -55,14 +55,8 @@ func (s *ClientService) ListGroups() ([]GroupSummary, error) {
 	}
 	out := make([]GroupSummary, 0, len(merged))
 	for name, agg := range merged {
-		up := agg.up - baseUp[name]
-		if up < 0 {
-			up = 0
-		}
-		down := agg.down - baseDown[name]
-		if down < 0 {
-			down = 0
-		}
+		up := max(agg.up-baseUp[name], 0)
+		down := max(agg.down-baseDown[name], 0)
 		out = append(out, GroupSummary{Name: name, ClientCount: agg.count, TrafficUsed: up + down, Up: up, Down: down})
 	}
 	sort.Slice(out, func(i, j int) bool {


### PR DESCRIPTION
## Summary


In Go 1.21, the standard library includes built-in [max/min](https://pkg.go.dev/builtin@go1.21.0#max) function, which can greatly simplify the code.


## Why

<!--
What problem does this solve, or what use case does it enable?
Link related issues here: "Closes #123", "Refs #456".
-->

## Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Refactoring (no behavior change)
- [ ] Documentation
- [ ] Tests only
- [ ] Build / CI / tooling
- [ ] Other

## Areas affected

- [ ] Frontend (UI / panel pages)
- [ ] Backend (API endpoints, login, settings)
- [ ] Xray config generation
- [ ] Subscription (share links / Clash / JSON)
- [ ] Statistics / traffic counters
- [ ] Database / migrations
- [ ] Install / upgrade script
- [ ] Docker image
- [ ] Multi-node (sub-nodes)
- [ ] Telegram bot

## How was this tested?

<!--
Concrete steps the reviewer can repeat. For UI changes: which page,
which actions, which browser. For backend: which endpoint, which payload,
which response. Mention any new unit/integration tests added.
-->

## Screenshots / recordings

<!-- Required for UI changes. Drag images or GIFs here. Remove if N/A. -->

## Breaking changes

<!--
Does this change require existing users to update their config, run a
migration, or change their API calls? If yes, describe the migration path.
Write "None" if there are no breaking changes.
-->

## Checklist

- [x] I tested the change locally and confirmed the described behavior.
- [ ] I added or updated tests for the new behavior (when applicable).
- [x] `go build ./...` and the test suite pass locally.
- [x] For frontend changes: `npm run lint`, `npm run typecheck`, and `npm run build` pass.
- [ ] I updated the Wiki / README / API docs if user-facing behavior changed.
- [ ] My commits follow the project's existing message style.
- [x] I have no unrelated changes mixed into this PR.
