### PR TITLE
fix(node): avoid full inbound reconcile after client edits

### DIFF
--- a/internal/web/runtime/reconcile_skip_test.go
+++ b/internal/web/runtime/reconcile_skip_test.go
@@ -63,3 +63,119 @@ func TestReconcileInbound_SkipsUnchanged(t *testing.T) {
 		t.Fatalf("absent-on-node reconcile pushes=%d, want 3", got)
 	}
 }
+
+func TestRemotePerClientMutationsSeedReconcileFingerprint(t *testing.T) {
+	var inboundUpdates atomic.Int32
+	var clientMutations atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case strings.Contains(r.URL.Path, "/panel/api/inbounds/update/"):
+			inboundUpdates.Add(1)
+		case strings.Contains(r.URL.Path, "/panel/api/clients/"):
+			clientMutations.Add(1)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"success":true}`))
+	}))
+	defer srv.Close()
+
+	client := model.Client{ID: "11111111-1111-1111-1111-111111111111", Email: "a@x", SubID: "s", Enable: true}
+	tests := []struct {
+		name string
+		run  func(*Remote, *model.Inbound) error
+	}{
+		{"add", func(r *Remote, ib *model.Inbound) error {
+			return r.AddClient(context.Background(), ib, client)
+		}},
+		{"delete", func(r *Remote, ib *model.Inbound) error {
+			return r.DeleteUser(context.Background(), ib, client.Email)
+		}},
+		{"update", func(r *Remote, ib *model.Inbound) error {
+			return r.UpdateUser(context.Background(), ib, client.Email, client)
+		}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			inboundUpdates.Store(0)
+			clientMutations.Store(0)
+			r := NewRemote(nodeForPlainServer(t, srv, "verify", "tok"), nil)
+			ib := &model.Inbound{Tag: "in-" + tt.name, Protocol: model.VLESS, Port: 443, Settings: `{"clients":[{"id":"11111111-1111-1111-1111-111111111111","email":"a@x","subId":"s","enable":true}]}`}
+			r.cacheSet(ib.Tag, 7)
+
+			if err := tt.run(r, ib); err != nil {
+				t.Fatalf("%s client mutation: %v", tt.name, err)
+			}
+			if got := clientMutations.Load(); got != 1 {
+				t.Fatalf("%s client mutation requests=%d, want 1", tt.name, got)
+			}
+			if pushed, err := r.ReconcileInbound(context.Background(), ib, true); err != nil || pushed {
+				t.Fatalf("%s reconcile after client mutation: pushed=%v err=%v, want skip", tt.name, pushed, err)
+			}
+			if got := inboundUpdates.Load(); got != 0 {
+				t.Fatalf("%s reconcile sent %d full inbound updates, want 0", tt.name, got)
+			}
+		})
+	}
+}
+
+func TestDeleteUserNotFoundSeedsReconcileFingerprint(t *testing.T) {
+	var inboundUpdates atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.Contains(r.URL.Path, "/panel/api/inbounds/update/") {
+			inboundUpdates.Add(1)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		if strings.Contains(r.URL.Path, "/panel/api/clients/") {
+			_, _ = w.Write([]byte(`{"success":false,"msg":"client not found"}`))
+			return
+		}
+		_, _ = w.Write([]byte(`{"success":true}`))
+	}))
+	defer srv.Close()
+
+	r := NewRemote(nodeForPlainServer(t, srv, "verify", "tok"), nil)
+	ib := &model.Inbound{Tag: "in-delete-missing", Protocol: model.VLESS, Port: 443, Settings: `{"clients":[]}`}
+	r.cacheSet(ib.Tag, 7)
+
+	if err := r.DeleteUser(context.Background(), ib, "missing@x"); err != nil {
+		t.Fatalf("DeleteUser missing client: %v", err)
+	}
+	if pushed, err := r.ReconcileInbound(context.Background(), ib, true); err != nil || pushed {
+		t.Fatalf("reconcile after missing-client delete: pushed=%v err=%v, want skip", pushed, err)
+	}
+	if got := inboundUpdates.Load(); got != 0 {
+		t.Fatalf("reconcile sent %d full inbound updates, want 0", got)
+	}
+}
+
+func TestUpdateInboundFallbackAddSeedsReconcileFingerprint(t *testing.T) {
+	var adds atomic.Int32
+	var inboundUpdates atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case strings.Contains(r.URL.Path, "/panel/api/inbounds/add"):
+			adds.Add(1)
+		case strings.Contains(r.URL.Path, "/panel/api/inbounds/update/"):
+			inboundUpdates.Add(1)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"success":true}`))
+	}))
+	defer srv.Close()
+
+	r := NewRemote(nodeForPlainServer(t, srv, "verify", "tok"), nil)
+	ib := &model.Inbound{Tag: "in-add-fallback", Protocol: model.VLESS, Port: 443, Settings: `{"clients":[]}`}
+
+	if err := r.UpdateInbound(context.Background(), ib, ib); err != nil {
+		t.Fatalf("UpdateInbound fallback add: %v", err)
+	}
+	if got := adds.Load(); got != 1 {
+		t.Fatalf("fallback add requests=%d, want 1", got)
+	}
+	if pushed, err := r.ReconcileInbound(context.Background(), ib, true); err != nil || pushed {
+		t.Fatalf("reconcile after fallback add: pushed=%v err=%v, want skip", pushed, err)
+	}
+	if got := inboundUpdates.Load(); got != 0 {
+		t.Fatalf("reconcile sent %d full inbound updates, want 0", got)
+	}
+}

--- a/internal/web/runtime/remote.go
+++ b/internal/web/runtime/remote.go
@@ -407,6 +407,7 @@ func (r *Remote) AddInbound(ctx context.Context, ib *model.Inbound) error {
 			r.cacheSet(created.Tag, created.Id)
 		}
 	}
+	r.rememberPushedInbound(ib)
 	return nil
 }
 
@@ -436,6 +437,7 @@ func (r *Remote) UpdateInbound(ctx context.Context, oldIb, newIb *model.Inbound)
 		r.cacheDel(oldIb.Tag)
 	}
 	r.cacheSet(newIb.Tag, id)
+	r.rememberPushedInbound(newIb)
 	return nil
 }
 
@@ -457,10 +459,13 @@ func (r *Remote) ReconcileInbound(ctx context.Context, ib *model.Inbound, exists
 	if err := r.UpdateInbound(ctx, ib, ib); err != nil {
 		return false, err
 	}
-	r.mu.Lock()
-	r.pushedFP[ib.Tag] = fp
-	r.mu.Unlock()
 	return true, nil
+}
+
+func (r *Remote) rememberPushedInbound(ib *model.Inbound) {
+	r.mu.Lock()
+	r.pushedFP[ib.Tag] = wireFingerprint(wireInbound(ib, r.node.Id))
+	r.mu.Unlock()
 }
 
 // wireFingerprint hashes a wire payload so an unchanged inbound is cheap to detect.
@@ -489,6 +494,7 @@ func (r *Remote) AddClient(ctx context.Context, ib *model.Inbound, client model.
 	if _, err := r.do(ctx, http.MethodPost, "panel/api/clients/add", payload); err != nil {
 		return err
 	}
+	r.rememberPushedInbound(ib)
 	return nil
 }
 
@@ -507,9 +513,11 @@ func (r *Remote) DeleteUser(ctx context.Context, ib *model.Inbound, email string
 	_, err = r.do(ctx, http.MethodPost,
 		"panel/api/clients/"+url.PathEscape(email)+"/detach", body)
 	if err == nil {
+		r.rememberPushedInbound(ib)
 		return nil
 	}
 	if strings.Contains(strings.ToLower(err.Error()), "not found") {
+		r.rememberPushedInbound(ib)
 		return nil
 	}
 	return err
@@ -528,6 +536,7 @@ func (r *Remote) UpdateUser(ctx context.Context, ib *model.Inbound, oldEmail str
 	if _, err := r.do(ctx, http.MethodPost, path, payload); err != nil {
 		return err
 	}
+	r.rememberPushedInbound(ib)
 	return nil
 }
 

--- a/internal/web/runtime/remote.go
+++ b/internal/web/runtime/remote.go
@@ -407,7 +407,7 @@ func (r *Remote) AddInbound(ctx context.Context, ib *model.Inbound) error {
 			r.cacheSet(created.Tag, created.Id)
 		}
 	}
-	r.rememberPushedInbound(ib)
+	r.RecordPushedInbound(ib)
 	return nil
 }
 
@@ -437,7 +437,7 @@ func (r *Remote) UpdateInbound(ctx context.Context, oldIb, newIb *model.Inbound)
 		r.cacheDel(oldIb.Tag)
 	}
 	r.cacheSet(newIb.Tag, id)
-	r.rememberPushedInbound(newIb)
+	r.RecordPushedInbound(newIb)
 	return nil
 }
 
@@ -459,10 +459,15 @@ func (r *Remote) ReconcileInbound(ctx context.Context, ib *model.Inbound, exists
 	if err := r.UpdateInbound(ctx, ib, ib); err != nil {
 		return false, err
 	}
+	r.mu.Lock()
+	r.pushedFP[ib.Tag] = fp
+	r.mu.Unlock()
 	return true, nil
 }
 
-func (r *Remote) rememberPushedInbound(ib *model.Inbound) {
+// RecordPushedInbound explicitly stamps the inbound fingerprint after a multi-client
+// edit or bulk operation.
+func (r *Remote) RecordPushedInbound(ib *model.Inbound) {
 	r.mu.Lock()
 	r.pushedFP[ib.Tag] = wireFingerprint(wireInbound(ib, r.node.Id))
 	r.mu.Unlock()
@@ -494,7 +499,7 @@ func (r *Remote) AddClient(ctx context.Context, ib *model.Inbound, client model.
 	if _, err := r.do(ctx, http.MethodPost, "panel/api/clients/add", payload); err != nil {
 		return err
 	}
-	r.rememberPushedInbound(ib)
+	r.RecordPushedInbound(ib)
 	return nil
 }
 
@@ -513,11 +518,11 @@ func (r *Remote) DeleteUser(ctx context.Context, ib *model.Inbound, email string
 	_, err = r.do(ctx, http.MethodPost,
 		"panel/api/clients/"+url.PathEscape(email)+"/detach", body)
 	if err == nil {
-		r.rememberPushedInbound(ib)
+		r.RecordPushedInbound(ib)
 		return nil
 	}
 	if strings.Contains(strings.ToLower(err.Error()), "not found") {
-		r.rememberPushedInbound(ib)
+		r.RecordPushedInbound(ib)
 		return nil
 	}
 	return err
@@ -536,7 +541,7 @@ func (r *Remote) UpdateUser(ctx context.Context, ib *model.Inbound, oldEmail str
 	if _, err := r.do(ctx, http.MethodPost, path, payload); err != nil {
 		return err
 	}
-	r.rememberPushedInbound(ib)
+	r.RecordPushedInbound(ib)
 	return nil
 }
 

--- a/internal/web/service/bulk_clients_test.go
+++ b/internal/web/service/bulk_clients_test.go
@@ -26,7 +26,15 @@ func clientsSettings(t *testing.T, clients []model.Client) string {
 	if err != nil {
 		t.Fatalf("marshal settings: %v", err)
 	}
-	return string(b)
+	var out map[string]any
+	if err := json.Unmarshal(b, &out); err != nil {
+		t.Fatalf("unmarshal settings: %v", err)
+	}
+	b2, err := json.MarshalIndent(out, "", "  ")
+	if err != nil {
+		t.Fatalf("marshal settings again: %v", err)
+	}
+	return string(b2)
 }
 
 func emailsOf(clients []model.Client) []string {

--- a/internal/web/service/client_bulk.go
+++ b/internal/web/service/client_bulk.go
@@ -682,6 +682,8 @@ func (s *ClientService) bulkAdjustInboundClients(
 					updated.UpdatedAt = nowMs
 					if err1 := rt.UpdateUser(context.Background(), oldInbound, email, updated); err1 != nil {
 						logger.Warning("Error in updating client on", rt.Name(), ":", err1)
+					} else if r, ok := rt.(interface{ RecordPushedInbound(*model.Inbound) }); ok {
+						r.RecordPushedInbound(oldInbound)
 					}
 				}
 			}
@@ -1630,6 +1632,8 @@ func (s *ClientService) bulkSetEnableInboundClients(inboundSvc *InboundService, 
 			updated.UpdatedAt = nowMs
 			if err1 := rt.UpdateUser(context.Background(), oldInbound, ch.email, updated); err1 != nil {
 				logger.Warning("Error in updating client on", rt.Name(), ":", err1)
+			} else if r, ok := rt.(interface{ RecordPushedInbound(*model.Inbound) }); ok {
+				r.RecordPushedInbound(oldInbound)
 			}
 		}
 	}

--- a/internal/web/service/client_inbound_apply.go
+++ b/internal/web/service/client_inbound_apply.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"maps"
-	"reflect"
 	"strings"
 	"time"
 
@@ -25,7 +24,9 @@ func sameClientConfigExceptUpdatedAt(a, b map[string]any) bool {
 	bb := maps.Clone(b)
 	delete(aa, "updated_at")
 	delete(bb, "updated_at")
-	return reflect.DeepEqual(aa, bb)
+	an, aerr := json.Marshal(aa)
+	bn, berr := json.Marshal(bb)
+	return aerr == nil && berr == nil && string(an) == string(bn)
 }
 
 // delInboundClients removes several clients from a single inbound in one pass:
@@ -213,6 +214,8 @@ func (s *ClientService) delInboundClients(inboundSvc *InboundService, inboundId 
 		} else if nodePush {
 			if err1 := nodeRt.DeleteUser(context.Background(), oldInbound, t.email); err1 != nil {
 				logger.Warning("Error in deleting client on", nodeRt.Name(), ":", err1)
+			} else if r, ok := nodeRt.(interface{ RecordPushedInbound(*model.Inbound) }); ok {
+				r.RecordPushedInbound(oldInbound)
 			}
 		}
 	}
@@ -572,10 +575,6 @@ func (s *ClientService) UpdateInboundClient(inboundSvc *InboundService, data *mo
 	if err != nil {
 		return false, err
 	}
-	var oldSettingsBefore map[string]any
-	if err := json.Unmarshal([]byte(oldInbound.Settings), &oldSettingsBefore); err != nil {
-		return false, err
-	}
 	settingsClients, _ := oldSettings["clients"].([]any)
 	var preservedCreated any
 	var preservedUpdated any
@@ -653,13 +652,13 @@ func (s *ClientService) UpdateInboundClient(inboundSvc *InboundService, data *mo
 		}
 	}
 
-	if reflect.DeepEqual(oldSettingsBefore, oldSettings) {
-		return false, nil
-	}
-
 	newSettings, err := json.MarshalIndent(oldSettings, "", "  ")
 	if err != nil {
 		return false, err
+	}
+
+	if string(newSettings) == oldInbound.Settings {
+		return false, nil
 	}
 
 	oldInbound.Settings = string(newSettings)
@@ -800,6 +799,8 @@ func (s *ClientService) UpdateInboundClient(inboundSvc *InboundService, data *mo
 		} else if push {
 			if err1 := rt.UpdateUser(context.Background(), oldInbound, oldEmail, clients[0]); err1 != nil {
 				logger.Warning("Error in updating client on", rt.Name(), ":", err1)
+			} else if r, ok := rt.(interface{ RecordPushedInbound(*model.Inbound) }); ok {
+				r.RecordPushedInbound(oldInbound)
 			}
 		}
 	} else {
@@ -954,6 +955,8 @@ func (s *ClientService) DelInboundClientByEmail(inboundSvc *InboundService, inbo
 			if push {
 				if err1 := rt.DeleteUser(context.Background(), oldInbound, email); err1 != nil {
 					logger.Warning("Error in deleting client on", rt.Name(), ":", err1)
+				} else if r, ok := rt.(interface{ RecordPushedInbound(*model.Inbound) }); ok {
+					r.RecordPushedInbound(oldInbound)
 				}
 			}
 		}

--- a/internal/web/service/client_inbound_apply.go
+++ b/internal/web/service/client_inbound_apply.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"maps"
+	"reflect"
 	"strings"
 	"time"
 
@@ -17,6 +19,14 @@ import (
 
 	"gorm.io/gorm"
 )
+
+func sameClientConfigExceptUpdatedAt(a, b map[string]any) bool {
+	aa := maps.Clone(a)
+	bb := maps.Clone(b)
+	delete(aa, "updated_at")
+	delete(bb, "updated_at")
+	return reflect.DeepEqual(aa, bb)
+}
 
 // delInboundClients removes several clients from a single inbound in one pass:
 // one settings rewrite, one runtime sweep, one Save and one SyncInbound for the
@@ -562,13 +572,23 @@ func (s *ClientService) UpdateInboundClient(inboundSvc *InboundService, data *mo
 	if err != nil {
 		return false, err
 	}
+	var oldSettingsBefore map[string]any
+	if err := json.Unmarshal([]byte(oldInbound.Settings), &oldSettingsBefore); err != nil {
+		return false, err
+	}
 	settingsClients, _ := oldSettings["clients"].([]any)
 	var preservedCreated any
+	var preservedUpdated any
 	var preservedSubID string
+	var oldClientMap map[string]any
 	if clientIndex >= 0 && clientIndex < len(settingsClients) {
 		if oldMap, ok := settingsClients[clientIndex].(map[string]any); ok {
+			oldClientMap = oldMap
 			if v, ok2 := oldMap["created_at"]; ok2 {
 				preservedCreated = v
+			}
+			if v, ok2 := oldMap["updated_at"]; ok2 {
+				preservedUpdated = v
 			}
 			preservedSubID, _ = oldMap["subId"].(string)
 		}
@@ -579,7 +599,6 @@ func (s *ClientService) UpdateInboundClient(inboundSvc *InboundService, data *mo
 				preservedCreated = time.Now().Unix() * 1000
 			}
 			newMap["created_at"] = preservedCreated
-			newMap["updated_at"] = time.Now().Unix() * 1000
 			newSub, _ := newMap["subId"].(string)
 			if strings.TrimSpace(newSub) == "" {
 				if strings.TrimSpace(preservedSubID) != "" {
@@ -598,6 +617,15 @@ func (s *ClientService) UpdateInboundClient(inboundSvc *InboundService, data *mo
 				if clients[0].KeepAlive > 0 {
 					newMap["keepAlive"] = clients[0].KeepAlive
 				}
+			}
+			if oldClientMap != nil && sameClientConfigExceptUpdatedAt(oldClientMap, newMap) {
+				if preservedUpdated != nil {
+					newMap["updated_at"] = preservedUpdated
+				} else {
+					delete(newMap, "updated_at")
+				}
+			} else {
+				newMap["updated_at"] = time.Now().Unix() * 1000
 			}
 			interfaceClients[0] = newMap
 		}
@@ -623,6 +651,10 @@ func (s *ClientService) UpdateInboundClient(inboundSvc *InboundService, data *mo
 		if !hasVisionFlow {
 			delete(oldSettings, "testseed")
 		}
+	}
+
+	if reflect.DeepEqual(oldSettingsBefore, oldSettings) {
+		return false, nil
 	}
 
 	newSettings, err := json.MarshalIndent(oldSettings, "", "  ")

--- a/internal/web/service/node_bulk_dispatch_test.go
+++ b/internal/web/service/node_bulk_dispatch_test.go
@@ -141,6 +141,81 @@ func TestNodeBulk_SmallAddPushesLive(t *testing.T) {
 	}
 }
 
+func TestNodeUpdateInboundClientNoopSkipsRuntimeAndDirty(t *testing.T) {
+	setupBulkDB(t)
+	nodeID, fake := setupNodeRuntime(t)
+	client := model.Client{
+		ID:        uuid.NewString(),
+		Email:     "noop@x",
+		SubID:     "sub-noop",
+		Enable:    true,
+		CreatedAt: 111,
+		UpdatedAt: 222,
+	}
+	ib := nodeInbound(t, nodeID, 30020, []model.Client{client})
+
+	svc := &ClientService{}
+	inboundSvc := &InboundService{}
+	if _, err := svc.UpdateInboundClient(inboundSvc, &model.Inbound{
+		Id:       ib.Id,
+		Protocol: model.VLESS,
+		Settings: clientsSettings(t, []model.Client{client}),
+	}, client.Email); err != nil {
+		t.Fatalf("UpdateInboundClient: %v", err)
+	}
+
+	if got := fake.updateUser.Load(); got != 0 {
+		t.Fatalf("no-op update streamed %d UpdateUser RPCs, want 0", got)
+	}
+	if _, _, dirty, _, err := (&NodeService{}).NodeSyncState(nodeID); err != nil {
+		t.Fatalf("NodeSyncState: %v", err)
+	} else if dirty {
+		t.Fatal("no-op update must not mark the node dirty")
+	}
+	reloaded, err := inboundSvc.GetInbound(ib.Id)
+	if err != nil {
+		t.Fatalf("GetInbound: %v", err)
+	}
+	if reloaded.Settings != ib.Settings {
+		t.Fatal("no-op update rewrote inbound settings")
+	}
+}
+
+func TestNodeUpdateInboundClientLivePushKeepsDirtyBackup(t *testing.T) {
+	setupBulkDB(t)
+	nodeID, fake := setupNodeRuntime(t)
+	client := model.Client{
+		ID:        uuid.NewString(),
+		Email:     "edit@x",
+		SubID:     "sub-edit",
+		Enable:    true,
+		CreatedAt: 111,
+		UpdatedAt: 222,
+	}
+	ib := nodeInbound(t, nodeID, 30021, []model.Client{client})
+
+	edited := client
+	edited.Comment = "changed"
+	svc := &ClientService{}
+	inboundSvc := &InboundService{}
+	if _, err := svc.UpdateInboundClient(inboundSvc, &model.Inbound{
+		Id:       ib.Id,
+		Protocol: model.VLESS,
+		Settings: clientsSettings(t, []model.Client{edited}),
+	}, client.Email); err != nil {
+		t.Fatalf("UpdateInboundClient: %v", err)
+	}
+
+	if got := fake.updateUser.Load(); got != 1 {
+		t.Fatalf("edit streamed %d UpdateUser RPCs, want 1", got)
+	}
+	if _, _, dirty, _, err := (&NodeService{}).NodeSyncState(nodeID); err != nil {
+		t.Fatalf("NodeSyncState: %v", err)
+	} else if !dirty {
+		t.Fatal("successful live update should keep node dirty as reconcile backup")
+	}
+}
+
 // TestNodeBulk_LargeDeleteFoldsToDirty: deleting more than the threshold from an
 // online node inbound must fold into a reconcile rather than per-client deletes.
 func TestNodeBulk_LargeDeleteFoldsToDirty(t *testing.T) {


### PR DESCRIPTION
## Summary

Avoids remote-node full inbound reconciles caused by client edits, especially no-op client saves.

- No-op `UpdateInboundClient` now preserves the existing client `updated_at` and returns before any DB write, runtime RPC, or node dirty mark when the effective settings did not change.
- Successful remote per-client add/update/delete calls now record the pushed inbound fingerprint, so the later dirty-node reconcile keeps the crash-recovery safety net but skips `panel/api/inbounds/update/:id` when the node already has the same wire payload.

## Why

Closes #5764.
Closes #5771.

Saving an unchanged client used to stamp a fresh `updated_at`, mark the remote node dirty, then let the 5s node sync send a full inbound update. On the node that full update removes/re-adds the Xray inbound handler, which matches the reported traffic stop while the Xray process still appears running.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactoring (no behavior change)
- [ ] Documentation
- [ ] Tests only
- [ ] Build / CI / tooling
- [ ] Other

## Areas affected

- [ ] Frontend (UI / panel pages)
- [x] Backend (API endpoints, login, settings)
- [ ] Xray config generation
- [ ] Subscription (share links / Clash / JSON)
- [ ] Statistics / traffic counters
- [ ] Database / migrations
- [ ] Install / upgrade script
- [ ] Docker image
- [x] Multi-node (sub-nodes)
- [ ] Telegram bot

## How was this tested?

- `go test ./internal/web/service ./internal/web/runtime -run 'TestNodeUpdateInboundClient(NoopSkipsRuntimeAndDirty|LivePushKeepsDirtyBackup)$|TestRemotePerClientMutationsSeedReconcileFingerprint$|TestReconcileInbound_SkipsUnchanged$' -count=1`
- `go test ./internal/web/service ./internal/web/runtime -count=1`
- `go test ./...`
- `go test -shuffle=on -count=1 ./...`
- `go test -race -shuffle=on -count=1 ./...`
- `go test -run '^$' -fuzz 'FuzzParseLink$' -fuzztime=30s ./internal/util/link/`
- `go test -run '^$' -fuzz 'FuzzDecodeCertPin$' -fuzztime=30s ./internal/web/runtime/`
- `go build ./...`
- `golangci-lint run`
- `go run golang.org/x/vuln/cmd/govulncheck@latest ./...`
- `cd frontend && npm ci && npm run lint && npm run typecheck && npm test && npm run build && npm audit --audit-level=high`
- `git diff --check`

## Screenshots / recordings

N/A — backend-only change.

## Breaking changes

None.

## Checklist

- [x] I tested the change locally and confirmed the described behavior.
- [x] I added or updated tests for the new behavior (when applicable).
- [x] `go build ./...` and the test suite pass locally.
- [x] For frontend changes: `npm run lint`, `npm run typecheck`, and `npm run build` pass. (No frontend changes; ran anyway.)
- [x] I updated the Wiki / README / API docs if user-facing behavior changed. (N/A.)
- [x] My commits follow the project's existing message style.
- [x] I have no unrelated changes mixed into this PR.
