### PR TITLE
fix(script): correct hardcoded menu option numbers in x-ui.sh

### DIFF
--- a/x-ui.sh
+++ b/x-ui.sh
@@ -467,12 +467,12 @@ check_config() {
                 start 0 > /dev/null 2>&1
             else
                 LOGE "IP certificate setup failed."
-                echo -e "${yellow}You can try again via option 19 (SSL Certificate Management).${plain}"
+                echo -e "${yellow}You can try again via option 20 (SSL Certificate Management).${plain}"
                 start 0 > /dev/null 2>&1
             fi
         else
             echo -e "${yellow}Access URL: http://${server_ip}:${existing_port}${existing_webBasePath}${plain}"
-            echo -e "${yellow}For security, please configure SSL certificate using option 19 (SSL Certificate Management)${plain}"
+            echo -e "${yellow}For security, please configure SSL certificate using option 20 (SSL Certificate Management)${plain}"
         fi
     fi
 }
@@ -3069,7 +3069,7 @@ migrate_to_postgres() {
     if check_status; then
         LOGI "Migration complete. The panel is now running on PostgreSQL."
     else
-        LOGE "Panel did not come up. Check logs (option 16). Your SQLite data is left intact."
+        LOGE "Panel did not come up. Check logs (option 17). Your SQLite data is left intact."
     fi
 }
 

--- a/x-ui.sh
+++ b/x-ui.sh
@@ -467,12 +467,12 @@ check_config() {
                 start 0 > /dev/null 2>&1
             else
                 LOGE "IP certificate setup failed."
-                echo -e "${yellow}You can try again via option 20 (SSL Certificate Management).${plain}"
+                echo -e "${yellow}You can try again via main menu option 20 (SSL Certificate Management).${plain}"
                 start 0 > /dev/null 2>&1
             fi
         else
             echo -e "${yellow}Access URL: http://${server_ip}:${existing_port}${existing_webBasePath}${plain}"
-            echo -e "${yellow}For security, please configure SSL certificate using option 20 (SSL Certificate Management)${plain}"
+            echo -e "${yellow}For security, please configure SSL certificate using main menu option 20 (SSL Certificate Management)${plain}"
         fi
     fi
 }
@@ -3069,7 +3069,7 @@ migrate_to_postgres() {
     if check_status; then
         LOGI "Migration complete. The panel is now running on PostgreSQL."
     else
-        LOGE "Panel did not come up. Check logs (option 17). Your SQLite data is left intact."
+        LOGE "Panel did not come up. Check logs (main menu option 17). Your SQLite data is left intact."
     fi
 }
 


### PR DESCRIPTION
## Summary

Fixed the incorrect option numbers in the prompt message.
The error messages referenced option 19 for SSL Certificate Management and option 16 for Logs Management, but the actual positions in show_menu are 20 and 17 respectively.

## Why

Fixed the incorrect option numbers in the prompt message.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactoring (no behavior change)
- [ ] Documentation
- [ ] Tests only
- [ ] Build / CI / tooling
- [ ] Other

## Areas affected

- [ ] Frontend (UI / panel pages)
- [ ] Backend (API endpoints, login, settings)
- [ ] Xray config generation
- [ ] Subscription (share links / Clash / JSON)
- [ ] Statistics / traffic counters
- [ ] Database / migrations
- [x] Install / upgrade script
- [ ] Docker image
- [ ] Multi-node (sub-nodes)
- [ ] Telegram bot

## How was this tested?

Manually verified: confirmed the main menu in show_menu() shows SSL Certificate Management at position 20 and Logs Management at
position 17, matching the updated messages. No automated tests cover the shell script.

## Screenshots / recordings

N/A

## Breaking changes

None.

## Checklist

- [x] I tested the change locally and confirmed the described behavior.
- [x] I added or updated tests for the new behavior (when applicable).
- [x] `go build ./...` and the test suite pass locally.
- [x] For frontend changes: `npm run lint`, `npm run typecheck`, and `npm run build` pass.
- [x] I updated the Wiki / README / API docs if user-facing behavior changed.
- [x] My commits follow the project's existing message style.
- [x] I have no unrelated changes mixed into this PR.
