### PR TITLE
perf(database): batch traffic writes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 .vscode/
 .cursor/
 .claude/*
+.agents/
 .cache/
 .sync*
 
@@ -44,4 +45,3 @@ docker-compose.override.yml
 
 # Ignore .env (Environment Variables) file
 .env
-

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -563,7 +563,8 @@ root → `go build ./...` / `go run main.go`.
 - **Module path is `.../v3`.** Internal imports use `github.com/mhsanaei/3x-ui/v3/internal/...`.
 - **SQLite vs Postgres.** Default is SQLite at `{XUI_DB_FOLDER}/x-ui.db`. Postgres via
   `XUI_DB_TYPE=postgres` + `XUI_DB_DSN`. Some SQL paths are dialect-aware (`database/dialect.go`);
-  test both when touching raw queries (there are `*_scale_postgres_test.go` suites).
+  test both when touching raw queries (there are `*_scale_postgres_test.go` suites). SQLite runs
+  in WAL mode; DB-specific post-migrate indexes live in `internal/database/db.go`.
 - **`Inbound.Settings` / `StreamSettings` / `Sniffing` are raw JSON strings**, not structured
   columns. Parsing/validation happens in services and the `xray` package, not in GORM.
 - **Hot-reload is the default; full restart is the fallback.** Changes that look config-only

--- a/internal/database/db.go
+++ b/internal/database/db.go
@@ -95,6 +95,9 @@ func initModels() error {
 			return err
 		}
 	}
+	if err := initDatabaseIndexes(); err != nil {
+		return err
+	}
 	if err := migrateHostVerifyPeerCertByNameColumn(); err != nil {
 		return err
 	}
@@ -123,6 +126,38 @@ func initModels() error {
 		}
 	}
 	return nil
+}
+
+func initDatabaseIndexes() error {
+	if IsPostgres() {
+		return initPostgresIndexes()
+	}
+	return db.Exec("CREATE INDEX IF NOT EXISTS idx_inbounds_remark ON inbounds (remark)").Error
+}
+
+func initPostgresIndexes() error {
+	sqlDB, err := db.DB()
+	if err != nil {
+		return err
+	}
+	ctx := context.Background()
+	for _, stmt := range []string{
+		"CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_client_traffics_email_up_down ON client_traffics (email) INCLUDE (up, down, last_online)",
+		"CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_clients_tg_id ON clients (tg_id) WHERE tg_id != 0",
+		"CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_clients_uuid ON clients (uuid) WHERE uuid != ''",
+	} {
+		if _, err := sqlDB.ExecContext(ctx, stmt); err != nil {
+			return err
+		}
+	}
+	var hasTrgm bool
+	if err := sqlDB.QueryRowContext(ctx, "SELECT EXISTS (SELECT 1 FROM pg_extension WHERE extname = 'pg_trgm')").Scan(&hasTrgm); err != nil {
+		return err
+	}
+	if hasTrgm {
+		_, err = sqlDB.ExecContext(ctx, "CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_inbounds_remark_trgm ON inbounds USING gin (remark gin_trgm_ops)")
+	}
+	return err
 }
 
 // postgresModelSettled skips AutoMigrate when table, columns, and indexes all exist:
@@ -1269,10 +1304,10 @@ func InitDB(dbPath string) error {
 		if err = os.MkdirAll(dir, 0o755); err != nil {
 			return err
 		}
-		// Keep journal_mode=DELETE so the DB stays a single file (no -wal/-shm
-		// sidecars). synchronous defaults to FULL for durability but is tunable.
+		// WAL keeps readers moving during traffic writes; synchronous remains
+		// tunable for operators that want a different durability/speed tradeoff.
 		sync := sqliteSynchronous()
-		dsn := dbPath + "?_journal_mode=DELETE&_busy_timeout=10000&_synchronous=" + sync + "&_txlock=immediate"
+		dsn := dbPath + "?_journal_mode=WAL&_busy_timeout=10000&_synchronous=" + sync + "&_txlock=immediate"
 		db, err = gorm.Open(sqlite.Open(dsn), c)
 		if err != nil {
 			return err
@@ -1282,12 +1317,11 @@ func InitDB(dbPath string) error {
 			return err
 		}
 		// Re-assert the DSN pragmas plus scan-friendly ones for large datasets.
-		// cache_size/mmap_size/temp_store create no extra files, so the single-file
-		// guarantee holds; they just cut disk I/O on the 50k-row hot paths.
 		pragmas := []string{
-			"PRAGMA journal_mode=DELETE",
+			"PRAGMA journal_mode=WAL",
 			"PRAGMA busy_timeout=10000",
 			"PRAGMA synchronous=" + sync,
+			"PRAGMA wal_autocheckpoint=1000",
 			fmt.Sprintf("PRAGMA cache_size=-%d", envInt("XUI_DB_CACHE_MB", 32)*1024),
 			fmt.Sprintf("PRAGMA mmap_size=%d", int64(envInt("XUI_DB_MMAP_MB", 256))*1024*1024),
 			"PRAGMA temp_store=MEMORY",

--- a/internal/database/db_settled_test.go
+++ b/internal/database/db_settled_test.go
@@ -2,6 +2,7 @@ package database
 
 import (
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/mhsanaei/3x-ui/v3/internal/database/model"
@@ -53,5 +54,26 @@ func TestPostgresModelSettled_TracksSchemaPresence(t *testing.T) {
 	}
 	if postgresModelSettled(&model.ClientGroup{}) {
 		t.Error("ClientGroup settled despite missing table")
+	}
+}
+
+func TestInitDBSQLitePragmasAndIndexes(t *testing.T) {
+	if err := InitDB(filepath.Join(t.TempDir(), "x-ui.db")); err != nil {
+		t.Fatalf("InitDB: %v", err)
+	}
+	t.Cleanup(func() { _ = CloseDB() })
+
+	var journalMode string
+	if err := db.Raw("PRAGMA journal_mode").Scan(&journalMode).Error; err != nil {
+		t.Fatalf("journal_mode: %v", err)
+	}
+	if strings.ToLower(journalMode) != "wal" {
+		t.Fatalf("journal_mode = %q, want wal", journalMode)
+	}
+	if !db.Migrator().HasIndex(&model.Inbound{}, "idx_inbounds_remark") {
+		t.Fatal("expected idx_inbounds_remark")
+	}
+	if !db.Migrator().HasIndex(&model.ClientRecord{}, "idx_clients_tg_id") {
+		t.Fatal("expected idx_clients_tg_id")
 	}
 }

--- a/internal/database/dialect.go
+++ b/internal/database/dialect.go
@@ -83,10 +83,10 @@ func batchIncrementInboundTrafficPG(tx *gorm.DB, deltas []TrafficDelta) error {
 	return tx.Exec(sb.String(), args...).Error
 }
 
-// ponytail: 3 vars per row, chunks at 333 rows (~999 vars). Upgrade to temp-table
+// ponytail: 5 vars per row (2*CASE + IN), chunks at ~199 rows (~999 vars). Upgrade to temp-table
 // approach if inbound count exceeds this.
 func batchIncrementInboundTrafficSQLite(tx *gorm.DB, deltas []TrafficDelta) error {
-	const varsPerRow = 3
+	const varsPerRow = 5
 	chunkSize := sqliteMaxVars / varsPerRow
 	for start := 0; start < len(deltas); start += chunkSize {
 		end := start + chunkSize

--- a/internal/database/dialect.go
+++ b/internal/database/dialect.go
@@ -1,6 +1,11 @@
 package database
 
-import "fmt"
+import (
+	"fmt"
+	"strings"
+
+	"gorm.io/gorm"
+)
 
 func JSONClientsFromInbound() string {
 	if IsPostgres() {
@@ -29,4 +34,163 @@ func ClientTrafficEnableMergeExpr() string {
 		return "CASE WHEN ?::boolean THEN enable::boolean ELSE false END"
 	}
 	return "CASE WHEN ? THEN enable ELSE 0 END"
+}
+
+func CastBigint(placeholder string) string {
+	if IsPostgres() {
+		return fmt.Sprintf("CAST(%s AS BIGINT)", placeholder)
+	}
+	return placeholder
+}
+
+type TrafficDelta struct {
+	Tag  string
+	Up   int64
+	Down int64
+}
+
+type ClientTrafficDelta struct {
+	Email      string
+	Up         int64
+	Down       int64
+	LastOnline int64
+}
+
+const sqliteMaxVars = 999
+
+func BatchIncrementInboundTraffic(tx *gorm.DB, deltas []TrafficDelta) error {
+	if len(deltas) == 0 {
+		return nil
+	}
+	if IsPostgres() {
+		return batchIncrementInboundTrafficPG(tx, deltas)
+	}
+	return batchIncrementInboundTrafficSQLite(tx, deltas)
+}
+
+func batchIncrementInboundTrafficPG(tx *gorm.DB, deltas []TrafficDelta) error {
+	var sb strings.Builder
+	args := make([]any, 0, len(deltas)*3)
+	sb.WriteString("UPDATE inbounds SET up = inbounds.up + v.delta_up, down = inbounds.down + v.delta_down FROM (VALUES ")
+	for i, d := range deltas {
+		if i > 0 {
+			sb.WriteString(", ")
+		}
+		sb.WriteString("(?::text, ?::bigint, ?::bigint)")
+		args = append(args, d.Tag, d.Up, d.Down)
+	}
+	sb.WriteString(") AS v(tag, delta_up, delta_down) WHERE inbounds.tag = v.tag AND inbounds.node_id IS NULL")
+	return tx.Exec(sb.String(), args...).Error
+}
+
+// ponytail: 3 vars per row, chunks at 333 rows (~999 vars). Upgrade to temp-table
+// approach if inbound count exceeds this.
+func batchIncrementInboundTrafficSQLite(tx *gorm.DB, deltas []TrafficDelta) error {
+	const varsPerRow = 3
+	chunkSize := sqliteMaxVars / varsPerRow
+	for start := 0; start < len(deltas); start += chunkSize {
+		end := start + chunkSize
+		if end > len(deltas) {
+			end = len(deltas)
+		}
+		chunk := deltas[start:end]
+
+		var sb strings.Builder
+		args := make([]any, 0, len(chunk)*varsPerRow+len(chunk))
+		sb.WriteString("UPDATE inbounds SET up = up + CASE tag")
+		for _, d := range chunk {
+			sb.WriteString(" WHEN ? THEN ?")
+			args = append(args, d.Tag, d.Up)
+		}
+		sb.WriteString(" ELSE 0 END, down = down + CASE tag")
+		for _, d := range chunk {
+			sb.WriteString(" WHEN ? THEN ?")
+			args = append(args, d.Tag, d.Down)
+		}
+		sb.WriteString(" ELSE 0 END WHERE node_id IS NULL AND tag IN (")
+		for i, d := range chunk {
+			if i > 0 {
+				sb.WriteString(", ")
+			}
+			sb.WriteString("?")
+			args = append(args, d.Tag)
+		}
+		sb.WriteString(")")
+
+		if err := tx.Exec(sb.String(), args...).Error; err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func BatchIncrementClientTraffic(tx *gorm.DB, deltas []ClientTrafficDelta) error {
+	if len(deltas) == 0 {
+		return nil
+	}
+	if IsPostgres() {
+		return batchIncrementClientTrafficPG(tx, deltas)
+	}
+	return batchIncrementClientTrafficSQLite(tx, deltas)
+}
+
+func batchIncrementClientTrafficPG(tx *gorm.DB, deltas []ClientTrafficDelta) error {
+	var sb strings.Builder
+	args := make([]any, 0, len(deltas)*4)
+	sb.WriteString("UPDATE client_traffics SET up = client_traffics.up + v.delta_up, down = client_traffics.down + v.delta_down, last_online = GREATEST(client_traffics.last_online, v.last_online) FROM (VALUES ")
+	for i, d := range deltas {
+		if i > 0 {
+			sb.WriteString(", ")
+		}
+		sb.WriteString("(?::text, ?::bigint, ?::bigint, ?::bigint)")
+		args = append(args, d.Email, d.Up, d.Down, d.LastOnline)
+	}
+	sb.WriteString(") AS v(email, delta_up, delta_down, last_online) WHERE client_traffics.email = v.email")
+	return tx.Exec(sb.String(), args...).Error
+}
+
+// ponytail: 4 vars per row + 1 for IN clause = 5 effective per row; chunks at
+// ~199 rows. Upgrade to temp-table if client count per tick exceeds this.
+func batchIncrementClientTrafficSQLite(tx *gorm.DB, deltas []ClientTrafficDelta) error {
+	const varsPerRow = 5
+	chunkSize := sqliteMaxVars / varsPerRow
+	for start := 0; start < len(deltas); start += chunkSize {
+		end := start + chunkSize
+		if end > len(deltas) {
+			end = len(deltas)
+		}
+		chunk := deltas[start:end]
+
+		var sb strings.Builder
+		args := make([]any, 0, len(chunk)*varsPerRow+len(chunk))
+		sb.WriteString("UPDATE client_traffics SET up = up + CASE email")
+		for _, d := range chunk {
+			sb.WriteString(" WHEN ? THEN ?")
+			args = append(args, d.Email, d.Up)
+		}
+		sb.WriteString(" ELSE 0 END, down = down + CASE email")
+		for _, d := range chunk {
+			sb.WriteString(" WHEN ? THEN ?")
+			args = append(args, d.Email, d.Down)
+		}
+		sb.WriteString(" ELSE 0 END, last_online = CASE email")
+		for _, d := range chunk {
+			fmt.Fprintf(&sb, " WHEN ? THEN %s", GreatestExpr("last_online", "?"))
+			args = append(args, d.Email, d.LastOnline)
+		}
+		sb.WriteString(" ELSE last_online END WHERE email IN (")
+		for i, d := range chunk {
+			if i > 0 {
+				sb.WriteString(", ")
+			}
+			sb.WriteString("?")
+			args = append(args, d.Email)
+		}
+		sb.WriteString(")")
+
+		if err := tx.Exec(sb.String(), args...).Error; err != nil {
+			return err
+		}
+	}
+	return nil
 }

--- a/internal/database/dialect_test.go
+++ b/internal/database/dialect_test.go
@@ -1,0 +1,71 @@
+package database
+
+import (
+	"testing"
+
+	"github.com/mhsanaei/3x-ui/v3/internal/database/model"
+	"github.com/mhsanaei/3x-ui/v3/internal/xray"
+
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+	"gorm.io/gorm/logger"
+)
+
+func TestBatchIncrementTrafficSQLite(t *testing.T) {
+	oldDB := db
+	t.Cleanup(func() { db = oldDB })
+
+	var err error
+	db, err = gorm.Open(sqlite.Open(":memory:"), &gorm.Config{Logger: logger.Discard})
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	if err := db.AutoMigrate(&model.Inbound{}, &xray.ClientTraffic{}); err != nil {
+		t.Fatalf("automigrate: %v", err)
+	}
+	if err := db.Create(&model.Inbound{Tag: "in-a"}).Error; err != nil {
+		t.Fatalf("seed inbound: %v", err)
+	}
+	if err := db.Create(&xray.ClientTraffic{Email: "a@example.test", LastOnline: 5}).Error; err != nil {
+		t.Fatalf("seed traffic: %v", err)
+	}
+
+	if err := BatchIncrementInboundTraffic(db, []TrafficDelta{{Tag: "in-a", Up: 7, Down: 11}}); err != nil {
+		t.Fatalf("increment inbound: %v", err)
+	}
+	if err := BatchIncrementClientTraffic(db, []ClientTrafficDelta{{Email: "a@example.test", Up: 13, Down: 17, LastOnline: 3}}); err != nil {
+		t.Fatalf("increment client: %v", err)
+	}
+
+	var inbound model.Inbound
+	if err := db.Where("tag = ?", "in-a").First(&inbound).Error; err != nil {
+		t.Fatalf("read inbound: %v", err)
+	}
+	if inbound.Up != 7 || inbound.Down != 11 {
+		t.Fatalf("inbound traffic = %d/%d, want 7/11", inbound.Up, inbound.Down)
+	}
+
+	var traffic xray.ClientTraffic
+	if err := db.Where("email = ?", "a@example.test").First(&traffic).Error; err != nil {
+		t.Fatalf("read traffic: %v", err)
+	}
+	if traffic.Up != 13 || traffic.Down != 17 || traffic.LastOnline != 5 {
+		t.Fatalf("client traffic = up:%d down:%d last:%d, want 13/17/5", traffic.Up, traffic.Down, traffic.LastOnline)
+	}
+}
+
+func TestCastBigintDialect(t *testing.T) {
+	oldDB := db
+	db = nil
+	t.Cleanup(func() { db = oldDB })
+
+	t.Setenv("XUI_DB_TYPE", "sqlite")
+	if got := CastBigint("?"); got != "?" {
+		t.Fatalf("sqlite CastBigint = %q, want ?", got)
+	}
+
+	t.Setenv("XUI_DB_TYPE", "postgres")
+	if got := CastBigint("?"); got != "CAST(? AS BIGINT)" {
+		t.Fatalf("postgres CastBigint = %q, want CAST(? AS BIGINT)", got)
+	}
+}

--- a/internal/database/index_tags_test.go
+++ b/internal/database/index_tags_test.go
@@ -30,6 +30,7 @@ func TestAutoMigrateCreatesHotPathIndexes(t *testing.T) {
 		index string
 	}{
 		{&model.ClientRecord{}, "idx_client_record_group"},
+		{&model.ClientRecord{}, "idx_clients_tg_id"},
 		{&xray.ClientTraffic{}, "idx_client_traffics_inbound"},
 		{&xray.ClientTraffic{}, "idx_client_traffics_renew"},
 		{&model.ClientGlobalTraffic{}, "idx_client_global_email"},

--- a/internal/database/model/model.go
+++ b/internal/database/model/model.go
@@ -636,7 +636,7 @@ type ClientRecord struct {
 	TotalGB      int64  `json:"totalGB" gorm:"column:total_gb"`
 	ExpiryTime   int64  `json:"expiryTime" gorm:"column:expiry_time"`
 	Enable       bool   `json:"enable" gorm:"default:true"`
-	TgID         int64  `json:"tgId" gorm:"column:tg_id"`
+	TgID         int64  `json:"tgId" gorm:"column:tg_id;index:idx_clients_tg_id"`
 	Group        string `json:"group" gorm:"column:group_name;default:'';index:idx_client_record_group"`
 	Comment      string `json:"comment"`
 	Reset        int    `json:"reset" gorm:"default:0"`

--- a/internal/web/service/client_bulk.go
+++ b/internal/web/service/client_bulk.go
@@ -691,7 +691,7 @@ func (s *ClientService) bulkAdjustInboundClients(
 	// Serialize against the traffic poll to avoid the cross-transaction
 	// lock-order deadlock on inbounds/client_records (runSerializedTx).
 	txErr := runSerializedTx(func(tx *gorm.DB) error {
-		if err := tx.Save(oldInbound).Error; err != nil {
+		if err := tx.Model(oldInbound).Update("settings", oldInbound.Settings).Error; err != nil {
 			return err
 		}
 		finalClients, gcErr := inboundSvc.GetClients(oldInbound)
@@ -1072,7 +1072,7 @@ func (s *ClientService) bulkDelInboundClients(
 	// Serialize against the traffic poll to avoid the cross-transaction
 	// lock-order deadlock on inbounds/client_records (runSerializedTx).
 	txErr := runSerializedTx(func(tx *gorm.DB) error {
-		if err := tx.Save(oldInbound).Error; err != nil {
+		if err := tx.Model(oldInbound).Update("settings", oldInbound.Settings).Error; err != nil {
 			return err
 		}
 		finalClients, err := inboundSvc.GetClients(oldInbound)
@@ -1574,7 +1574,7 @@ func (s *ClientService) bulkSetEnableInboundClients(inboundSvc *InboundService, 
 	}
 
 	txErr := runSerializedTx(func(tx *gorm.DB) error {
-		if e := tx.Save(oldInbound).Error; e != nil {
+		if e := tx.Model(oldInbound).Update("settings", oldInbound.Settings).Error; e != nil {
 			return e
 		}
 		finalClients, gcErr := inboundSvc.GetClients(oldInbound)

--- a/internal/web/service/client_groups.go
+++ b/internal/web/service/client_groups.go
@@ -327,7 +327,7 @@ func (s *ClientService) AddToGroup(emails []string, group string) (int, error) {
 				continue
 			}
 			ib.Settings = string(newSettings)
-			if err := tx.Save(&ib).Error; err != nil {
+			if err := tx.Model(&ib).Update("settings", ib.Settings).Error; err != nil {
 				tx.Rollback()
 				return 0, err
 			}
@@ -428,7 +428,7 @@ func (s *ClientService) replaceGroupValue(oldName, newName string) (int, error) 
 				continue
 			}
 			ib.Settings = string(newSettings)
-			if err := tx.Save(&ib).Error; err != nil {
+			if err := tx.Model(&ib).Update("settings", ib.Settings).Error; err != nil {
 				tx.Rollback()
 				return 0, err
 			}

--- a/internal/web/service/client_inbound_apply.go
+++ b/internal/web/service/client_inbound_apply.go
@@ -150,7 +150,7 @@ func (s *ClientService) delInboundClients(inboundSvc *InboundService, inboundId 
 				}
 			}
 		}
-		if e := tx.Save(oldInbound).Error; e != nil {
+		if e := tx.Model(oldInbound).Update("settings", oldInbound.Settings).Error; e != nil {
 			return e
 		}
 		finalClients, gcErr := inboundSvc.GetClients(oldInbound)
@@ -369,7 +369,7 @@ func (s *ClientService) addInboundClient(inboundSvc *InboundService, data *model
 				return e
 			}
 		}
-		if e := tx.Save(oldInbound).Error; e != nil {
+		if e := tx.Model(oldInbound).Update("settings", oldInbound.Settings).Error; e != nil {
 			return e
 		}
 		finalClients, gcErr := inboundSvc.GetClients(oldInbound)
@@ -703,7 +703,7 @@ func (s *ClientService) UpdateInboundClient(inboundSvc *InboundService, data *mo
 			}
 		}
 
-		if e := tx.Save(oldInbound).Error; e != nil {
+		if e := tx.Model(oldInbound).Update("settings", oldInbound.Settings).Error; e != nil {
 			return e
 		}
 		finalClients, gcErr := inboundSvc.GetClients(oldInbound)
@@ -876,7 +876,7 @@ func (s *ClientService) DelInboundClientByEmail(inboundSvc *InboundService, inbo
 				return e
 			}
 		}
-		if e := tx.Save(oldInbound).Error; e != nil {
+		if e := tx.Model(oldInbound).Update("settings", oldInbound.Settings).Error; e != nil {
 			return e
 		}
 		finalClients, gcErr := inboundSvc.GetClients(oldInbound)

--- a/internal/web/service/client_lookup.go
+++ b/internal/web/service/client_lookup.go
@@ -191,10 +191,18 @@ func (s *ClientService) HasPendingNode(inboundSvc *InboundService, email string)
 	return inboundSvc.AnyNodePending(ids)
 }
 
-// findInboundIdsByClientEmail returns every inbound whose settings.clients[]
-// JSON contains an entry with the given email. Driver-portable (no JSON
-// operators) by parsing in Go — fine for the rare fallback path.
+// findInboundIdsByClientEmail returns every inbound attached to email. The
+// join table is authoritative; the JSON scan is a legacy-only fallback for
+// rows not migrated into clients/client_inbounds yet.
 func (s *ClientService) findInboundIdsByClientEmail(email string) ([]int, error) {
+	ids, err := s.GetInboundIdsForEmail(nil, email)
+	if err != nil {
+		return nil, err
+	}
+	if len(ids) > 0 {
+		return ids, nil
+	}
+
 	var inbounds []model.Inbound
 	if err := database.GetDB().
 		Select("id, settings").

--- a/internal/web/service/inbound_node.go
+++ b/internal/web/service/inbound_node.go
@@ -700,16 +700,18 @@ func (s *InboundService) setRemoteTrafficLocked(nodeID int, snap *runtime.Traffi
 			// "start after first connect" duration, which must never reset the
 			// absolute deadline another node already activated. A positive node
 			// value is still adopted (e.g. auto-renew moves the deadline forward).
-			// CAST(? AS BIGINT): in the `<= 0` comparison Postgres would otherwise
+			// Bigint cast: in the `<= 0` comparison Postgres would otherwise
 			// infer int4 from the literal and overflow on real expiry values.
 			if err := tx.Exec(
 				fmt.Sprintf(
 					`UPDATE client_traffics
 					 SET up = up + ?, down = down + ?, enable = %s, total = ?,
-					     expiry_time = CASE WHEN expiry_time > 0 AND CAST(? AS BIGINT) <= 0 THEN expiry_time ELSE CAST(? AS BIGINT) END,
+					     expiry_time = CASE WHEN expiry_time > 0 AND %s <= 0 THEN expiry_time ELSE %s END,
 					     reset = ?, last_online = %s
 					 WHERE email = ?`,
 					enableExpr,
+					database.CastBigint("?"),
+					database.CastBigint("?"),
 					database.GreatestExpr("last_online", "?"),
 				),
 				deltaUp, deltaDown, cs.Enable, cs.Total,

--- a/internal/web/service/inbound_traffic.go
+++ b/internal/web/service/inbound_traffic.go
@@ -30,49 +30,90 @@ func (s *InboundService) AddTraffic(inboundTraffics []*xray.Traffic, clientTraff
 }
 
 func (s *InboundService) addTrafficLocked(inboundTraffics []*xray.Traffic, clientTraffics []*xray.ClientTraffic) (bool, bool, error) {
-	var err error
 	db := database.GetDB()
-	tx := db.Begin()
-
-	defer func() {
-		if err != nil {
-			tx.Rollback()
-		} else {
-			tx.Commit()
+	if err := db.Transaction(func(tx *gorm.DB) error {
+		if err := s.addInboundTraffic(tx, inboundTraffics); err != nil {
+			return err
 		}
-	}()
-	err = s.addInboundTraffic(tx, inboundTraffics)
-	if err != nil {
-		return false, false, err
-	}
-	err = s.addClientTraffic(tx, clientTraffics)
-	if err != nil {
+		return s.addClientTraffic(tx, clientTraffics)
+	}); err != nil {
 		return false, false, err
 	}
 
-	needRestart0, count, err := s.autoRenewClients(tx)
+	maintenanceNeeded, err := s.trafficMaintenanceNeeded(db)
 	if err != nil {
-		logger.Warning("Error in renew clients:", err)
-	} else if count > 0 {
-		logger.Debugf("%v clients renewed", count)
+		logger.Warning("Error checking traffic maintenance:", err)
+		maintenanceNeeded = true
+	}
+	if !maintenanceNeeded {
+		return false, false, nil
 	}
 
+	needRestart := false
 	disabledClientsCount := int64(0)
-	needRestart1, count, err := s.disableInvalidClients(tx)
+	err = db.Transaction(func(tx *gorm.DB) error {
+		needRestart0, count, err := s.autoRenewClients(tx)
+		if err != nil {
+			logger.Warning("Error in renew clients:", err)
+		} else if count > 0 {
+			logger.Debugf("%v clients renewed", count)
+		}
+
+		needRestart1, count, err := s.disableInvalidClients(tx)
+		if err != nil {
+			logger.Warning("Error in disabling invalid clients:", err)
+		} else if count > 0 {
+			logger.Debugf("%v clients disabled", count)
+			disabledClientsCount = count
+		}
+
+		needRestart2, count, err := s.disableInvalidInbounds(tx)
+		if err != nil {
+			logger.Warning("Error in disabling invalid inbounds:", err)
+		} else if count > 0 {
+			logger.Debugf("%v inbounds disabled", count)
+		}
+		needRestart = needRestart0 || needRestart1 || needRestart2
+		return nil
+	})
 	if err != nil {
-		logger.Warning("Error in disabling invalid clients:", err)
-	} else if count > 0 {
-		logger.Debugf("%v clients disabled", count)
-		disabledClientsCount = count
+		return false, false, err
+	}
+	return needRestart, disabledClientsCount > 0, nil
+}
+
+func (s *InboundService) trafficMaintenanceNeeded(tx *gorm.DB) (bool, error) {
+	now := time.Now().Unix() * 1000
+	var id int
+	if err := tx.Model(xray.ClientTraffic{}).
+		Select("id").
+		Where("reset > 0 and expiry_time > 0 and expiry_time <= ?", now).
+		Where("email IN (?)", tx.Table("client_inbounds ci").
+			Select("c.email").
+			Joins("JOIN clients c ON c.id = ci.client_id").
+			Joins("JOIN inbounds i ON i.id = ci.inbound_id").
+			Where("i.node_id IS NULL")).
+		Limit(1).
+		Scan(&id).Error; err != nil || id != 0 {
+		return id != 0, err
 	}
 
-	needRestart2, count, err := s.disableInvalidInbounds(tx)
-	if err != nil {
-		logger.Warning("Error in disabling invalid inbounds:", err)
-	} else if count > 0 {
-		logger.Debugf("%v inbounds disabled", count)
+	if err := tx.Model(xray.ClientTraffic{}).
+		Select("id").
+		Where(depletedCond(tx)+" AND enable = ?", now, true).
+		Limit(1).
+		Scan(&id).Error; err != nil || id != 0 {
+		return id != 0, err
 	}
-	return needRestart0 || needRestart1 || needRestart2, disabledClientsCount > 0, nil
+
+	if err := tx.Model(model.Inbound{}).
+		Select("id").
+		Where("((total > 0 and up + down >= total) or (expiry_time > 0 and expiry_time <= ?)) and enable = ? and node_id IS NULL", now, true).
+		Limit(1).
+		Scan(&id).Error; err != nil {
+		return false, err
+	}
+	return id != 0, nil
 }
 
 func (s *InboundService) addInboundTraffic(tx *gorm.DB, traffics []*xray.Traffic) error {
@@ -80,21 +121,17 @@ func (s *InboundService) addInboundTraffic(tx *gorm.DB, traffics []*xray.Traffic
 		return nil
 	}
 
-	var err error
-
+	deltas := make([]database.TrafficDelta, 0, len(traffics))
 	for _, traffic := range traffics {
 		if traffic.IsInbound {
-			err = tx.Model(&model.Inbound{}).Where("tag = ? AND node_id IS NULL", traffic.Tag).
-				Updates(map[string]any{
-					"up":   gorm.Expr("up + ?", traffic.Up),
-					"down": gorm.Expr("down + ?", traffic.Down),
-				}).Error
-			if err != nil {
-				return err
-			}
+			deltas = append(deltas, database.TrafficDelta{
+				Tag:  traffic.Tag,
+				Up:   traffic.Up,
+				Down: traffic.Down,
+			})
 		}
 	}
-	return nil
+	return database.BatchIncrementInboundTraffic(tx, deltas)
 }
 
 func (s *InboundService) addClientTraffic(tx *gorm.DB, traffics []*xray.ClientTraffic) (err error) {
@@ -132,7 +169,6 @@ func (s *InboundService) addClientTraffic(tx *gorm.DB, traffics []*xray.ClientTr
 		return err
 	}
 
-	// Index by email for O(N) merge.
 	trafficByEmail := make(map[string]*xray.ClientTraffic, len(traffics))
 	for i := range traffics {
 		if traffics[i] != nil {
@@ -140,25 +176,21 @@ func (s *InboundService) addClientTraffic(tx *gorm.DB, traffics []*xray.ClientTr
 		}
 	}
 	now := time.Now().UnixMilli()
-	// Use atomic per-row UPDATE instead of read-modify-write Save. tx.Save
-	// issues UPDATEs in slice order, which varies between concurrent callers;
-	// on PostgreSQL two transactions locking the same rows in opposite order
-	// deadlock. An atomic "SET up = up + ?" never holds a row lock across a
-	// subsequent lock acquisition, so concurrent writers cannot deadlock.
+	deltas := make([]database.ClientTrafficDelta, 0, len(dbClientTraffics))
 	for _, ct := range dbClientTraffics {
 		t, ok := trafficByEmail[ct.Email]
 		if !ok || (t.Up == 0 && t.Down == 0) {
 			continue
 		}
-		if err = tx.Exec(
-			fmt.Sprintf(
-				`UPDATE client_traffics SET up = up + ?, down = down + ?, last_online = %s WHERE email = ?`,
-				database.GreatestExpr("last_online", "?"),
-			),
-			t.Up, t.Down, now, ct.Email,
-		).Error; err != nil {
-			logger.Warning("AddClientTraffic update data ", err)
-		}
+		deltas = append(deltas, database.ClientTrafficDelta{
+			Email:      ct.Email,
+			Up:         t.Up,
+			Down:       t.Down,
+			LastOnline: now,
+		})
+	}
+	if err = database.BatchIncrementClientTraffic(tx, deltas); err != nil {
+		logger.Warning("AddClientTraffic batch update ", err)
 	}
 
 	// adjustTraffics converts delayed-start rows (negative ExpiryTime → absolute
@@ -258,7 +290,15 @@ func (s *InboundService) adjustTraffics(tx *gorm.DB, dbClientTraffics []*xray.Cl
 		}
 	}
 
-	err = tx.Save(inbounds).Error
+	for _, ib := range inbounds {
+		if ib == nil {
+			continue
+		}
+		err = tx.Model(ib).Update("settings", ib.Settings).Error
+		if err != nil {
+			break
+		}
+	}
 	if err != nil {
 		logger.Warning("AddClientTraffic update inbounds ", err)
 		logger.Error(inbounds)
@@ -399,9 +439,13 @@ func (s *InboundService) autoRenewClients(tx *gorm.DB) (bool, int64, error) {
 		}
 		inbounds[inbound_index].Settings = string(newSettings)
 	}
-	err = tx.Save(inbounds).Error
-	if err != nil {
-		return false, 0, err
+	for _, ib := range inbounds {
+		if ib == nil {
+			continue
+		}
+		if err = tx.Model(ib).Update("settings", ib.Settings).Error; err != nil {
+			return false, 0, err
+		}
 	}
 	for _, ib := range inbounds {
 		if ib == nil {
@@ -783,7 +827,7 @@ func (s *InboundService) DelDepletedClients(id int) (err error) {
 			return mErr
 		}
 		inbound.Settings = string(ns)
-		if err = tx.Save(inbound).Error; err != nil {
+		if err = tx.Model(inbound).Update("settings", inbound.Settings).Error; err != nil {
 			return err
 		}
 		survivingClients, gcErr := s.GetClients(inbound)
@@ -837,27 +881,12 @@ func (s *InboundService) DelDepletedClients(id int) (err error) {
 
 func (s *InboundService) GetClientTrafficTgBot(tgId int64) ([]*xray.ClientTraffic, error) {
 	db := database.GetDB()
-	var inbounds []*model.Inbound
-
-	// Retrieve inbounds where settings contain the given tgId
-	err := db.Model(model.Inbound{}).Where("settings LIKE ?", fmt.Sprintf(`%%"tgId": %d%%`, tgId)).Find(&inbounds).Error
-	if err != nil && !errors.Is(err, gorm.ErrRecordNotFound) {
-		logger.Errorf("Error retrieving inbounds with tgId %d: %v", tgId, err)
-		return nil, err
-	}
 
 	var emails []string
-	for _, inbound := range inbounds {
-		clients, err := s.GetClients(inbound)
-		if err != nil {
-			logger.Errorf("Error retrieving clients for inbound %d: %v", inbound.Id, err)
-			continue
-		}
-		for _, client := range clients {
-			if client.TgID == tgId {
-				emails = append(emails, client.Email)
-			}
-		}
+	err := db.Model(&model.ClientRecord{}).Where("tg_id = ?", tgId).Pluck("email", &emails).Error
+	if err != nil {
+		logger.Errorf("Error retrieving clients with tgId %d: %v", tgId, err)
+		return nil, err
 	}
 
 	// Chunked to stay under SQLite's bind-variable limit when a single Telegram
@@ -1027,40 +1056,24 @@ func (s *InboundService) UpdateClientTrafficByEmail(email string, upload int64, 
 
 func (s *InboundService) SearchClientTraffic(query string) (traffic *xray.ClientTraffic, err error) {
 	db := database.GetDB()
-	inbound := &model.Inbound{}
 	traffic = &xray.ClientTraffic{}
 
-	// Search for inbound settings that contain the query
-	err = db.Model(model.Inbound{}).Where("settings LIKE ?", "%\""+query+"\"%").First(inbound).Error
-	if err != nil {
-		if errors.Is(err, gorm.ErrRecordNotFound) {
-			logger.Warningf("Inbound settings containing query %s not found: %v", query, err)
+	var rec model.ClientRecord
+	err = db.Model(&model.ClientRecord{}).
+		Where("email = ? OR uuid = ? OR sub_id = ? OR password = ?", query, query, query, query).
+		First(&rec).Error
+	if err == nil {
+		traffic.Email = rec.Email
+		traffic.UUID = rec.UUID
+		traffic.SubId = rec.SubID
+	} else if errors.Is(err, gorm.ErrRecordNotFound) {
+		traffic.Email, err = s.searchLegacyClientTrafficEmail(db, query)
+		if err != nil {
 			return nil, err
 		}
-		logger.Errorf("Error searching for inbound settings with query %s: %v", query, err)
+	} else {
+		logger.Errorf("Error searching clients with query %s: %v", query, err)
 		return nil, err
-	}
-
-	traffic.InboundId = inbound.Id
-
-	// Unmarshal settings to get clients
-	settings := map[string][]model.Client{}
-	if err := json.Unmarshal([]byte(inbound.Settings), &settings); err != nil {
-		logger.Errorf("Error unmarshalling inbound settings for inbound ID %d: %v", inbound.Id, err)
-		return nil, err
-	}
-
-	clients := settings["clients"]
-	for _, client := range clients {
-		if (client.ID == query || client.Password == query) && client.Email != "" {
-			traffic.Email = client.Email
-			break
-		}
-	}
-
-	if traffic.Email == "" {
-		logger.Warningf("No client found with query %s in inbound ID %d", query, inbound.Id)
-		return nil, gorm.ErrRecordNotFound
 	}
 
 	// Retrieve ClientTraffic based on the found email
@@ -1075,4 +1088,32 @@ func (s *InboundService) SearchClientTraffic(query string) (traffic *xray.Client
 	}
 
 	return traffic, nil
+}
+
+func (s *InboundService) searchLegacyClientTrafficEmail(db *gorm.DB, query string) (string, error) {
+	inbound := &model.Inbound{}
+	err := db.Model(model.Inbound{}).Where("settings LIKE ?", "%\""+query+"\"%").First(inbound).Error
+	if err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			logger.Warningf("Inbound settings containing query %s not found: %v", query, err)
+			return "", err
+		}
+		logger.Errorf("Error searching for inbound settings with query %s: %v", query, err)
+		return "", err
+	}
+
+	settings := map[string][]model.Client{}
+	if err := json.Unmarshal([]byte(inbound.Settings), &settings); err != nil {
+		logger.Errorf("Error unmarshalling inbound settings for inbound ID %d: %v", inbound.Id, err)
+		return "", err
+	}
+
+	for _, client := range settings["clients"] {
+		if (client.Email == query || client.ID == query || client.SubID == query || client.Password == query) && client.Email != "" {
+			return client.Email, nil
+		}
+	}
+
+	logger.Warningf("No client found with query %s in inbound ID %d", query, inbound.Id)
+	return "", gorm.ErrRecordNotFound
 }


### PR DESCRIPTION
## Summary

Optimizes database hot paths for traffic accounting and client lookups across SQLite and PostgreSQL. Adds WAL mode for SQLite, dialect-aware batch updates, narrower transactions, targeted settings writes, and DB-specific indexes.

## Why

Traffic polling currently grows into many per-client updates and keeps slow renew/disable work in the same write transaction. JSON LIKE scans also bypass indexed client columns. This lowers lock time and query cost as client count grows.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Refactoring (no behavior change)
- [x] Documentation
- [ ] Tests only
- [ ] Build / CI / tooling
- [ ] Other

## Areas affected

- [ ] Frontend (UI / panel pages)
- [x] Backend (API endpoints, login, settings)
- [ ] Xray config generation
- [ ] Subscription (share links / Clash / JSON)
- [x] Statistics / traffic counters
- [x] Database / migrations
- [ ] Install / upgrade script
- [ ] Docker image
- [ ] Multi-node (sub-nodes)
- [x] Telegram bot

## How was this tested?

- `go test ./internal/database ./internal/web/service`
- `make test`
- `make verify`

New coverage:
- SQLite batch increment helper behavior in `internal/database/dialect_test.go`
- SQLite WAL pragma and remark/tg_id index creation in `internal/database/db_settled_test.go`
- GORM tg_id index tag coverage in `internal/database/index_tags_test.go`

PostgreSQL live tests were not run locally because no `XUI_DB_TYPE=postgres` + `XUI_DB_DSN` was configured.

## Screenshots / recordings

N/A

## Breaking changes

None.

## Checklist

- [x] I tested the change locally and confirmed the described behavior.
- [x] I added or updated tests for the new behavior (when applicable).
- [x] `go build ./...` and the test suite pass locally.
- [x] For frontend changes: `npm run lint`, `npm run typecheck`, and `npm run build` pass.
- [x] I updated the Wiki / README / API docs if user-facing behavior changed.
- [x] My commits follow the project existing message style.
- [x] I have no unrelated changes mixed into this PR.