### PR TITLE
fix(tgbot): resolve Telegram usage lookup by clients.tg_id

### DIFF
--- a/internal/web/service/inbound_client_traffic_test.go
+++ b/internal/web/service/inbound_client_traffic_test.go
@@ -304,3 +304,78 @@ func TestGetClientTrafficTgBotLegacyCompactJSON(t *testing.T) {
 		t.Fatalf("traffic emails = %#v, want %q", got, email)
 	}
 }
+
+func TestGetClientTrafficTgBotNormalizedFastPath(t *testing.T) {
+	dbDir := t.TempDir()
+	t.Setenv("XUI_DB_FOLDER", dbDir)
+	if err := database.InitDB(filepath.Join(dbDir, "x-ui.db")); err != nil {
+		t.Fatalf("InitDB: %v", err)
+	}
+	t.Cleanup(func() { _ = database.CloseDB() })
+
+	db := database.GetDB()
+	const email = "norm-fast@example.test"
+	const tgID int64 = 313131313
+
+	if err := db.Create(&model.ClientRecord{Email: email, TgID: tgID, Enable: true}).Error; err != nil {
+		t.Fatalf("create client record: %v", err)
+	}
+	if err := db.Create(&xray.ClientTraffic{Email: email, Enable: true}).Error; err != nil {
+		t.Fatalf("create traffic: %v", err)
+	}
+
+	got, err := (&InboundService{}).GetClientTrafficTgBot(tgID)
+	if err != nil {
+		t.Fatalf("GetClientTrafficTgBot: %v", err)
+	}
+	if len(got) != 1 || got[0].Email != email {
+		t.Fatalf("traffic emails = %#v, want %q", got, email)
+	}
+}
+
+func TestGetClientTrafficTgBotMergesNormalizedAndLegacy(t *testing.T) {
+	dbDir := t.TempDir()
+	t.Setenv("XUI_DB_FOLDER", dbDir)
+	if err := database.InitDB(filepath.Join(dbDir, "x-ui.db")); err != nil {
+		t.Fatalf("InitDB: %v", err)
+	}
+	t.Cleanup(func() { _ = database.CloseDB() })
+
+	db := database.GetDB()
+	const tgID int64 = 424242424
+	const emailNorm = "norm@example.test"
+	const emailLegacy = "legacy-sibling@example.test"
+
+	if err := db.Create(&model.ClientRecord{Email: emailNorm, TgID: tgID, Enable: true}).Error; err != nil {
+		t.Fatalf("create normalized client: %v", err)
+	}
+	if err := db.Create(&xray.ClientTraffic{Email: emailNorm, Enable: true}).Error; err != nil {
+		t.Fatalf("create norm traffic: %v", err)
+	}
+
+	inbound := &model.Inbound{
+		UserId: 1, Tag: "legacy-sibling", Enable: true, Port: 46004, Protocol: model.VLESS,
+		Settings: `{"clients":[{"id":"ce8d33df-3a64-4f10-8f9b-91c3a8e0d004","email":"legacy-sibling@example.test","enable":true,"tgId":424242424}],"decryption":"none"}`,
+	}
+	if err := db.Create(inbound).Error; err != nil {
+		t.Fatalf("create inbound: %v", err)
+	}
+	if err := db.Create(&xray.ClientTraffic{InboundId: inbound.Id, Email: emailLegacy, Enable: true}).Error; err != nil {
+		t.Fatalf("create legacy traffic: %v", err)
+	}
+
+	got, err := (&InboundService{}).GetClientTrafficTgBot(tgID)
+	if err != nil {
+		t.Fatalf("GetClientTrafficTgBot: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("want 2 traffic rows, got %#v", got)
+	}
+	seen := map[string]bool{}
+	for _, tr := range got {
+		seen[tr.Email] = true
+	}
+	if !seen[emailNorm] || !seen[emailLegacy] {
+		t.Fatalf("emails = %#v, want %q and %q", got, emailNorm, emailLegacy)
+	}
+}

--- a/internal/web/service/inbound_client_traffic_test.go
+++ b/internal/web/service/inbound_client_traffic_test.go
@@ -231,3 +231,76 @@ func TestAddClientTraffic_ExpiryWriteOnlyForConvertedClients(t *testing.T) {
 		t.Errorf("normal traffic not applied: up=%d down=%d, want 30/40", normal.Up, normal.Down)
 	}
 }
+
+func TestGetClientTrafficTgBotFallsBackToInboundSettings(t *testing.T) {
+	dbDir := t.TempDir()
+	t.Setenv("XUI_DB_FOLDER", dbDir)
+	if err := database.InitDB(filepath.Join(dbDir, "x-ui.db")); err != nil {
+		t.Fatalf("InitDB: %v", err)
+	}
+	t.Cleanup(func() { _ = database.CloseDB() })
+
+	db := database.GetDB()
+	const email = "legacy-tg@example.test"
+	const tgID int64 = 987654321
+
+	inbound := &model.Inbound{
+		UserId:   1,
+		Tag:      "legacy-tg",
+		Enable:   true,
+		Port:     46001,
+		Protocol: model.VLESS,
+		Settings: clientsSettings(t, []model.Client{{
+			Email:  email,
+			ID:     "ce8d33df-3a64-4f10-8f9b-91c3a8e0d001",
+			Enable: true,
+			TgID:   tgID,
+		}}),
+	}
+	if err := db.Create(inbound).Error; err != nil {
+		t.Fatalf("create inbound: %v", err)
+	}
+	if err := db.Create(&xray.ClientTraffic{InboundId: inbound.Id, Email: email, Enable: true}).Error; err != nil {
+		t.Fatalf("create traffic: %v", err)
+	}
+
+	got, err := (&InboundService{}).GetClientTrafficTgBot(tgID)
+	if err != nil {
+		t.Fatalf("GetClientTrafficTgBot: %v", err)
+	}
+	if len(got) != 1 || got[0].Email != email {
+		t.Fatalf("traffic emails = %#v, want %q", got, email)
+	}
+}
+
+func TestGetClientTrafficTgBotLegacyCompactJSON(t *testing.T) {
+	dbDir := t.TempDir()
+	t.Setenv("XUI_DB_FOLDER", dbDir)
+	if err := database.InitDB(filepath.Join(dbDir, "x-ui.db")); err != nil {
+		t.Fatalf("InitDB: %v", err)
+	}
+	t.Cleanup(func() { _ = database.CloseDB() })
+
+	db := database.GetDB()
+	const email = "legacy-compact@example.test"
+	const tgID int64 = 555444333
+
+	inbound := &model.Inbound{
+		UserId: 1, Tag: "legacy-compact", Enable: true, Port: 46003, Protocol: model.VLESS,
+		Settings: `{"clients":[{"id":"ce8d33df-3a64-4f10-8f9b-91c3a8e0d003","email":"legacy-compact@example.test","enable":true,"tgId":555444333}],"decryption":"none"}`,
+	}
+	if err := db.Create(inbound).Error; err != nil {
+		t.Fatalf("create inbound: %v", err)
+	}
+	if err := db.Create(&xray.ClientTraffic{InboundId: inbound.Id, Email: email, Enable: true}).Error; err != nil {
+		t.Fatalf("create traffic: %v", err)
+	}
+
+	got, err := (&InboundService{}).GetClientTrafficTgBot(tgID)
+	if err != nil {
+		t.Fatalf("GetClientTrafficTgBot: %v", err)
+	}
+	if len(got) != 1 || got[0].Email != email {
+		t.Fatalf("traffic emails = %#v, want %q", got, email)
+	}
+}

--- a/internal/web/service/inbound_traffic.go
+++ b/internal/web/service/inbound_traffic.go
@@ -844,12 +844,11 @@ func (s *InboundService) GetClientTrafficTgBot(tgId int64) ([]*xray.ClientTraffi
 		logger.Errorf("Error retrieving clients with tgId %d: %v", tgId, err)
 		return nil, err
 	}
-	if len(emails) == 0 {
-		emails, err = s.legacyClientEmailsByTgID(db, tgId)
-		if err != nil {
-			return nil, err
-		}
+	legacyEmails, err := s.legacyClientEmailsByTgID(db, tgId)
+	if err != nil {
+		return nil, err
 	}
+	emails = append(emails, legacyEmails...)
 
 	// Chunked to stay under SQLite's bind-variable limit when a single Telegram
 	// account owns thousands of clients across inbounds.

--- a/internal/web/service/inbound_traffic.go
+++ b/internal/web/service/inbound_traffic.go
@@ -837,26 +837,17 @@ func (s *InboundService) DelDepletedClients(id int) (err error) {
 
 func (s *InboundService) GetClientTrafficTgBot(tgId int64) ([]*xray.ClientTraffic, error) {
 	db := database.GetDB()
-	var inbounds []*model.Inbound
-
-	// Retrieve inbounds where settings contain the given tgId
-	err := db.Model(model.Inbound{}).Where("settings LIKE ?", fmt.Sprintf(`%%"tgId": %d%%`, tgId)).Find(&inbounds).Error
-	if err != nil && !errors.Is(err, gorm.ErrRecordNotFound) {
-		logger.Errorf("Error retrieving inbounds with tgId %d: %v", tgId, err)
-		return nil, err
-	}
 
 	var emails []string
-	for _, inbound := range inbounds {
-		clients, err := s.GetClients(inbound)
+	err := db.Model(&model.ClientRecord{}).Where("tg_id = ?", tgId).Pluck("email", &emails).Error
+	if err != nil {
+		logger.Errorf("Error retrieving clients with tgId %d: %v", tgId, err)
+		return nil, err
+	}
+	if len(emails) == 0 {
+		emails, err = s.legacyClientEmailsByTgID(db, tgId)
 		if err != nil {
-			logger.Errorf("Error retrieving clients for inbound %d: %v", inbound.Id, err)
-			continue
-		}
-		for _, client := range clients {
-			if client.TgID == tgId {
-				emails = append(emails, client.Email)
-			}
+			return nil, err
 		}
 	}
 
@@ -890,6 +881,34 @@ func (s *InboundService) GetClientTrafficTgBot(tgId int64) ([]*xray.ClientTraffi
 	}
 
 	return traffics, nil
+}
+
+func (s *InboundService) legacyClientEmailsByTgID(db *gorm.DB, tgId int64) ([]string, error) {
+	var inbounds []*model.Inbound
+	err := db.Model(model.Inbound{}).
+		Where("settings LIKE ? OR settings LIKE ?",
+			fmt.Sprintf(`%%"tgId": %d%%`, tgId),
+			fmt.Sprintf(`%%"tgId":%d%%`, tgId)).
+		Find(&inbounds).Error
+	if err != nil {
+		logger.Errorf("Error retrieving legacy inbounds with tgId %d: %v", tgId, err)
+		return nil, err
+	}
+
+	emails := make([]string, 0)
+	for _, inbound := range inbounds {
+		clients, err := s.GetClients(inbound)
+		if err != nil {
+			logger.Errorf("Error retrieving clients for inbound %d: %v", inbound.Id, err)
+			continue
+		}
+		for _, client := range clients {
+			if client.TgID == tgId {
+				emails = append(emails, client.Email)
+			}
+		}
+	}
+	return emails, nil
 }
 
 // BumpClientsLastOnline sets client_traffics.last_online to now for the given


### PR DESCRIPTION
## Summary

Fix Telegram bot usage lookup when inbound `settings` JSON stores `tgId` without a space after the colon (common after node sync/import).

## Why

Closes #5805. The bot used `settings LIKE '%"tgId": 123%'`, which misses compact `"tgId":123` and returned no client traffic.

## Type of change

- [x] Bug fix

## Areas affected

- [x] Telegram bot
- [x] Database / migrations (read path on normalized `clients.tg_id`)

## How was this tested?

- `go test -shuffle=on -count=1 ./internal/web/service -run GetClientTrafficTgBot`
- `TestGetClientTrafficTgBotFallsBackToInboundSettings` (legacy settings-only rows)
- `TestGetClientTrafficTgBotLegacyCompactJSON` (compact JSON, no `clients` row)

## Screenshots / recordings

N/A

## Breaking changes

None

## Checklist

- [x] I tested the change locally and confirmed the described behavior.
- [x] I added or updated tests for the new behavior (when applicable).
- [x] `go build ./...` and the test suite pass locally.
- [ ] For frontend changes: N/A
- [ ] I updated the Wiki / README / API docs if user-facing behavior changed.
- [x] My commits follow the project's existing message style.
- [x] I have no unrelated changes mixed into this PR.