### PR TITLE
fix: clean up node_client_traffics when deleting a client

### DIFF
--- a/internal/web/service/client_crud.go
+++ b/internal/web/service/client_crud.go
@@ -514,6 +514,9 @@ func (s *ClientService) Delete(inboundSvc *InboundService, id int, keepTraffic b
 			if err := tx.Where("client_email = ?", existing.Email).Delete(&model.InboundClientIps{}).Error; err != nil {
 				return err
 			}
+			if err := tx.Where("email = ?", existing.Email).Delete(&model.NodeClientTraffic{}).Error; err != nil {
+				return err
+			}
 		}
 		return tx.Delete(&model.ClientRecord{}, id).Error
 	}); err != nil {
@@ -655,6 +658,9 @@ func (s *ClientService) DeleteByEmail(inboundSvc *InboundService, email string, 
 			return needRestart, err
 		}
 		if err := db.Where("client_email = ?", email).Delete(&model.InboundClientIps{}).Error; err != nil {
+			return needRestart, err
+		}
+		if err := db.Where("email = ?", email).Delete(&model.NodeClientTraffic{}).Error; err != nil {
 			return needRestart, err
 		}
 	}


### PR DESCRIPTION
## Summary

When a client is deleted, the `node_client_traffics` table is not cleaned up. This PR adds the missing `Delete` call in both `Delete()` and `DeleteByEmail()` code paths.

## Problem

Deleting a client via the panel UI or API cleans up all related tables — `client_traffics`, `client_global_traffic`, `inbound_client_ips`, `client_inbounds`, `client_external_links`, the inbound settings JSON, and the `ClientRecord` row — but `node_client_traffics` is never touched.

This means:

- **Orphaned rows accumulate** in `node_client_traffics` for every client ever created and deleted, across every registered node.
- **Manual cleanup is not permanent**: even if you `DELETE FROM node_client_traffics WHERE email = ?` directly, the next node traffic sync cycle **re-creates** the rows — the master re-inserts orphaned traffic based on stale xray stats counters from remote nodes.
- The only way to permanently remove them today is to stop x-ui, delete the rows, then restart — not practical in production.

## Fix

Add `db.Where("email = ?", email).Delete(&model.NodeClientTraffic{})` in both deletion paths, alongside the existing `client_traffics` / `inbound_client_ips` cleanup.

This ensures consistency: when `keepTraffic=false`, **all** traffic-related tables for that email are purged, including per-node records.

## Changes

```diff
// In Delete() — inside the transaction:
+ if err := tx.Where("email = ?", existing.Email).Delete(&model.NodeClientTraffic{}).Error; err != nil {
+     return err
+ }

// In DeleteByEmail() — fallback path when no ClientRecord exists:
+ if err := db.Where("email = ?", email).Delete(&model.NodeClientTraffic{}).Error; err != nil {
+     return needRestart, err
+ }
```

## Testing

- Verified on a production multi-node deployment (1 master + 15 remote nodes, SQLite): after applying this fix, deleting a client via the panel UI now removes all rows from `node_client_traffics` immediately and permanently.
- The `keepTraffic=true` path (detach) correctly preserves `node_client_traffics` rows, same as it preserves `client_traffics`.

Fixes #5841
