### PR TITLE
fix(ldap): convert default total GB to bytes when auto-creating clients

### DIFF
--- a/internal/web/job/ldap_sync_job.go
+++ b/internal/web/job/ldap_sync_job.go
@@ -189,7 +189,7 @@ func (j *LdapSyncJob) buildClient(email string, defGB, defExpiryDays, defLimitIP
 		Email:   email,
 		Enable:  true,
 		LimitIP: defLimitIP,
-		TotalGB: int64(defGB),
+		TotalGB: int64(defGB) * 1024 * 1024 * 1024,
 	}
 	if defExpiryDays > 0 {
 		c.ExpiryTime = time.Now().Add(time.Duration(defExpiryDays) * 24 * time.Hour).UnixMilli()

--- a/internal/web/job/ldap_sync_job_test.go
+++ b/internal/web/job/ldap_sync_job_test.go
@@ -19,6 +19,14 @@ func initLdapJobDB(t *testing.T) {
 	t.Cleanup(func() { _ = database.CloseDB() })
 }
 
+func TestBuildClient_ConvertsDefaultTotalGBToBytes(t *testing.T) {
+	j := NewLdapSyncJob()
+	c := j.buildClient("user@example.com", 10, 0, 0)
+	if want := int64(10) * 1024 * 1024 * 1024; c.TotalGB != want {
+		t.Errorf("TotalGB = %d, want %d", c.TotalGB, want)
+	}
+}
+
 func TestLdapCreateClients_AttachesToAllConfiguredInbounds(t *testing.T) {
 	initLdapJobDB(t)
 	db := database.GetDB()


### PR DESCRIPTION
## Summary

`LdapSyncJob.buildClient` (`internal/web/job/ldap_sync_job.go`) stored `ldapDefaultTotalGB` directly into `Client.TotalGB` with no unit conversion:

```go
TotalGB: int64(defGB),
```

Every other place that takes a GB-denominated input and persists it into this byte-denominated field converts first:
- `ClientFormModal.tsx` → `gbToBytes(form.totalGB)`
- `tgbot_router.go` → `limitTraffic * 1024 * 1024 * 1024`
- `client_inbound_apply.go` → `totalGB * 1024 * 1024 * 1024`

So a "Default total (GB)" setting of `10` was persisted as `10` bytes instead of `10737418240` bytes — the auto-created client hits its quota almost immediately.

## Fix

```go
TotalGB: int64(defGB) * 1024 * 1024 * 1024,
```

`0` still means unlimited (0 * anything = 0), consistent with every other path.

## Test plan
- [x] `go build ./internal/web/job/...`
- [x] `go test ./internal/web/job/...` — existing `TestLdapCreateClients_AttachesToAllConfiguredInbounds` passes (uses `defGB=0`, unaffected by the conversion)

Closes #5852