### PR TITLE
fix(sub): apply host Allow Insecure to Hysteria2 subscription links

### DIFF
--- a/internal/sub/clash_service.go
+++ b/internal/sub/clash_service.go
@@ -336,6 +336,9 @@ func (s *SubClashService) buildHysteriaProxy(subReq *SubService, inbound *model.
 			}
 		}
 	}
+	if insecure, ok := ep["allowInsecure"].(bool); ok && insecure {
+		proxy["skip-cert-verify"] = true
+	}
 
 	// Salamander obfs (Hysteria2). Read the same finalmask.udp[salamander]
 	// block the subscription link generator uses.

--- a/internal/sub/service.go
+++ b/internal/sub/service.go
@@ -1556,17 +1556,18 @@ func applyExternalProxyTLSParams(ep map[string]any, params map[string]string, se
 // the inbound's own — Hysteria external proxies are typically alternate
 // endpoints (port-hop / CDN) fronting the same certificate.
 func applyExternalProxyHysteriaParams(ep map[string]any, params map[string]string) {
-	pins, ok := externalProxyPins(ep["pinnedPeerCertSha256"])
-	if !ok {
-		return
-	}
-	hexPins := make([]string, 0, len(pins))
-	for _, p := range pins {
-		if s, ok := p.(string); ok {
-			hexPins = append(hexPins, hysteriaPinHex(s))
+	if pins, ok := externalProxyPins(ep["pinnedPeerCertSha256"]); ok {
+		hexPins := make([]string, 0, len(pins))
+		for _, p := range pins {
+			if s, ok := p.(string); ok {
+				hexPins = append(hexPins, hysteriaPinHex(s))
+			}
 		}
+		params["pinSHA256"] = strings.Join(hexPins, ",")
 	}
-	params["pinSHA256"] = strings.Join(hexPins, ",")
+	if ai, ok := ep["allowInsecure"].(bool); ok && ai {
+		params["insecure"] = "1"
+	}
 }
 
 // cloneStreamForExternalProxy returns a shallow clone of stream with


### PR DESCRIPTION
## What changed

A subscription host's `Allow Insecure` setting (`Host.AllowInsecure` in `internal/database/model/model.go`) was never applied to Hysteria/Hysteria2 links, even though the same setting works for VLESS/VMess/Trojan/Shadowsocks.

- `internal/sub/service.go` — `applyExternalProxyHysteriaParams` (used by `genHysteriaLink`'s per-external-proxy/per-host loop) only carried over the cert pin. It now also emits `insecure=1` in the raw `hysteria2://` link when the host/external-proxy entry has `allowInsecure: true`.
- `internal/sub/clash_service.go` — `buildHysteriaProxy` builds the Clash/Mihomo proxy entry by re-reading the TLS settings straight from `inbound.StreamSettings`, ignoring the per-host `ep` override entirely (unlike every other protocol's Clash builder). It now also sets `skip-cert-verify: true` when the host/external-proxy entry has `allowInsecure: true`.

## Why

For a Hysteria2 inbound fronted with a self-signed certificate, an admin can only express "skip certificate verification" through a subscription **Host** (there is no such field on the inbound's own TLS settings). Both Hysteria link generators build one link per host by projecting the `Host` row onto an `externalProxy`-shaped map (`hostToExternalProxyMap` in `internal/sub/host_sub.go`, which already sets `ep["allowInsecure"] = true`), but neither Hysteria-specific renderer looked at that key, so the flag was silently dropped:
- raw subscription: no `insecure=1` query param.
- Clash/Mihomo subscription: no `skip-cert-verify: true`.

This left Hysteria2 nodes behind a self-signed cert unusable from the generated subscription until the user manually edited the client and enabled insecure certificate trust.

## Scope

Both changes are additive `if` blocks gated on `ep["allowInsecure"]`/`ep`'s absence of that key, so behavior for hosts/external proxies without `Allow Insecure` set is unchanged (verified against the existing `TestApplyExternalProxyHysteriaParams_*` and `TestChar_C6_HysteriaExternalProxy` cases, none of which set that key).

Fixes #5865.