### PR TITLE
fix(link): strip query and trailing slash when parsing ss:// port

### DIFF
--- a/internal/util/link/outbound.go
+++ b/internal/util/link/outbound.go
@@ -361,7 +361,10 @@ func parseShadowsocks(link string) (*ParseResult, error) {
 			return nil, fmt.Errorf("bad ss host:port")
 		}
 		host := hp[:colon]
-		port, _ := strconv.Atoi(hp[colon+1:])
+		port, err := strconv.Atoi(hp[colon+1:])
+		if err != nil {
+			return nil, fmt.Errorf("bad ss port %q: %w", hp[colon+1:], err)
+		}
 		method, pass := splitMethodPass(userInfo)
 		identity := "ss:" + method + ":" + pass + "@" + host + ":" + strconv.Itoa(port)
 		ob := Outbound{
@@ -391,7 +394,10 @@ func parseShadowsocks(link string) (*ParseResult, error) {
 		return nil, fmt.Errorf("bad legacy ss hp")
 	}
 	host := hp[:colon]
-	port, _ := strconv.Atoi(hp[colon+1:])
+	port, err := strconv.Atoi(hp[colon+1:])
+	if err != nil {
+		return nil, fmt.Errorf("bad legacy ss port %q: %w", hp[colon+1:], err)
+	}
 	method, pass := splitMethodPass(userInfo)
 	identity := "ss:" + method + ":" + pass + "@" + host + ":" + strconv.Itoa(port)
 	ob := Outbound{

--- a/internal/util/link/outbound.go
+++ b/internal/util/link/outbound.go
@@ -338,12 +338,15 @@ func parseShadowsocks(link string) (*ParseResult, error) {
 		remark, _ = url.QueryUnescape(link[i+1:])
 		link = link[:i]
 	}
+	if i := strings.Index(link, "?"); i >= 0 {
+		link = link[:i]
+	}
 	core := strings.TrimPrefix(link, "ss://")
 	at := strings.Index(core, "@")
 	if at >= 0 {
 		// modern
 		userB64 := core[:at]
-		hp := core[at+1:]
+		hp := strings.TrimRight(core[at+1:], "/")
 		userInfo, err := base64DecodeFlexible(userB64)
 		if err != nil {
 			// SIP022 (2022-blake3-*) userinfo is percent-encoded, not base64.

--- a/internal/util/link/outbound_test.go
+++ b/internal/util/link/outbound_test.go
@@ -208,6 +208,21 @@ func TestParseShadowsocks(t *testing.T) {
 	}
 }
 
+func TestParseShadowsocksBadPort(t *testing.T) {
+	user := base64.StdEncoding.EncodeToString([]byte("aes-256-gcm:secretpass"))
+	cases := map[string]string{
+		"modern": "ss://" + user + "@1.2.3.4:notaport#node",
+		"legacy": "ss://" + base64.StdEncoding.EncodeToString([]byte("aes-256-gcm:secretpass@1.2.3.4:notaport")) + "#node",
+	}
+	for name, link := range cases {
+		t.Run(name, func(t *testing.T) {
+			if _, err := ParseLink(link); err == nil {
+				t.Errorf("expected parse error for non-numeric port, got nil")
+			}
+		})
+	}
+}
+
 func TestParseSubscriptionBody_Base64(t *testing.T) {
 	// base64 of the two joined links:
 	// vless://u@h:443?type=tcp#A\nvless://u2@h2:443?type=tcp#B

--- a/internal/util/link/outbound_test.go
+++ b/internal/util/link/outbound_test.go
@@ -1,6 +1,7 @@
 package link
 
 import (
+	"encoding/base64"
 	"net/url"
 	"strings"
 	"testing"
@@ -108,6 +109,100 @@ func TestSanitizeFinalMaskQuicParams_ClampsAndRejects(t *testing.T) {
 			}
 			if !exists || got != c.want {
 				t.Fatalf("%s: expected %v, got %v (%T)", c.key, c.want, got, got)
+			}
+		})
+	}
+}
+
+func TestParseShadowsocks(t *testing.T) {
+	modernUser := base64.StdEncoding.EncodeToString([]byte("aes-256-gcm:secretpass"))
+	legacyBody := base64.StdEncoding.EncodeToString([]byte("aes-256-gcm:secretpass@1.2.3.4:8388"))
+	cases := []struct {
+		name   string
+		link   string
+		host   string
+		port   int
+		method string
+		pass   string
+	}{
+		{
+			name:   "modern",
+			link:   "ss://" + modernUser + "@1.2.3.4:8388#node",
+			host:   "1.2.3.4",
+			port:   8388,
+			method: "aes-256-gcm",
+			pass:   "secretpass",
+		},
+		{
+			name:   "modern with plugin query",
+			link:   "ss://" + modernUser + "@1.2.3.4:8388?plugin=v2ray-plugin#node",
+			host:   "1.2.3.4",
+			port:   8388,
+			method: "aes-256-gcm",
+			pass:   "secretpass",
+		},
+		{
+			name:   "modern sip002 slash query",
+			link:   "ss://" + modernUser + "@1.2.3.4:8388/?plugin=obfs-local%3Bobfs%3Dhttp#node",
+			host:   "1.2.3.4",
+			port:   8388,
+			method: "aes-256-gcm",
+			pass:   "secretpass",
+		},
+		{
+			name:   "legacy",
+			link:   "ss://" + legacyBody + "#node",
+			host:   "1.2.3.4",
+			port:   8388,
+			method: "aes-256-gcm",
+			pass:   "secretpass",
+		},
+		{
+			name:   "base64url userinfo with plugin and trailing slash",
+			link:   "ss://" + base64.RawURLEncoding.EncodeToString([]byte("aes-128-gcm:pa+ss/word")) + "@1.2.3.4:8388/?plugin=obfs-local%3Bobfs%3Dhttp#node",
+			host:   "1.2.3.4",
+			port:   8388,
+			method: "aes-128-gcm",
+			pass:   "pa+ss/word",
+		},
+		{
+			name:   "sip022 percent-encoded userinfo",
+			link:   "ss://2022-blake3-aes-256-gcm:YctPZ6U7xPPcU%2Bgp3u%2B0tx%2FtRizJN9K8y%2BuKlW2qjlI%3D@example.com:8888#Example3",
+			host:   "example.com",
+			port:   8888,
+			method: "2022-blake3-aes-256-gcm",
+			pass:   "YctPZ6U7xPPcU+gp3u+0tx/tRizJN9K8y+uKlW2qjlI=",
+		},
+		{
+			name:   "sip022 dual-key password with type query preserves inner colon",
+			link:   "ss://2022-blake3-aes-256-gcm:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA%3D:BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB%3D@1.2.3.4:9999?type=tcp#node",
+			host:   "1.2.3.4",
+			port:   9999,
+			method: "2022-blake3-aes-256-gcm",
+			pass:   "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=:BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB=",
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			res, err := ParseLink(c.link)
+			if err != nil {
+				t.Fatalf("parse ss: %v", err)
+			}
+			if res.Outbound["protocol"] != "shadowsocks" {
+				t.Fatalf("protocol = %v, want shadowsocks", res.Outbound["protocol"])
+			}
+			srv := res.Outbound["settings"].(map[string]any)["servers"].([]any)[0].(map[string]any)
+			if srv["address"] != c.host {
+				t.Errorf("address = %v, want %v", srv["address"], c.host)
+			}
+			if srv["port"] != c.port {
+				t.Errorf("port = %v, want %v", srv["port"], c.port)
+			}
+			if srv["method"] != c.method {
+				t.Errorf("method = %v, want %v", srv["method"], c.method)
+			}
+			if srv["password"] != c.pass {
+				t.Errorf("password = %v, want %v", srv["password"], c.pass)
 			}
 		})
 	}


### PR DESCRIPTION
## What

Fixes Shadowsocks outbound port being parsed as `0` when a subscription's
`ss://` link carries a query string (e.g. `?plugin=...` or `?type=tcp`) and/or
the optional SIP002 trailing slash.

## Why

Per the SIP002 grammar the URI is:

ss://userinfo@host:port[ "/" ][ "?" plugin ][ "#" tag ]

`parseShadowsocks` (`internal/util/link/outbound.go`) only stripped the
`#fragment`. The `?query` and the trailing `/` leaked into the `host:port`
split, so `strconv.Atoi` failed and the port was silently set to `0` (the
error was discarded). The outbound then pointed at port 0 and never connected.

Direct link import was unaffected because that path runs through the frontend
parser (`src/lib/xray/outbound-link-parser.ts`), which already strips the query.
Only the Go subscription-import path was broken — hence "works when pasting the
link, breaks from a subscription".

This is the parse/import counterpart of #5432 / #5670, which fixed the SS2022
generation side (userinfo percent-encoding). Generation was fixed; parsing the
same links back was not.

## Fix

Strip the `?query` and the trailing `/` before splitting `host:port`,
mirroring the frontend parser and the SIP002 grammar. The trailing slash is
trimmed only in the modern (`userinfo@host:port`) branch so a legacy
base64 blob that legitimately ends in `/` is left intact.

## Tests

Added table-driven `TestParseShadowsocks` covering:
- modern `ss://base64(method:pass)@host:port`
- modern with `?plugin=` query
- modern SIP002 `.../?plugin=...` (slash + query)
- legacy fully-base64 form
- base64url (websafe) userinfo with plugin + trailing slash
- SIP022 percent-encoded userinfo with a dual-key password (inner `:` preserved)

`go test -race -shuffle=on ./internal/util/link/` passes; `gofmt`/`go vet` clean.

## How to test

Add an outbound subscription whose body contains an SS2022 link with a query,
e.g. `ss://2022-blake3-aes-256-gcm:<key>:<key>@host:9999?type=tcp#name`.
Before: the imported outbound has `port: 0`. After: the real port is used.