### PR TITLE
Add mobile management client to community tools in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,6 +187,7 @@ Contributions are welcome. Please read the [Contributing Guide](/CONTRIBUTING.md
 Tools and integrations built by the community around 3x-ui.
 
 - [terraform-provider-3x-ui](https://github.com/batonogov/terraform-provider-threexui) (License: **MIT**): _Manage inbounds, clients, panel settings, and Xray configuration as code with Terraform / OpenTofu._
+- - [3X-UI-Manager](https://github.com/yukh975/3X-UI-Manager) (License: **<MIT>**): _Mobile app for managing 3x-ui panels, available on Android and sideloadable on iOS._
 
 ## Support project
 

--- a/README.md
+++ b/README.md
@@ -187,7 +187,7 @@ Contributions are welcome. Please read the [Contributing Guide](/CONTRIBUTING.md
 Tools and integrations built by the community around 3x-ui.
 
 - [terraform-provider-3x-ui](https://github.com/batonogov/terraform-provider-threexui) (License: **MIT**): _Manage inbounds, clients, panel settings, and Xray configuration as code with Terraform / OpenTofu._
-- - [3X-UI-Manager](https://github.com/yukh975/3X-UI-Manager) (License: **<MIT>**): _Mobile app for managing 3x-ui panels, available on Android and sideloadable on iOS._
+- - [3X-UI-Manager](https://github.com/yukh975/3X-UI-Manager) (License: **<MIT>**): _Mobile app for managing 3x-ui panels, available on Android via apk or f-droid and sideloadable on iOS._
 
 ## Support project
 


### PR DESCRIPTION
## Summary

Adds https://github.com/yukh975/3X-UI-Manager to community tools 

## Why


Allows people to more easily discover this mobile client for Android and iOS?
Link related issues here: "Closes #5901 "


## Type of change
- [x] Documentation


## Areas affected
- [x] Github readme.md

## Checklist

- [ ] I tested the change locally and confirmed the described behavior.
- [ ] I added or updated tests for the new behavior (when applicable).
- [ ] `go build ./...` and the test suite pass locally.
- [ ] For frontend changes: `npm run lint`, `npm run typecheck`, and `npm run build` pass.
- [x] I updated the Wiki / README / API docs if user-facing behavior changed.
- [x] My commits follow the project's existing message style.
- [x] I have no unrelated changes mixed into this PR.
