### PR TITLE
fix(api): preserve 64-bit integer schema formats

### DIFF
--- a/frontend/public/openapi.json
+++ b/frontend/public/openapi.json
@@ -881,6 +881,7 @@
       "ApiToken": {
         "properties": {
           "createdAt": {
+            "format": "int64",
             "type": "integer"
           },
           "enabled": {
@@ -910,6 +911,7 @@
         "properties": {
           "createdAt": {
             "example": 1736000000,
+            "format": "int64",
             "type": "integer"
           },
           "enabled": {
@@ -960,6 +962,7 @@
           },
           "created_at": {
             "description": "Creation timestamp",
+            "format": "int64",
             "type": "integer"
           },
           "email": {
@@ -972,6 +975,7 @@
           },
           "expiryTime": {
             "description": "Expiration timestamp",
+            "format": "int64",
             "type": "integer"
           },
           "flow": {
@@ -1033,14 +1037,17 @@
           },
           "tgId": {
             "description": "Telegram user ID for notifications",
+            "format": "int64",
             "type": "integer"
           },
           "totalGB": {
             "description": "Total traffic limit in GB",
+            "format": "int64",
             "type": "integer"
           },
           "updated_at": {
             "description": "Last update timestamp",
+            "format": "int64",
             "type": "integer"
           }
         },
@@ -1064,6 +1071,7 @@
             "type": "integer"
           },
           "createdAt": {
+            "format": "int64",
             "type": "integer"
           },
           "flowOverride": {
@@ -1096,6 +1104,7 @@
             "type": "string"
           },
           "createdAt": {
+            "format": "int64",
             "type": "integer"
           },
           "email": {
@@ -1105,6 +1114,7 @@
             "type": "boolean"
           },
           "expiryTime": {
+            "format": "int64",
             "type": "integer"
           },
           "flow": {
@@ -1148,12 +1158,15 @@
             "type": "string"
           },
           "tgId": {
+            "format": "int64",
             "type": "integer"
           },
           "totalGB": {
+            "format": "int64",
             "type": "integer"
           },
           "updatedAt": {
+            "format": "int64",
             "type": "integer"
           },
           "uuid": {
@@ -1206,6 +1219,7 @@
         "properties": {
           "down": {
             "example": 2097152,
+            "format": "int64",
             "type": "integer"
           },
           "email": {
@@ -1218,6 +1232,7 @@
           },
           "expiryTime": {
             "example": 1735689600000,
+            "format": "int64",
             "type": "integer"
           },
           "id": {
@@ -1230,6 +1245,7 @@
           },
           "lastOnline": {
             "example": 1735680000000,
+            "format": "int64",
             "type": "integer"
           },
           "reset": {
@@ -1242,10 +1258,12 @@
           },
           "total": {
             "example": 10737418240,
+            "format": "int64",
             "type": "integer"
           },
           "up": {
             "example": 1048576,
+            "format": "int64",
             "type": "integer"
           },
           "uuid": {
@@ -1316,6 +1334,7 @@
             "type": "array"
           },
           "createdAt": {
+            "format": "int64",
             "type": "integer"
           },
           "echConfigList": {
@@ -1431,6 +1450,7 @@
             "type": "array"
           },
           "updatedAt": {
+            "format": "int64",
             "type": "integer"
           },
           "verifyPeerCertByName": {
@@ -1660,6 +1680,7 @@
           },
           "down": {
             "description": "Download traffic in bytes",
+            "format": "int64",
             "type": "integer"
           },
           "enable": {
@@ -1669,6 +1690,7 @@
           },
           "expiryTime": {
             "description": "Expiration timestamp",
+            "format": "int64",
             "type": "integer"
           },
           "fallbackParent": {
@@ -1687,6 +1709,7 @@
           },
           "lastTrafficResetTime": {
             "description": "Last traffic reset timestamp",
+            "format": "int64",
             "type": "integer"
           },
           "listen": {
@@ -1755,6 +1778,7 @@
           },
           "total": {
             "description": "Total traffic limit in bytes",
+            "format": "int64",
             "type": "integer"
           },
           "trafficReset": {
@@ -1770,6 +1794,7 @@
           },
           "up": {
             "description": "Upload traffic in bytes",
+            "format": "int64",
             "type": "integer"
           }
         },
@@ -1981,6 +2006,7 @@
             "type": "boolean"
           },
           "configDirtyAt": {
+            "format": "int64",
             "type": "integer"
           },
           "cpuPct": {
@@ -1989,6 +2015,7 @@
           },
           "createdAt": {
             "example": 1700000000,
+            "format": "int64",
             "type": "integer"
           },
           "depletedCount": {
@@ -2034,6 +2061,7 @@
           "lastHeartbeat": {
             "description": "unix seconds, 0 = never",
             "example": 1700000000,
+            "format": "int64",
             "type": "integer"
           },
           "latencyMs": {
@@ -2050,10 +2078,12 @@
           },
           "netDown": {
             "example": 2097152,
+            "format": "int64",
             "type": "integer"
           },
           "netUp": {
             "example": 1048576,
+            "format": "int64",
             "type": "integer"
           },
           "onlineCount": {
@@ -2110,10 +2140,12 @@
           },
           "updatedAt": {
             "example": 1700000000,
+            "format": "int64",
             "type": "integer"
           },
           "uptimeSecs": {
             "example": 86400,
+            "format": "int64",
             "type": "integer"
           },
           "xrayError": {
@@ -2175,6 +2207,7 @@
         "description": "OutboundTraffics tracks traffic statistics for Xray outbound connections.",
         "properties": {
           "down": {
+            "format": "int64",
             "type": "integer"
           },
           "id": {
@@ -2184,9 +2217,11 @@
             "type": "string"
           },
           "total": {
+            "format": "int64",
             "type": "integer"
           },
           "up": {
+            "format": "int64",
             "type": "integer"
           }
         },
@@ -2208,6 +2243,7 @@
           },
           "finishedAt": {
             "example": 1735689612,
+            "format": "int64",
             "type": "integer"
           },
           "runId": {
@@ -2254,6 +2290,7 @@
           },
           "uptimeSecs": {
             "example": 86400,
+            "format": "int64",
             "type": "integer"
           },
           "xrayError": {

--- a/frontend/src/generated/schemas.ts
+++ b/frontend/src/generated/schemas.ts
@@ -855,6 +855,7 @@ export const SCHEMAS: Record<string, unknown> = {
   "ApiToken": {
     "properties": {
       "createdAt": {
+        "format": "int64",
         "type": "integer"
       },
       "enabled": {
@@ -884,6 +885,7 @@ export const SCHEMAS: Record<string, unknown> = {
     "properties": {
       "createdAt": {
         "example": 1736000000,
+        "format": "int64",
         "type": "integer"
       },
       "enabled": {
@@ -934,6 +936,7 @@ export const SCHEMAS: Record<string, unknown> = {
       },
       "created_at": {
         "description": "Creation timestamp",
+        "format": "int64",
         "type": "integer"
       },
       "email": {
@@ -946,6 +949,7 @@ export const SCHEMAS: Record<string, unknown> = {
       },
       "expiryTime": {
         "description": "Expiration timestamp",
+        "format": "int64",
         "type": "integer"
       },
       "flow": {
@@ -1007,14 +1011,17 @@ export const SCHEMAS: Record<string, unknown> = {
       },
       "tgId": {
         "description": "Telegram user ID for notifications",
+        "format": "int64",
         "type": "integer"
       },
       "totalGB": {
         "description": "Total traffic limit in GB",
+        "format": "int64",
         "type": "integer"
       },
       "updated_at": {
         "description": "Last update timestamp",
+        "format": "int64",
         "type": "integer"
       }
     },
@@ -1038,6 +1045,7 @@ export const SCHEMAS: Record<string, unknown> = {
         "type": "integer"
       },
       "createdAt": {
+        "format": "int64",
         "type": "integer"
       },
       "flowOverride": {
@@ -1070,6 +1078,7 @@ export const SCHEMAS: Record<string, unknown> = {
         "type": "string"
       },
       "createdAt": {
+        "format": "int64",
         "type": "integer"
       },
       "email": {
@@ -1079,6 +1088,7 @@ export const SCHEMAS: Record<string, unknown> = {
         "type": "boolean"
       },
       "expiryTime": {
+        "format": "int64",
         "type": "integer"
       },
       "flow": {
@@ -1122,12 +1132,15 @@ export const SCHEMAS: Record<string, unknown> = {
         "type": "string"
       },
       "tgId": {
+        "format": "int64",
         "type": "integer"
       },
       "totalGB": {
+        "format": "int64",
         "type": "integer"
       },
       "updatedAt": {
+        "format": "int64",
         "type": "integer"
       },
       "uuid": {
@@ -1180,6 +1193,7 @@ export const SCHEMAS: Record<string, unknown> = {
     "properties": {
       "down": {
         "example": 2097152,
+        "format": "int64",
         "type": "integer"
       },
       "email": {
@@ -1192,6 +1206,7 @@ export const SCHEMAS: Record<string, unknown> = {
       },
       "expiryTime": {
         "example": 1735689600000,
+        "format": "int64",
         "type": "integer"
       },
       "id": {
@@ -1204,6 +1219,7 @@ export const SCHEMAS: Record<string, unknown> = {
       },
       "lastOnline": {
         "example": 1735680000000,
+        "format": "int64",
         "type": "integer"
       },
       "reset": {
@@ -1216,10 +1232,12 @@ export const SCHEMAS: Record<string, unknown> = {
       },
       "total": {
         "example": 10737418240,
+        "format": "int64",
         "type": "integer"
       },
       "up": {
         "example": 1048576,
+        "format": "int64",
         "type": "integer"
       },
       "uuid": {
@@ -1290,6 +1308,7 @@ export const SCHEMAS: Record<string, unknown> = {
         "type": "array"
       },
       "createdAt": {
+        "format": "int64",
         "type": "integer"
       },
       "echConfigList": {
@@ -1405,6 +1424,7 @@ export const SCHEMAS: Record<string, unknown> = {
         "type": "array"
       },
       "updatedAt": {
+        "format": "int64",
         "type": "integer"
       },
       "verifyPeerCertByName": {
@@ -1634,6 +1654,7 @@ export const SCHEMAS: Record<string, unknown> = {
       },
       "down": {
         "description": "Download traffic in bytes",
+        "format": "int64",
         "type": "integer"
       },
       "enable": {
@@ -1643,6 +1664,7 @@ export const SCHEMAS: Record<string, unknown> = {
       },
       "expiryTime": {
         "description": "Expiration timestamp",
+        "format": "int64",
         "type": "integer"
       },
       "fallbackParent": {
@@ -1661,6 +1683,7 @@ export const SCHEMAS: Record<string, unknown> = {
       },
       "lastTrafficResetTime": {
         "description": "Last traffic reset timestamp",
+        "format": "int64",
         "type": "integer"
       },
       "listen": {
@@ -1729,6 +1752,7 @@ export const SCHEMAS: Record<string, unknown> = {
       },
       "total": {
         "description": "Total traffic limit in bytes",
+        "format": "int64",
         "type": "integer"
       },
       "trafficReset": {
@@ -1744,6 +1768,7 @@ export const SCHEMAS: Record<string, unknown> = {
       },
       "up": {
         "description": "Upload traffic in bytes",
+        "format": "int64",
         "type": "integer"
       }
     },
@@ -1955,6 +1980,7 @@ export const SCHEMAS: Record<string, unknown> = {
         "type": "boolean"
       },
       "configDirtyAt": {
+        "format": "int64",
         "type": "integer"
       },
       "cpuPct": {
@@ -1963,6 +1989,7 @@ export const SCHEMAS: Record<string, unknown> = {
       },
       "createdAt": {
         "example": 1700000000,
+        "format": "int64",
         "type": "integer"
       },
       "depletedCount": {
@@ -2008,6 +2035,7 @@ export const SCHEMAS: Record<string, unknown> = {
       "lastHeartbeat": {
         "description": "unix seconds, 0 = never",
         "example": 1700000000,
+        "format": "int64",
         "type": "integer"
       },
       "latencyMs": {
@@ -2024,10 +2052,12 @@ export const SCHEMAS: Record<string, unknown> = {
       },
       "netDown": {
         "example": 2097152,
+        "format": "int64",
         "type": "integer"
       },
       "netUp": {
         "example": 1048576,
+        "format": "int64",
         "type": "integer"
       },
       "onlineCount": {
@@ -2084,10 +2114,12 @@ export const SCHEMAS: Record<string, unknown> = {
       },
       "updatedAt": {
         "example": 1700000000,
+        "format": "int64",
         "type": "integer"
       },
       "uptimeSecs": {
         "example": 86400,
+        "format": "int64",
         "type": "integer"
       },
       "xrayError": {
@@ -2149,6 +2181,7 @@ export const SCHEMAS: Record<string, unknown> = {
     "description": "OutboundTraffics tracks traffic statistics for Xray outbound connections.",
     "properties": {
       "down": {
+        "format": "int64",
         "type": "integer"
       },
       "id": {
@@ -2158,9 +2191,11 @@ export const SCHEMAS: Record<string, unknown> = {
         "type": "string"
       },
       "total": {
+        "format": "int64",
         "type": "integer"
       },
       "up": {
+        "format": "int64",
         "type": "integer"
       }
     },
@@ -2182,6 +2217,7 @@ export const SCHEMAS: Record<string, unknown> = {
       },
       "finishedAt": {
         "example": 1735689612,
+        "format": "int64",
         "type": "integer"
       },
       "runId": {
@@ -2228,6 +2264,7 @@ export const SCHEMAS: Record<string, unknown> = {
       },
       "uptimeSecs": {
         "example": 86400,
+        "format": "int64",
         "type": "integer"
       },
       "xrayError": {

--- a/tools/openapigen/emit_jsonschema.go
+++ b/tools/openapigen/emit_jsonschema.go
@@ -97,7 +97,11 @@ func (g *schemaGen) typeSchema(t TypeRef) map[string]any {
 		}
 		return map[string]any{"type": "string"}
 	case KindInt:
-		return map[string]any{"type": "integer"}
+		sch := map[string]any{"type": "integer"}
+		if t.Name == "int64" {
+			sch["format"] = "int64"
+		}
+		return sch
 	case KindNumber:
 		return map[string]any{"type": "number"}
 	case KindBool:

--- a/tools/openapigen/emit_jsonschema_test.go
+++ b/tools/openapigen/emit_jsonschema_test.go
@@ -1,0 +1,30 @@
+package main
+
+import "testing"
+
+func TestIntegerSchemaFormats(t *testing.T) {
+	tests := []struct {
+		name       string
+		goType     string
+		wantFormat string
+	}{
+		{name: "int", goType: "int"},
+		{name: "int32", goType: "int32"},
+		{name: "int64", goType: "int64", wantFormat: "int64"},
+		{name: "uint64", goType: "uint64", wantFormat: "int64"},
+	}
+
+	gen := &schemaGen{}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			schema := gen.typeSchema(identType(tt.goType))
+			if got := schema["type"]; got != "integer" {
+				t.Fatalf("type = %v, want integer", got)
+			}
+			got, _ := schema["format"].(string)
+			if got != tt.wantFormat {
+				t.Fatalf("format = %q, want %q", got, tt.wantFormat)
+			}
+		})
+	}
+}

--- a/tools/openapigen/walker.go
+++ b/tools/openapigen/walker.go
@@ -197,8 +197,10 @@ func identType(name string) TypeRef {
 		return TypeRef{Kind: KindString}
 	case "bool":
 		return TypeRef{Kind: KindBool}
-	case "int", "int8", "int16", "int32", "int64",
-		"uint", "uint8", "uint16", "uint32", "uint64":
+	case "int64", "uint64":
+		return TypeRef{Kind: KindInt, Name: "int64"}
+	case "int", "int8", "int16", "int32",
+		"uint", "uint8", "uint16", "uint32":
 		return TypeRef{Kind: KindInt}
 	case "float32", "float64":
 		return TypeRef{Kind: KindNumber}


### PR DESCRIPTION
## Summary
- preserve 64-bit Go integer width in generated schemas
- emit `format: int64` for 64-bit traffic counters and timestamps
- add regression coverage for integer schema formats

## Testing
- [x] `go test ./tools/openapigen/...`
- [x] `golangci-lint run`
- [x] `cd frontend && npm run lint && npm run typecheck && npm run test && npm run build`
- [x] `go build ./...`
- [x] `git diff --check`

Closes #5907
