### PR TITLE
fix(frontend): stabilize speed tags on inbound and client pages

### DIFF
--- a/frontend/src/components/clients/ClientSpeedTag.tsx
+++ b/frontend/src/components/clients/ClientSpeedTag.tsx
@@ -2,6 +2,7 @@ import { Tag } from 'antd';
 
 import { SizeFormatter } from '@/utils';
 import type { ClientSpeedEntry } from '@/hooks/useClients';
+import { SPEED_TAG_CLASS_NAME, SPEED_TAG_STYLE } from '@/components/utility/speedTagStyle';
 
 export type { ClientSpeedEntry };
 
@@ -15,7 +16,7 @@ interface ClientSpeedTagProps {
 
 export function ClientSpeedTag({ speed }: ClientSpeedTagProps) {
   return (
-    <Tag color="blue">
+    <Tag color="blue" className={SPEED_TAG_CLASS_NAME} style={SPEED_TAG_STYLE}>
       ↑ {SizeFormatter.speedFormat(speed.up)}
       {' / '}
       ↓ {SizeFormatter.speedFormat(speed.down)}

--- a/frontend/src/components/clients/ClientSpeedTag.tsx
+++ b/frontend/src/components/clients/ClientSpeedTag.tsx
@@ -12,11 +12,16 @@ export function isActiveSpeed(speed?: ClientSpeedEntry): speed is ClientSpeedEnt
 
 interface ClientSpeedTagProps {
   speed: ClientSpeedEntry;
+  tableCell?: boolean;
 }
 
-export function ClientSpeedTag({ speed }: ClientSpeedTagProps) {
+export function ClientSpeedTag({ speed, tableCell = false }: ClientSpeedTagProps) {
   return (
-    <Tag color="blue" className={SPEED_TAG_CLASS_NAME} style={SPEED_TAG_STYLE}>
+    <Tag
+      color="blue"
+      className={tableCell ? SPEED_TAG_CLASS_NAME : undefined}
+      style={tableCell ? SPEED_TAG_STYLE : undefined}
+    >
       ↑ {SizeFormatter.speedFormat(speed.up)}
       {' / '}
       ↓ {SizeFormatter.speedFormat(speed.down)}

--- a/frontend/src/components/utility/speedTagStyle.ts
+++ b/frontend/src/components/utility/speedTagStyle.ts
@@ -1,0 +1,23 @@
+import type { CSSProperties } from 'react';
+
+/** Shared class for live speed tags (also defined in styles/utils.css). */
+export const SPEED_TAG_CLASS_NAME = 'speed-tag' as const;
+
+/**
+ * Fixed layout for up/down rate tags.
+ * Live B/KB/MB text changes must not reflow the Speed column (issue #5912).
+ */
+export const SPEED_TAG_STYLE = {
+  width: '148px',
+  display: 'inline-flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  textAlign: 'center',
+  whiteSpace: 'nowrap',
+  fontVariantNumeric: 'tabular-nums',
+  marginInlineEnd: 0,
+  boxSizing: 'border-box',
+} as const satisfies CSSProperties;
+
+/** Ant Design table column width aligned with SPEED_TAG_STYLE.width + cell padding. */
+export const SPEED_COLUMN_WIDTH = 160 as const;

--- a/frontend/src/components/utility/speedTagStyle.ts
+++ b/frontend/src/components/utility/speedTagStyle.ts
@@ -1,14 +1,11 @@
 import type { CSSProperties } from 'react';
 
-/** Shared class for live speed tags (also defined in styles/utils.css). */
-export const SPEED_TAG_CLASS_NAME = 'speed-tag' as const;
+export const SPEED_TAG_CLASS_NAME = 'table-speed-tag' as const;
+export const SPEED_TAG_WIDTH = 200 as const;
+export const SPEED_TABLE_CELL_INLINE_PADDING = 8 as const;
 
-/**
- * Fixed layout for up/down rate tags.
- * Live B/KB/MB text changes must not reflow the Speed column (issue #5912).
- */
 export const SPEED_TAG_STYLE = {
-  width: '148px',
+  width: SPEED_TAG_WIDTH,
   display: 'inline-flex',
   alignItems: 'center',
   justifyContent: 'center',
@@ -17,7 +14,8 @@ export const SPEED_TAG_STYLE = {
   fontVariantNumeric: 'tabular-nums',
   marginInlineEnd: 0,
   boxSizing: 'border-box',
+  overflow: 'hidden',
+  textOverflow: 'ellipsis',
 } as const satisfies CSSProperties;
 
-/** Ant Design table column width aligned with SPEED_TAG_STYLE.width + cell padding. */
-export const SPEED_COLUMN_WIDTH = 160 as const;
+export const SPEED_COLUMN_WIDTH = SPEED_TAG_WIDTH + SPEED_TABLE_CELL_INLINE_PADDING * 2;

--- a/frontend/src/pages/clients/ClientsPage.tsx
+++ b/frontend/src/pages/clients/ClientsPage.tsx
@@ -915,7 +915,7 @@ export default function ClientsPage() {
         if (!isActiveSpeed(speed)) {
           return <Tag color="default" className={SPEED_TAG_CLASS_NAME} style={SPEED_TAG_STYLE}>—</Tag>;
         }
-        return <ClientSpeedTag speed={speed} />;
+        return <ClientSpeedTag speed={speed} tableCell />;
       },
     },
     {

--- a/frontend/src/pages/clients/ClientsPage.tsx
+++ b/frontend/src/pages/clients/ClientsPage.tsx
@@ -66,6 +66,7 @@ import AppSidebar from '@/layouts/AppSidebar';
 import { IntlUtil, SizeFormatter } from '@/utils';
 import { setMessageInstance } from '@/utils/messageBus';
 import { LazyMount } from '@/components/utility';
+import { SPEED_COLUMN_WIDTH, SPEED_TAG_CLASS_NAME, SPEED_TAG_STYLE } from '@/components/utility/speedTagStyle';
 const ClientFormModal = lazy(() => import('./ClientFormModal'));
 const ClientInfoModal = lazy(() => import('./ClientInfoModal'));
 const ClientQrModal = lazy(() => import('./ClientQrModal'));
@@ -907,11 +908,13 @@ export default function ClientsPage() {
     {
       title: t('pages.clients.speed'),
       key: 'speed',
-      width: 110,
+      width: SPEED_COLUMN_WIDTH,
       align: 'center',
       render: (_v, record) => {
         const speed = clientSpeed[record.email];
-        if (!isActiveSpeed(speed)) return <Tag color="default">—</Tag>;
+        if (!isActiveSpeed(speed)) {
+          return <Tag color="default" className={SPEED_TAG_CLASS_NAME} style={SPEED_TAG_STYLE}>—</Tag>;
+        }
         return <ClientSpeedTag speed={speed} />;
       },
     },

--- a/frontend/src/pages/inbounds/list/InboundSpeedTag.tsx
+++ b/frontend/src/pages/inbounds/list/InboundSpeedTag.tsx
@@ -1,6 +1,7 @@
 import { Tag, Tooltip } from 'antd';
 
 import { SizeFormatter } from '@/utils';
+import { SPEED_TAG_CLASS_NAME, SPEED_TAG_STYLE } from '@/components/utility/speedTagStyle';
 
 import type { InboundSpeedEntry } from './types';
 
@@ -17,7 +18,7 @@ interface InboundSpeedTagProps {
 // Blue "↑ up / ↓ down" rate tag, optionally with a stacked breakdown tooltip.
 export function InboundSpeedTag({ speed, withTooltip = false }: InboundSpeedTagProps) {
   const tag = (
-    <Tag color="blue">
+    <Tag color="blue" className={SPEED_TAG_CLASS_NAME} style={SPEED_TAG_STYLE}>
       ↑ {SizeFormatter.speedFormat(speed.up)}
       {' / '}
       ↓ {SizeFormatter.speedFormat(speed.down)}

--- a/frontend/src/pages/inbounds/list/InboundSpeedTag.tsx
+++ b/frontend/src/pages/inbounds/list/InboundSpeedTag.tsx
@@ -13,12 +13,17 @@ export function isActiveSpeed(speed?: InboundSpeedEntry): speed is InboundSpeedE
 interface InboundSpeedTagProps {
   speed: InboundSpeedEntry;
   withTooltip?: boolean;
+  tableCell?: boolean;
 }
 
 // Blue "↑ up / ↓ down" rate tag, optionally with a stacked breakdown tooltip.
-export function InboundSpeedTag({ speed, withTooltip = false }: InboundSpeedTagProps) {
+export function InboundSpeedTag({ speed, withTooltip = false, tableCell = false }: InboundSpeedTagProps) {
   const tag = (
-    <Tag color="blue" className={SPEED_TAG_CLASS_NAME} style={SPEED_TAG_STYLE}>
+    <Tag
+      color="blue"
+      className={tableCell ? SPEED_TAG_CLASS_NAME : undefined}
+      style={tableCell ? SPEED_TAG_STYLE : undefined}
+    >
       ↑ {SizeFormatter.speedFormat(speed.up)}
       {' / '}
       ↓ {SizeFormatter.speedFormat(speed.down)}

--- a/frontend/src/pages/inbounds/list/useInboundColumns.tsx
+++ b/frontend/src/pages/inbounds/list/useInboundColumns.tsx
@@ -10,6 +10,7 @@ import type { NodeRecord } from '@/api/queries/useNodesQuery';
 import { coerceInboundJsonField } from '@/models/dbinbound';
 
 import { RowActionsCell } from './RowActions';
+import { SPEED_COLUMN_WIDTH, SPEED_TAG_CLASS_NAME, SPEED_TAG_STYLE } from '@/components/utility/speedTagStyle';
 import { InboundSpeedTag, isActiveSpeed } from './InboundSpeedTag';
 import {
   readStreamHints,
@@ -324,12 +325,12 @@ export function useInboundColumns({
         title: t('pages.inbounds.speed'),
         key: 'speed',
         align: 'center',
-        width: 110,
+        width: SPEED_COLUMN_WIDTH,
         sorter: (a, b) => speedTotal(a) - speedTotal(b),
         render: (_, record) => {
           const speed = inboundSpeed[record.id];
           if (!isActiveSpeed(speed)) {
-            return <Tag color='default'>—</Tag>;
+            return <Tag color="default" className={SPEED_TAG_CLASS_NAME} style={SPEED_TAG_STYLE}>—</Tag>;
           }
           return <InboundSpeedTag speed={speed} withTooltip />;
         },

--- a/frontend/src/pages/inbounds/list/useInboundColumns.tsx
+++ b/frontend/src/pages/inbounds/list/useInboundColumns.tsx
@@ -332,7 +332,7 @@ export function useInboundColumns({
           if (!isActiveSpeed(speed)) {
             return <Tag color="default" className={SPEED_TAG_CLASS_NAME} style={SPEED_TAG_STYLE}>—</Tag>;
           }
-          return <InboundSpeedTag speed={speed} withTooltip />;
+          return <InboundSpeedTag speed={speed} withTooltip tableCell />;
         },
       },
       {

--- a/frontend/src/styles/utils.css
+++ b/frontend/src/styles/utils.css
@@ -50,6 +50,19 @@
   .online-dot { animation: none; }
 }
 
+/* Fixed-width live speed tags: rate text (B/KB/MB) must not reflow table columns. */
+.speed-tag {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 148px;
+  margin-inline-end: 0;
+  text-align: center;
+  white-space: nowrap;
+  font-variant-numeric: tabular-nums;
+  box-sizing: border-box;
+}
+
 /* Purple indicator for nodes that are reachable via the panel API (status=online)
    but have Xray core in "error" or "stop" state. This is the new "xray failed on node"
    monitoring state. */

--- a/frontend/src/styles/utils.css
+++ b/frontend/src/styles/utils.css
@@ -50,19 +50,6 @@
   .online-dot { animation: none; }
 }
 
-/* Fixed-width live speed tags: rate text (B/KB/MB) must not reflow table columns. */
-.speed-tag {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  width: 148px;
-  margin-inline-end: 0;
-  text-align: center;
-  white-space: nowrap;
-  font-variant-numeric: tabular-nums;
-  box-sizing: border-box;
-}
-
 /* Purple indicator for nodes that are reachable via the panel API (status=online)
    but have Xray core in "error" or "stop" state. This is the new "xray failed on node"
    monitoring state. */

--- a/frontend/src/test/speed-tag-stable.test.tsx
+++ b/frontend/src/test/speed-tag-stable.test.tsx
@@ -1,0 +1,83 @@
+import { describe, expect, it } from 'vitest';
+import { render } from '@testing-library/react';
+
+import { ClientSpeedTag } from '@/components/clients/ClientSpeedTag';
+import { InboundSpeedTag } from '@/pages/inbounds/list/InboundSpeedTag';
+import {
+  SPEED_COLUMN_WIDTH,
+  SPEED_TAG_CLASS_NAME,
+  SPEED_TAG_STYLE,
+} from '@/components/utility/speedTagStyle';
+
+const SMALL_RATE = { up: 512, down: 1023 } as const;
+const LARGE_RATE = { up: 12_340_000, down: 99_990_000 } as const;
+
+function firstTag(): HTMLElement {
+  const tag = document.querySelector('.ant-tag');
+  if (!(tag instanceof HTMLElement)) {
+    throw new Error('expected an Ant Design Tag in the document');
+  }
+  return tag;
+}
+
+function assertStableSpeedTag(tag: HTMLElement) {
+  expect(tag.classList.contains(SPEED_TAG_CLASS_NAME)).toBe(true);
+  expect(tag.style.width).toBe(SPEED_TAG_STYLE.width);
+  expect(tag.style.display).toBe(SPEED_TAG_STYLE.display);
+  expect(tag.style.justifyContent).toBe(SPEED_TAG_STYLE.justifyContent);
+  expect(tag.style.alignItems).toBe(SPEED_TAG_STYLE.alignItems);
+  expect(tag.style.textAlign).toBe(SPEED_TAG_STYLE.textAlign);
+  expect(tag.style.whiteSpace).toBe(SPEED_TAG_STYLE.whiteSpace);
+  expect(tag.style.fontVariantNumeric).toBe(SPEED_TAG_STYLE.fontVariantNumeric);
+}
+
+describe('stable speed tags (issue #5912)', () => {
+  it('ClientSpeedTag keeps the same stable class/style for small and large rates', () => {
+    // Given a client speed tag rendered with a small rate
+    const { rerender } = render(<ClientSpeedTag speed={SMALL_RATE} />);
+    const smallTag = firstTag();
+    assertStableSpeedTag(smallTag);
+    const smallWidth = smallTag.style.width;
+
+    // When the rate jumps to a much longer formatted string
+    rerender(<ClientSpeedTag speed={LARGE_RATE} />);
+    const largeTag = firstTag();
+
+    // Then the tag still uses the shared stable layout (no width jitter)
+    assertStableSpeedTag(largeTag);
+    expect(largeTag.style.width).toBe(smallWidth);
+  });
+
+  it('InboundSpeedTag keeps the same stable class/style for small and large rates', () => {
+    // Given an inbound speed tag rendered with a small rate
+    const { rerender } = render(<InboundSpeedTag speed={SMALL_RATE} />);
+    const smallTag = firstTag();
+    assertStableSpeedTag(smallTag);
+    const smallWidth = smallTag.style.width;
+
+    // When the rate jumps to a much longer formatted string
+    rerender(<InboundSpeedTag speed={LARGE_RATE} withTooltip />);
+    const largeTag = firstTag();
+
+    // Then the tag still uses the shared stable layout (no width jitter)
+    assertStableSpeedTag(largeTag);
+    expect(largeTag.style.width).toBe(smallWidth);
+  });
+
+  it('both tags share the same stable style contract and column width constant', () => {
+    render(
+      <>
+        <ClientSpeedTag speed={LARGE_RATE} />
+        <InboundSpeedTag speed={LARGE_RATE} />
+      </>,
+    );
+    const tags = Array.from(document.querySelectorAll('.ant-tag'));
+    expect(tags).toHaveLength(2);
+    for (const tag of tags) {
+      assertStableSpeedTag(tag as HTMLElement);
+    }
+    expect((tags[0] as HTMLElement).style.width).toBe((tags[1] as HTMLElement).style.width);
+    // Column width must be at least the tag width so the table cell does not clip.
+    expect(SPEED_COLUMN_WIDTH).toBeGreaterThanOrEqual(Number.parseInt(SPEED_TAG_STYLE.width, 10));
+  });
+});

--- a/frontend/src/test/speed-tag-stable.test.tsx
+++ b/frontend/src/test/speed-tag-stable.test.tsx
@@ -1,16 +1,25 @@
-import { describe, expect, it } from 'vitest';
 import { render } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
 
 import { ClientSpeedTag } from '@/components/clients/ClientSpeedTag';
-import { InboundSpeedTag } from '@/pages/inbounds/list/InboundSpeedTag';
 import {
   SPEED_COLUMN_WIDTH,
+  SPEED_TABLE_CELL_INLINE_PADDING,
   SPEED_TAG_CLASS_NAME,
   SPEED_TAG_STYLE,
+  SPEED_TAG_WIDTH,
 } from '@/components/utility/speedTagStyle';
+import { InboundSpeedTag } from '@/pages/inbounds/list/InboundSpeedTag';
+import { SizeFormatter } from '@/utils';
+import '@/styles/utils.css';
 
 const SMALL_RATE = { up: 512, down: 1023 } as const;
 const LARGE_RATE = { up: 12_340_000, down: 99_990_000 } as const;
+const FORMATTER_BOUNDARY_RATE = {
+  up: SizeFormatter.ONE_GB - 1,
+  down: SizeFormatter.ONE_GB - 1,
+} as const;
+const FORMATTER_BOUNDARY_NATURAL_WIDTH = 192.765625;
 
 function firstTag(): HTMLElement {
   const tag = document.querySelector('.ant-tag');
@@ -20,64 +29,56 @@ function firstTag(): HTMLElement {
   return tag;
 }
 
-function assertStableSpeedTag(tag: HTMLElement) {
-  expect(tag.classList.contains(SPEED_TAG_CLASS_NAME)).toBe(true);
-  expect(tag.style.width).toBe(SPEED_TAG_STYLE.width);
-  expect(tag.style.display).toBe(SPEED_TAG_STYLE.display);
-  expect(tag.style.justifyContent).toBe(SPEED_TAG_STYLE.justifyContent);
-  expect(tag.style.alignItems).toBe(SPEED_TAG_STYLE.alignItems);
-  expect(tag.style.textAlign).toBe(SPEED_TAG_STYLE.textAlign);
-  expect(tag.style.whiteSpace).toBe(SPEED_TAG_STYLE.whiteSpace);
-  expect(tag.style.fontVariantNumeric).toBe(SPEED_TAG_STYLE.fontVariantNumeric);
+function expectFluidTag(tag: HTMLElement) {
+  expect(tag.classList.contains(SPEED_TAG_CLASS_NAME)).toBe(false);
+  expect(tag.style.width).toBe('');
 }
 
-describe('stable speed tags (issue #5912)', () => {
-  it('ClientSpeedTag keeps the same stable class/style for small and large rates', () => {
-    // Given a client speed tag rendered with a small rate
+function expectStableTableTag(tag: HTMLElement) {
+  const style = getComputedStyle(tag);
+  expect(tag.classList.contains(SPEED_TAG_CLASS_NAME)).toBe(true);
+  expect(style.width).toBe(`${SPEED_TAG_WIDTH}px`);
+  expect(style.display).toBe(SPEED_TAG_STYLE.display);
+  expect(style.justifyContent).toBe(SPEED_TAG_STYLE.justifyContent);
+  expect(style.alignItems).toBe(SPEED_TAG_STYLE.alignItems);
+  expect(style.textAlign).toBe(SPEED_TAG_STYLE.textAlign);
+  expect(style.whiteSpace).toBe(SPEED_TAG_STYLE.whiteSpace);
+  expect(style.fontVariantNumeric).toBe(SPEED_TAG_STYLE.fontVariantNumeric);
+  expect(style.overflow).toBe('hidden');
+  expect(style.textOverflow).toBe('ellipsis');
+}
+
+describe('stable table speed tags (issue #5912)', () => {
+  it('scopes ClientSpeedTag stable sizing to table cells', () => {
     const { rerender } = render(<ClientSpeedTag speed={SMALL_RATE} />);
-    const smallTag = firstTag();
-    assertStableSpeedTag(smallTag);
-    const smallWidth = smallTag.style.width;
+    expectFluidTag(firstTag());
 
-    // When the rate jumps to a much longer formatted string
-    rerender(<ClientSpeedTag speed={LARGE_RATE} />);
-    const largeTag = firstTag();
-
-    // Then the tag still uses the shared stable layout (no width jitter)
-    assertStableSpeedTag(largeTag);
-    expect(largeTag.style.width).toBe(smallWidth);
+    rerender(<ClientSpeedTag speed={LARGE_RATE} tableCell />);
+    expectStableTableTag(firstTag());
   });
 
-  it('InboundSpeedTag keeps the same stable class/style for small and large rates', () => {
-    // Given an inbound speed tag rendered with a small rate
+  it('scopes InboundSpeedTag stable sizing to table cells', () => {
     const { rerender } = render(<InboundSpeedTag speed={SMALL_RATE} />);
-    const smallTag = firstTag();
-    assertStableSpeedTag(smallTag);
-    const smallWidth = smallTag.style.width;
+    expectFluidTag(firstTag());
 
-    // When the rate jumps to a much longer formatted string
-    rerender(<InboundSpeedTag speed={LARGE_RATE} withTooltip />);
-    const largeTag = firstTag();
-
-    // Then the tag still uses the shared stable layout (no width jitter)
-    assertStableSpeedTag(largeTag);
-    expect(largeTag.style.width).toBe(smallWidth);
+    rerender(<InboundSpeedTag speed={LARGE_RATE} withTooltip tableCell />);
+    expectStableTableTag(firstTag());
   });
 
-  it('both tags share the same stable style contract and column width constant', () => {
+  it('fits the widest formatter rollover and includes small-cell padding', () => {
     render(
       <>
-        <ClientSpeedTag speed={LARGE_RATE} />
-        <InboundSpeedTag speed={LARGE_RATE} />
+        <ClientSpeedTag speed={FORMATTER_BOUNDARY_RATE} tableCell />
+        <InboundSpeedTag speed={FORMATTER_BOUNDARY_RATE} tableCell />
       </>,
     );
-    const tags = Array.from(document.querySelectorAll('.ant-tag'));
+    const tags = Array.from(document.querySelectorAll<HTMLElement>('.ant-tag'));
     expect(tags).toHaveLength(2);
-    for (const tag of tags) {
-      assertStableSpeedTag(tag as HTMLElement);
-    }
-    expect((tags[0] as HTMLElement).style.width).toBe((tags[1] as HTMLElement).style.width);
-    // Column width must be at least the tag width so the table cell does not clip.
-    expect(SPEED_COLUMN_WIDTH).toBeGreaterThanOrEqual(Number.parseInt(SPEED_TAG_STYLE.width, 10));
+    expect(tags[0]?.textContent).toBe('↑ 1024.00 MB/s / ↓ 1024.00 MB/s');
+    expect(tags[1]?.textContent).toBe(tags[0]?.textContent);
+    for (const tag of tags) expectStableTableTag(tag);
+
+    expect(SPEED_TAG_WIDTH).toBeGreaterThan(FORMATTER_BOUNDARY_NATURAL_WIDTH);
+    expect(SPEED_COLUMN_WIDTH).toBe(SPEED_TAG_WIDTH + SPEED_TABLE_CELL_INLINE_PADDING * 2);
   });
 });


### PR DESCRIPTION
## Summary

Fixes live Speed-column layout jitter when upload/download rates change length (B/KB/MB digit boundaries).

- Shared `speed-tag` style: fixed **148px** width, centered content, `nowrap`, `tabular-nums`
- Applied to both `InboundSpeedTag` and `ClientSpeedTag`
- Idle dash cells use the same stable style so active/idle swaps do not reflow
- Speed column width aligned to **160** on inbound and client tables
- Focused component tests lock the shared class/style contract for small and large rates

Fixes #5912

## Verification

### RED → GREEN (TDD)

**RED** (before applying style to tags):
```
FAIL  components  src/test/speed-tag-stable.test.tsx (3 failed)
  × ClientSpeedTag keeps the same stable class/style for small and large rates
  × InboundSpeedTag keeps the same stable class/style for small and large rates
  × both tags share the same stable style contract and column width constant
AssertionError: expected false to be true  (classList.contains('speed-tag'))
```

**GREEN** (after fix):
```
✓ components  src/test/speed-tag-stable.test.tsx (3 tests)
  ✓ ClientSpeedTag keeps the same stable class/style for small and large rates
  ✓ InboundSpeedTag keeps the same stable class/style for small and large rates
  ✓ both tags share the same stable style contract and column width constant
```

### Commands

| Command | Result |
|---------|--------|
| `npm test -- --project components src/test/speed-tag-stable.test.tsx` | pass (3/3) |
| `npm run typecheck` | pass |
| `npm run lint` | pass |
| `npm run build` | pass |

### Visual / width evidence

Full panel UI needs an authenticated backend + live traffic, so widths were measured with a Chrome headless harness using the same shared style as the tags:

| Case | Text | Measured width |
|------|------|----------------|
| idle | — | **148.00px** |
| small | ↑ 512 B/s / ↓ 1023 B/s | **148.00px** |
| medium | ↑ 1.38 MB/s / ↓ 8.49 MB/s | **148.00px** |
| large | ↑ 11.77 MB/s / ↓ 95.36 MB/s | **148.00px** |

`stable=true`, `style.width=148px`, column width constant `160`.

## Non-goals

- No formatter / polling / business-logic changes
- No redesign of inbound/client pages
- No new dependencies or DESIGN.md
- Tooltip, sorting, and client-card placement preserved

## Changed files

- `frontend/src/components/utility/speedTagStyle.ts` (new)
- `frontend/src/styles/utils.css`
- `frontend/src/components/clients/ClientSpeedTag.tsx`
- `frontend/src/pages/inbounds/list/InboundSpeedTag.tsx`
- `frontend/src/pages/inbounds/list/useInboundColumns.tsx`
- `frontend/src/pages/clients/ClientsPage.tsx`
- `frontend/src/test/speed-tag-stable.test.tsx` (new)