### PR TITLE
feat(frontend): show client comments on mobile cards

### DIFF
--- a/frontend/src/components/clients/ClientCardComment.tsx
+++ b/frontend/src/components/clients/ClientCardComment.tsx
@@ -1,0 +1,13 @@
+type ClientCardCommentProps = {
+  comment?: string;
+};
+
+export default function ClientCardComment({ comment }: ClientCardCommentProps) {
+  if (!comment) return null;
+
+  return (
+    <div className="client-card-comment" title={comment}>
+      {comment}
+    </div>
+  );
+}

--- a/frontend/src/components/clients/ClientCardComment.tsx
+++ b/frontend/src/components/clients/ClientCardComment.tsx
@@ -1,13 +1,14 @@
 type ClientCardCommentProps = {
   comment?: string;
+  className?: string;
 };
 
-export default function ClientCardComment({ comment }: ClientCardCommentProps) {
+export default function ClientCardComment({ comment, className = 'client-card-comment' }: ClientCardCommentProps) {
   if (!comment) return null;
 
   return (
-    <div className="client-card-comment" title={comment}>
+    <span className={className} title={comment}>
       {comment}
-    </div>
+    </span>
   );
 }

--- a/frontend/src/pages/clients/ClientsPage.css
+++ b/frontend/src/pages/clients/ClientsPage.css
@@ -163,9 +163,12 @@
 }
 
 .client-card-comment {
+  display: block;
   margin-top: 6px;
   color: var(--ant-color-text-secondary);
   font-size: 12px;
+  max-height: 4.5em;
+  overflow-y: auto;
   overflow-wrap: anywhere;
   white-space: pre-wrap;
 }

--- a/frontend/src/pages/clients/ClientsPage.css
+++ b/frontend/src/pages/clients/ClientsPage.css
@@ -162,6 +162,14 @@
   background: color-mix(in srgb, var(--ant-color-primary) 6%, transparent);
 }
 
+.client-card-comment {
+  margin-top: 6px;
+  color: var(--ant-color-text-secondary);
+  font-size: 12px;
+  overflow-wrap: anywhere;
+  white-space: pre-wrap;
+}
+
 .client-card-speed {
   margin-top: 6px;
   font-size: 12px;

--- a/frontend/src/pages/clients/ClientsPage.tsx
+++ b/frontend/src/pages/clients/ClientsPage.tsx
@@ -819,7 +819,7 @@ export default function ClientsPage() {
         <div className="email-cell">
           <span className="email">{record.email}</span>
           {record.subId && <span className="sub" title={record.subId}>{record.subId}</span>}
-          {record.comment && <span className="sub" title={record.comment}>{record.comment}</span>}
+          <ClientCardComment comment={record.comment} className="sub" />
         </div>
       ),
     },

--- a/frontend/src/pages/clients/ClientsPage.tsx
+++ b/frontend/src/pages/clients/ClientsPage.tsx
@@ -62,6 +62,7 @@ import { useDatepicker } from '@/hooks/useDatepicker';
 import type { ClientRecord, InboundOption, ExternalLink, ExternalLinkInput } from '@/hooks/useClients';
 import ClientTrafficCell from '@/components/clients/ClientTrafficCell';
 import ClientSpeedTag, { isActiveSpeed } from '@/components/clients/ClientSpeedTag';
+import ClientCardComment from '@/components/clients/ClientCardComment';
 import AppSidebar from '@/layouts/AppSidebar';
 import { IntlUtil, SizeFormatter } from '@/utils';
 import { setMessageInstance } from '@/utils/messageBus';
@@ -1433,6 +1434,7 @@ export default function ClientsPage() {
                                       </Dropdown>
                                     </div>
                                   </div>
+                                  <ClientCardComment comment={row.comment} />
                                   <ClientTrafficCell
                                     compact
                                     up={row.traffic?.up}

--- a/frontend/src/test/client-card-comment.test.tsx
+++ b/frontend/src/test/client-card-comment.test.tsx
@@ -5,11 +5,18 @@ import ClientCardComment from '@/components/clients/ClientCardComment';
 
 describe('ClientCardComment', () => {
   it('renders a client comment in the card', () => {
-    render(<ClientCardComment comment="Primary mobile client" />);
+    render(<ClientCardComment comment={'Primary mobile client\nLine two'} />);
 
-    const comment = screen.getByText('Primary mobile client');
+    const comment = screen.getByText(/Primary mobile client/);
     expect(comment.className).toContain('client-card-comment');
-    expect(comment.getAttribute('title')).toBe('Primary mobile client');
+    expect(comment.textContent).toBe('Primary mobile client\nLine two');
+    expect(comment.getAttribute('title')).toBe('Primary mobile client\nLine two');
+  });
+
+  it('supports the compact desktop style', () => {
+    render(<ClientCardComment comment="Desktop comment" className="sub" />);
+
+    expect(screen.getByText('Desktop comment').className).toBe('sub');
   });
 
   it('renders nothing when no comment is set', () => {

--- a/frontend/src/test/client-card-comment.test.tsx
+++ b/frontend/src/test/client-card-comment.test.tsx
@@ -1,0 +1,20 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import ClientCardComment from '@/components/clients/ClientCardComment';
+
+describe('ClientCardComment', () => {
+  it('renders a client comment in the card', () => {
+    render(<ClientCardComment comment="Primary mobile client" />);
+
+    const comment = screen.getByText('Primary mobile client');
+    expect(comment.className).toContain('client-card-comment');
+    expect(comment.getAttribute('title')).toBe('Primary mobile client');
+  });
+
+  it('renders nothing when no comment is set', () => {
+    const { container } = render(<ClientCardComment comment="" />);
+
+    expect(container.childElementCount).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary

- Show each client's existing comment beneath the mobile card header.
- Preserve multiline comments and wrap long text within the card.

## Why

Mobile users currently need to open the client details modal to read comments.

Closes #5794

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactoring (no behavior change)
- [ ] Documentation
- [ ] Tests only
- [ ] Build / CI / tooling
- [ ] Other

## Areas affected

- [x] Frontend (UI / panel pages)
- [ ] Backend (API endpoints, login, settings)
- [ ] Xray config generation
- [ ] Subscription (share links / Clash / JSON)
- [ ] Statistics / traffic counters
- [ ] Database / migrations
- [ ] Install / upgrade script
- [ ] Docker image
- [ ] Multi-node (sub-nodes)

## How was this tested?

- `npm run test -- src/test/client-card-comment.test.tsx`
- `npm run lint`
- `npm run typecheck`
- `npm run test` (764 tests)
- `npm run build`

## Screenshots / recordings

Not included. The focused component test covers comments being present and absent.

## Breaking changes

None.

## Checklist

- [x] I tested the change locally and confirmed the described behavior.
- [x] I added or updated tests for the new behavior (when applicable).
- [x] The relevant frontend test suite passes locally.
- [x] For frontend changes: `npm run lint`, `npm run typecheck`, and `npm run build` pass.
- [x] I updated the Wiki / README / API docs if user-facing behavior changed.
- [x] My commits follow the project's existing message style.
- [x] I have no unrelated changes mixed into this PR.
