### PR TITLE
fix: stop forcing port 53 on DoH/DoQ DNS server entries

### DIFF
--- a/frontend/src/pages/xray/dns/DnsServerModal.tsx
+++ b/frontend/src/pages/xray/dns/DnsServerModal.tsx
@@ -10,6 +10,7 @@ import {
   DnsQueryStrategySchema,
   DnsServerObjectInnerSchema,
   DnsServerObjectSchema,
+  isEncryptedDnsAddress,
   type DnsServerObject,
 } from '@/schemas/dns';
 
@@ -109,7 +110,6 @@ function valuesToWire(values: DnsServerForm): DnsServerValue {
 
   const out: Record<string, unknown> = {
     address: values.address,
-    port: values.port,
     domains: values.domains.filter(Boolean),
     expectedIPs: values.expectedIPs.filter(Boolean),
     unexpectedIPs: values.unexpectedIPs.filter(Boolean),
@@ -121,6 +121,7 @@ function valuesToWire(values: DnsServerForm): DnsServerValue {
     serveExpiredTTL: values.serveExpiredTTL,
     timeoutMs: values.timeoutMs,
   };
+  if (!isEncryptedDnsAddress(values.address)) out.port = values.port;
   if (values.tag) out.tag = values.tag;
   if (values.clientIP) out.clientIP = values.clientIP;
   return out as DnsServerValue;

--- a/frontend/src/schemas/dns.ts
+++ b/frontend/src/schemas/dns.ts
@@ -14,9 +14,13 @@ const DnsHostValueSchema = z.union([z.string(), z.array(z.string())]);
 export const DnsHostsSchema = z.record(z.string(), DnsHostValueSchema);
 export type DnsHosts = z.infer<typeof DnsHostsSchema>;
 
+export function isEncryptedDnsAddress(address: string): boolean {
+  return /^(https|https\+local|h2c|h2c\+local|quic\+local):\/\//i.test(address);
+}
+
 export const DnsServerObjectInnerSchema = z.object({
   address: z.string(),
-  port: PortSchema.default(53),
+  port: PortSchema.optional(),
   domains: z.array(z.string()).optional(),
   expectedIPs: z.array(z.string()).optional(),
   unexpectedIPs: z.array(z.string()).optional(),
@@ -41,7 +45,12 @@ export const DnsServerObjectSchema = z.preprocess(
     return val;
   },
   DnsServerObjectInnerSchema,
-);
+).transform((v) => {
+  if (v.port === undefined && !isEncryptedDnsAddress(v.address)) {
+    return { ...v, port: 53 };
+  }
+  return v;
+});
 export type DnsServerObject = z.infer<typeof DnsServerObjectSchema>;
 
 export const DnsServerEntrySchema = z.union([z.string(), DnsServerObjectSchema]);

--- a/frontend/src/test/__snapshots__/dns.test.ts.snap
+++ b/frontend/src/test/__snapshots__/dns.test.ts.snap
@@ -41,7 +41,6 @@ exports[`DnsObjectSchema fixtures > parses full byte-stably 1`] = `
       "address": "quic+local://dns.adguard.com",
       "disableCache": true,
       "finalQuery": true,
-      "port": 53,
       "serveExpiredTTL": 60,
       "serveStale": false,
       "timeoutMs": 5000,

--- a/frontend/src/test/dns.test.ts
+++ b/frontend/src/test/dns.test.ts
@@ -41,3 +41,45 @@ describe('DnsServerObjectSchema fixtures', () => {
     });
   }
 });
+
+describe('DnsServerObjectSchema port defaulting', () => {
+  it('defaults port 53 for a plain address', () => {
+    const parsed = DnsServerObjectSchema.parse({ address: '8.8.8.8' });
+    expect(parsed.port).toBe(53);
+  });
+
+  it('defaults port 53 for a tcp address', () => {
+    const parsed = DnsServerObjectSchema.parse({ address: 'tcp://1.1.1.1' });
+    expect(parsed.port).toBe(53);
+  });
+
+  it('omits port for a DoH (https://) address', () => {
+    const parsed = DnsServerObjectSchema.parse({ address: 'https://cloudflare-dns.com/dns-query' });
+    expect(parsed.port).toBeUndefined();
+  });
+
+  it('omits port for a DoHL (https+local://) address', () => {
+    const parsed = DnsServerObjectSchema.parse({ address: 'https+local://dns.google/dns-query' });
+    expect(parsed.port).toBeUndefined();
+  });
+
+  it('omits port for a DoQ (quic+local://) address', () => {
+    const parsed = DnsServerObjectSchema.parse({ address: 'quic+local://dns.adguard.com' });
+    expect(parsed.port).toBeUndefined();
+  });
+
+  it('omits port for an h2c and h2c+local address', () => {
+    expect(DnsServerObjectSchema.parse({ address: 'h2c://dns.example.com/dns-query' }).port).toBeUndefined();
+    expect(DnsServerObjectSchema.parse({ address: 'h2c+local://dns.example.com/dns-query' }).port).toBeUndefined();
+  });
+
+  it('omits port for an uppercase encrypted scheme', () => {
+    const parsed = DnsServerObjectSchema.parse({ address: 'HTTPS://dns.google/dns-query' });
+    expect(parsed.port).toBeUndefined();
+  });
+
+  it('preserves an explicit port on an encrypted address', () => {
+    const parsed = DnsServerObjectSchema.parse({ address: 'https://dns.google/dns-query', port: 8443 });
+    expect(parsed.port).toBe(8443);
+  });
+});


### PR DESCRIPTION
## Summary

Stop the panel from writing `port: 53` onto DNS-over-HTTPS / DoH-Local / DoQ server entries in the Preset DNS editor. Those encrypted schemes carry any non-standard port inside the URL, so a separate `port` field is invalid for them.

## Why

As reported in #5920, DoH preset entries were being saved with `port: 53`. Two frontend paths injected it:

- `DnsServerObjectInnerSchema` in `frontend/src/schemas/dns.ts` declared `port: PortSchema.default(53)`, so every object-form entry got `port: 53` even when the source JSON omitted a port. The repo's own golden fixture makes this visible: the `quic+local://` DoQ entry in `full.json` has no port, yet the parsed snapshot showed `port: 53`.
- `valuesToWire` in `DnsServerModal.tsx` always set `out.port = values.port` whenever an entry was emitted in object form, adding `port: 53` to DoH/DoQ rows edited in the modal.

Xray-core treats `https`, `https+local`, `h2c`, `h2c+local` and `quic+local` as encrypted DNS transports and rejects a standalone port for them; the port belongs in the URL. The two paths above never accounted for the address scheme.

Closes #5920

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactoring (no behavior change)
- [ ] Documentation
- [ ] Tests only
- [ ] Build / CI / tooling
- [ ] Other

## Areas affected

- [x] Frontend (UI / panel pages)
- [ ] Backend (API endpoints, login, settings)
- [x] Xray config generation
- [ ] Subscription (share links / Clash / JSON)
- [ ] Statistics / traffic counters
- [ ] Database / migrations
- [ ] Install / upgrade script
- [ ] Docker image
- [ ] Multi-node (sub-nodes)
- [ ] Telegram bot

## How was this tested?

A shared `isEncryptedDnsAddress` helper now backs both paths. The Zod schema defaults `port` to 53 only for non-encrypted addresses and omits it for the encrypted schemes; the modal's `valuesToWire` skips the port assignment for the same set. Schemes are matched case-insensitively to mirror Xray-core's `EqualFold` comparison.

Added unit tests in `frontend/src/test/dns.test.ts` covering: a plain address (`8.8.8.8`) and a `tcp://` address still default to `port: 53`; `https://`, `https+local://`, `h2c://`, `h2c+local://` and `quic+local://` addresses omit the port; an uppercase scheme is treated the same; and an explicit port on an encrypted address is preserved. The `dns.test.ts` golden snapshot was regenerated so the `quic+local://` fixture entry no longer shows `port: 53`.

Ran locally in `frontend/`: `npm run typecheck`, `npm run lint`, `npm run test` (849 tests pass), and `npm run build` all succeed.

## Screenshots / recordings

No visible UI layout change; the fix affects the DNS config the panel emits. Behavior is covered by the unit tests and snapshot above.

## Breaking changes

None. Non-encrypted DNS entries keep their existing `port: 53` default, and explicit ports are always preserved.

## AI assistance disclosure

AI was used for assistance.

- Type of assistance: drafting the code change and its unit tests, and reviewing the diff.
- Scope: limited to the DNS `port` handling fix in the two named frontend files plus its tests and snapshot.
- Tools: an AI coding assistant.
- Level of modification: the change was authored with AI assistance and validated locally (typecheck, lint, full test suite, and production build all pass).

## Checklist

- [x] I tested the change locally and confirmed the described behavior.
- [x] I added or updated tests for the new behavior (when applicable).
- [ ] `go build ./...` and the test suite pass locally. (Frontend-only change; no Go files touched.)
- [x] For frontend changes: `npm run lint`, `npm run typecheck`, and `npm run build` pass.
- [ ] I updated the Wiki / README / API docs if user-facing behavior changed.
- [x] My commits follow the project's existing message style.
- [x] I have no unrelated changes mixed into this PR.
