### PR TITLE
fix(clients): don't drop VLESS xtls-rprx-vision flow when inbound options reload

### DIFF
--- a/frontend/src/pages/clients/ClientFormModal.tsx
+++ b/frontend/src/pages/clients/ClientFormModal.tsx
@@ -364,10 +364,15 @@ export default function ClientFormModal({
   }
 
   useEffect(() => {
-    if (!showFlow && flow) {
+    // Only clear the flow once we actually have inbound options to judge
+    // capability from. While the options list is momentarily empty (e.g. the
+    // options query is (re)loading and `inbounds` falls back to `[]`), showFlow
+    // is a false negative, so clearing here would silently drop a valid
+    // xtls-rprx-vision flow the user picked for a Reality/TLS inbound.
+    if (inbounds.length > 0 && !showFlow && flow) {
       methods.setValue('flow', '');
     }
-  }, [showFlow, flow, methods]);
+  }, [inbounds, showFlow, flow, methods]);
 
   useEffect(() => {
     if (!showReverseTag && reverseTag) {

--- a/frontend/src/test/client-form-flow.test.tsx
+++ b/frontend/src/test/client-form-flow.test.tsx
@@ -1,0 +1,70 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, fireEvent, waitFor, screen } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+
+import { ThemeProvider } from '@/hooks/useTheme';
+import ClientFormModal from '@/pages/clients/ClientFormModal';
+import type { ClientRecord, InboundOption } from '@/hooks/useClients';
+
+function makeQC() {
+  return new QueryClient({ defaultOptions: { queries: { retry: false } } });
+}
+
+const REALITY_INBOUND = {
+  id: 4,
+  port: 10443,
+  protocol: 'vless',
+  tag: 'in-10443-tcp',
+  tlsFlowCapable: true,
+  enable: true,
+} as unknown as InboundOption;
+
+const CLIENT = {
+  email: 'testuser',
+  flow: 'xtls-rprx-vision',
+  uuid: '11111111-1111-1111-1111-111111111111',
+  subId: 'subid123',
+  enable: true,
+} as unknown as ClientRecord;
+
+function savedFlow(save: ReturnType<typeof vi.fn>): unknown {
+  return (save.mock.calls[0][0] as Record<string, unknown>).flow;
+}
+
+describe('ClientFormModal — Vision flow preservation', () => {
+  it('keeps xtls-rprx-vision with a stable Reality inbound', async () => {
+    const qc = makeQC();
+    const save = vi.fn().mockResolvedValue({ success: true });
+    render(
+      <ThemeProvider>
+        <QueryClientProvider client={qc}>
+          <ClientFormModal open mode="edit" client={CLIENT} inbounds={[REALITY_INBOUND]} attachedIds={[4]} save={save} onOpenChange={() => {}} />
+        </QueryClientProvider>
+      </ThemeProvider>,
+    );
+    fireEvent.click(await screen.findByRole('button', { name: /save/i }));
+    await waitFor(() => expect(save).toHaveBeenCalled());
+    expect(savedFlow(save)).toBe('xtls-rprx-vision');
+  });
+
+  it('does not drop a selected Vision flow while the inbound options momentarily reload', async () => {
+    const qc = makeQC();
+    const save = vi.fn().mockResolvedValue({ success: true });
+    const tree = (inbounds: InboundOption[]) => (
+      <ThemeProvider>
+        <QueryClientProvider client={qc}>
+          <ClientFormModal open mode="edit" client={CLIENT} inbounds={inbounds} attachedIds={[4]} save={save} onOpenChange={() => {}} />
+        </QueryClientProvider>
+      </ThemeProvider>
+    );
+    // Options loaded -> reloading (inboundOptionsQuery.data ?? [] === []) -> loaded again.
+    const { rerender } = render(tree([REALITY_INBOUND]));
+    await screen.findByRole('button', { name: /save/i });
+    rerender(tree([]));
+    rerender(tree([REALITY_INBOUND]));
+
+    fireEvent.click(await screen.findByRole('button', { name: /save/i }));
+    await waitFor(() => expect(save).toHaveBeenCalled());
+    expect(savedFlow(save)).toBe('xtls-rprx-vision');
+  });
+});


### PR DESCRIPTION
## Problem

Adding (or editing) a **VLESS** client on a **TCP + REALITY** inbound through the panel can silently save the client with an **empty `flow`**, even when `xtls-rprx-vision` was explicitly selected. The client is then unusable with XTLS Vision — the server-side user has no flow, so a link carrying `flow=xtls-rprx-vision` fails the handshake.

I confirmed on the wire (loopback, plain HTTP) that this is dropped entirely client-side: `GET /panel/api/inbounds/options` correctly returns `tlsFlowCapable: true` for the reality inbound, but the following `POST /panel/api/clients/add` request body already contains `"flow": ""`.

## Root cause

`ClientFormModal` clears the `flow` field here:

```ts
useEffect(() => {
  if (!showFlow && flow) methods.setValue('flow', '');
}, [showFlow, flow, methods]);
```

`showFlow` is derived from `flowCapableIds`, which is built from the `inbounds` prop:

```ts
const flowCapableIds = useMemo(() => {
  const ids = new Set<number>();
  for (const row of inbounds || []) if (row?.tlsFlowCapable) ids.add(row.id);
  return ids;
}, [inbounds]);
```

and `inbounds` comes from `useClients`:

```ts
const inbounds = inboundOptionsQuery.data ?? [];
```

While the inbound-options query is (re)loading, `data` is `undefined`, so `inbounds` falls back to `[]`. During that window `flowCapableIds` is empty and `showFlow` is a **false negative** — the effect fires and permanently clears the valid `xtls-rprx-vision` flow. It is never restored once the options return, and `onSubmit` then sends `flow: ''` (it also gates on `showFlow`).

## Fix

Only clear the flow once the inbound options are actually available to judge capability from:

```ts
if (inbounds.length > 0 && !showFlow && flow) {
  methods.setValue('flow', '');
}
```

## Tests

Adds `frontend/src/test/client-form-flow.test.tsx`:

- keeps `xtls-rprx-vision` with a stable reality inbound (baseline);
- **does not drop a selected Vision flow while the inbound options momentarily reload** — this case fails on `main` (`flow` comes back `""`) and passes with the fix.

Verified locally: `npm run test` (858/858), `tsc --noEmit`, and `eslint` on the changed files all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
