### PR TITLE
fix(clients): allow multiple clients to share a subId

### DIFF
--- a/internal/web/service/client_bulk.go
+++ b/internal/web/service/client_bulk.go
@@ -1148,9 +1148,7 @@ func (s *ClientService) BulkCreate(inboundSvc *InboundService, payloads []Client
 	}
 	prep := make([]prepared, 0, len(payloads))
 	emails := make([]string, 0, len(payloads))
-	subIDs := make([]string, 0, len(payloads))
 	seenEmail := make(map[string]struct{}, len(payloads))
-	seenSubID := make(map[string]string, len(payloads))
 
 	for i := range payloads {
 		client := payloads[i].Client
@@ -1190,16 +1188,10 @@ func (s *ClientService) BulkCreate(inboundSvc *InboundService, payloads []Client
 			skip(email, "email already in use: "+email)
 			continue
 		}
-		if owner, ok := seenSubID[client.SubID]; ok && owner != le {
-			skip(email, "subId already in use: "+client.SubID)
-			continue
-		}
 		seenEmail[le] = struct{}{}
-		seenSubID[client.SubID] = le
 
 		prep = append(prep, prepared{client: client, inboundIds: payloads[i].InboundIds})
 		emails = append(emails, email)
-		subIDs = append(subIDs, client.SubID)
 	}
 
 	if len(prep) == 0 {
@@ -1219,18 +1211,6 @@ func (s *ClientService) BulkCreate(inboundSvc *InboundService, payloads []Client
 			existingByEmail[strings.ToLower(rows[i].Email)] = rows[i]
 		}
 	}
-	existingSubOwner := make(map[string]string, len(subIDs))
-	for start := 0; start < len(subIDs); start += lookupChunk {
-		end := min(start+lookupChunk, len(subIDs))
-		var rows []model.ClientRecord
-		if e := db.Where("sub_id IN ?", subIDs[start:end]).Find(&rows).Error; e != nil {
-			return result, false, e
-		}
-		for i := range rows {
-			existingSubOwner[rows[i].SubID] = strings.ToLower(rows[i].Email)
-		}
-	}
-
 	inboundCache := make(map[int]*model.Inbound)
 	getIb := func(id int) (*model.Inbound, error) {
 		if ib, ok := inboundCache[id]; ok {
@@ -1271,12 +1251,6 @@ func (s *ClientService) BulkCreate(inboundSvc *InboundService, payloads []Client
 				prep[idx].client.Secret = rec.Secret
 			}
 		}
-		if owner, ok := existingSubOwner[prep[idx].client.SubID]; ok && owner != le {
-			failed[idx] = true
-			reason[idx] = "subId already in use: " + prep[idx].client.SubID
-			continue
-		}
-
 		ok := true
 		for _, ibId := range prep[idx].inboundIds {
 			ib, e := getIb(ibId)

--- a/internal/web/service/client_crud.go
+++ b/internal/web/service/client_crud.go
@@ -98,18 +98,6 @@ func (s *ClientService) Create(inboundSvc *InboundService, payload *ClientCreate
 		}
 	}
 
-	if client.SubID != "" {
-		var subTaken int64
-		if err := database.GetDB().Model(&model.ClientRecord{}).
-			Where("sub_id = ? AND email <> ?", client.SubID, client.Email).
-			Count(&subTaken).Error; err != nil {
-			return false, err
-		}
-		if subTaken > 0 {
-			return false, common.NewError("subId already in use:", client.SubID)
-		}
-	}
-
 	needRestart := false
 	for _, ibId := range payload.InboundIds {
 		inbound, getErr := inboundSvc.GetInbound(ibId)
@@ -372,18 +360,6 @@ func (s *ClientService) Update(inboundSvc *InboundService, id int, updated model
 		}
 		if collisionCount > 0 {
 			return false, common.NewError("Duplicate email:", updated.Email)
-		}
-	}
-
-	if updated.SubID != "" {
-		var subCollision int64
-		if err := database.GetDB().Model(&model.ClientRecord{}).
-			Where("sub_id = ? AND id <> ?", updated.SubID, id).
-			Count(&subCollision).Error; err != nil {
-			return false, err
-		}
-		if subCollision > 0 {
-			return false, common.NewError("Duplicate subId:", updated.SubID)
 		}
 	}
 

--- a/internal/web/service/client_portable.go
+++ b/internal/web/service/client_portable.go
@@ -130,18 +130,6 @@ func (s *ClientService) ImportClients(inboundSvc *InboundService, items []Client
 		if client.SubID == "" {
 			client.SubID = uuid.NewString()
 		}
-		if client.SubID != "" {
-			var subTaken int64
-			if err := db.Model(&model.ClientRecord{}).
-				Where("sub_id = ? AND email <> ?", client.SubID, email).
-				Count(&subTaken).Error; err != nil {
-				return result, needRestart, err
-			}
-			if subTaken > 0 {
-				skip(email, "subId already in use: "+client.SubID)
-				continue
-			}
-		}
 		if !client.Enable {
 			client.Enable = true
 		}

--- a/internal/web/service/client_update_rename_test.go
+++ b/internal/web/service/client_update_rename_test.go
@@ -46,7 +46,7 @@ func TestUpdateInboundClientRenameDoesNotDuplicateRecord(t *testing.T) {
 	}
 }
 
-func TestClientUpdateDuplicateSubIDDoesNotRenameEmail(t *testing.T) {
+func TestClientUpdateAllowsSharedSubID(t *testing.T) {
 	setupBulkDB(t)
 	svc := &ClientService{}
 	inboundSvc := &InboundService{}
@@ -60,21 +60,22 @@ func TestClientUpdateDuplicateSubIDDoesNotRenameEmail(t *testing.T) {
 		t.Fatalf("seed linkage: %v", err)
 	}
 	origId := lookupClientRecord(t, "keep@x").Id
-	origSettings := mustInboundSettings(t, inboundSvc, ib.Id)
 
 	updated := source[0]
-	updated.Email = "kept@x"
 	updated.SubID = "sub-other"
-	if _, err := svc.Update(inboundSvc, origId, updated); err == nil {
-		t.Fatalf("Update with colliding subId succeeded, want error")
+	if _, err := svc.Update(inboundSvc, origId, updated); err != nil {
+		t.Fatalf("Update with shared subId: %v", err)
 	}
 
 	rec := lookupClientRecord(t, "keep@x")
 	if rec.Id != origId {
-		t.Fatalf("record id changed after rejected update")
+		t.Fatalf("record id changed after update")
 	}
-	if got := mustInboundSettings(t, inboundSvc, ib.Id); got != origSettings {
-		t.Fatalf("inbound settings changed after rejected update")
+	if rec.SubID != "sub-other" {
+		t.Fatalf("subId after update = %q, want %q", rec.SubID, "sub-other")
+	}
+	if got := lookupClientRecord(t, "other@x").SubID; got != "sub-other" {
+		t.Fatalf("other client's subId = %q, want unchanged %q", got, "sub-other")
 	}
 }
 


### PR DESCRIPTION
## Problem

Editing a client fails with `Duplicate subId` when its subscription ID matches another client's. In a multi-node setup, clients reconciled from different nodes are separate records with distinct emails and cannot be merged into one client, so a shared subId is the only way to aggregate them under a single subscription link.

## Why the uniqueness check is wrong

Commit 88a36773 introduced per-client subId uniqueness on the grounds that the first-class client model aggregates via one client attached to many inbounds. That holds for top-down provisioning, but not for clients synced bottom-up from nodes. Meanwhile the subscription pipeline explicitly supports many records per subId: `getInboundsBySubId` joins across all clients with the subId, and `indexStatsBySubId` plucks every matching email (plural). The checks blocked a flow the sub server already serves.

## Changes

- Remove the subId collision checks in `ClientService.Create`, `Update`, `BulkCreate` and portable import (`internal/web/service/client_crud.go`, `client_bulk.go`, `client_portable.go`).
- Email uniqueness is untouched, including the re-add identity checks that compare an existing email's subId.
- Replace `TestClientUpdateDuplicateSubIDDoesNotRenameEmail` with `TestClientUpdateAllowsSharedSubID`, asserting an update to a shared subId succeeds and leaves the other client intact.

## Testing

- `go test -shuffle=on -count=1 ./internal/web/service/ ./internal/sub/` — all pass (547 + sub package).
- `gofmt` / `go vet` clean on changed files.