### PR TITLE
fix(sub) Happ profileEnableRouting button

### DIFF
--- a/internal/sub/controller.go
+++ b/internal/sub/controller.go
@@ -11,7 +11,6 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
-	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -675,7 +674,9 @@ func (a *SUBController) ApplyCommonHeaders(
 	}
 
 	// Advanced (Happ)
-	c.Writer.Header().Set("Routing-Enable", strconv.FormatBool(profileEnableRouting))
+	if profileEnableRouting {
+		c.Writer.Header().Set("Routing-Enable", "true")
+	}
 	if profileRoutingRules != "" {
 		c.Writer.Header().Set("Routing", profileRoutingRules)
 	}


### PR DESCRIPTION
**Summary**
Make Happ RouteEnable optional in subscription generation — omit Routing-Enable parameter when disabled instead of sending "false", preserving client's local routing preferences.

**Why**
Currently, subscription always sends Routing-Enable with explicit true or false, forcing clients to enable or disable routing. Users had no way to let clients keep their own routing configuration. This change makes the parameter optional: enabled sends true, disabled omits the parameter entirely so clients retain their existing routing state.

**Type of change**
Bug fix

**Areas affected**
Backend (subscription response header "Routing-Enable")

**How was this tested?**
1. Enabled RouteEnable in subscription settings → verified subscription response contains Routing-Enable: true

2. Disabled RouteEnable in subscription settings → verified subscription response does not contain Routing-Enable parameter

3. Client with routing enabled locally → after subscription update with RouteEnable disabled, routing remained enabled (no forced override)

4. Client with routing disabled locally → after subscription update with RouteEnable disabled, routing remained disabled (no forced override)

5. Backward compatibility verified — existing configs with RouteEnable enabled continue to work as before

**Checklist**
I tested the change locally and confirmed the described behavior.

go build ./... and the test suite pass locally.