### PR TITLE
fix (install.sh): use realpath instead of script name

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -6,8 +6,6 @@ blue='\033[0;34m'
 yellow='\033[0;33m'
 plain='\033[0m'
 
-cur_dir=$(pwd)
-
 xui_folder="${XUI_MAIN_FOLDER:=/usr/local/x-ui}"
 xui_service="${XUI_SERVICE:=/etc/systemd/system}"
 
@@ -36,7 +34,7 @@ arch() {
         armv6* | armv6) echo 'armv6' ;;
         armv5* | armv5) echo 'armv5' ;;
         s390x) echo 's390x' ;;
-        *) echo -e "${green}Unsupported CPU architecture! ${plain}" && rm -f install.sh && exit 1 ;;
+        *) echo -e "${green}Unsupported CPU architecture! ${plain}" && rm -f "$(realpath $0)" && exit 1 ;;
     esac
 }
 

--- a/install.sh
+++ b/install.sh
@@ -34,7 +34,7 @@ arch() {
         armv6* | armv6) echo 'armv6' ;;
         armv5* | armv5) echo 'armv5' ;;
         s390x) echo 's390x' ;;
-        *) echo -e "${green}Unsupported CPU architecture! ${plain}" && rm -f "$(realpath $0)" && exit 1 ;;
+        *) echo -e "${green}Unsupported CPU architecture! ${plain}" && rm -f "$(realpath "$0")" && exit 1 ;;
     esac
 }
 


### PR DESCRIPTION
## Summary
* arch(): changes hardcoded script relative path to basename
* removes unused cur_dir variable

## Why
During arch() sctipt tries to delete itself in case no compatible arch found. This may lead to unexpected file deletion if executed outside root dir; also cur_dir is declared but doesn't seem to be used anywhere

## Type of change
- [+] Bug fix

## Areas affected
- [+] Install / upgrade script

## How was this tested?
First, i commented out x64 (my current arch) line to emulate unsupported arch and invoked script from different dir containing other install.sh

```bash
~/misc_tests$ cd ~/misc_tests
~/misc_tests$ ls install.sh
install.sh

./3x-ui/install.sh
The OS release is: ubuntu
Arch: Unsupported CPU architecture!
~/misc_tests$ ls install.sh
ls: cannot access 'install.sh': No such file or directory
~/misc_tests$ ls ./3x-ui/install.sh
./3x-ui/install.sh
```
Instead of deleting initial install script, corresponding script from current dir was deleted

## Breaking changes
None

## Checklist

- [x] I tested the change locally and confirmed the described behavior.
- [ ] I added or updated tests for the new behavior (when applicable).
- [ ] `go build ./...` and the test suite pass locally.
- [ ] For frontend changes: `npm run lint`, `npm run typecheck`, and `npm run build` pass.
- [ ] I updated the Wiki / README / API docs if user-facing behavior changed.
- [x] My commits follow the project's existing message style.
- [x] I have no unrelated changes mixed into this PR.
