### PR TITLE
fix(sub): drop duplicated fingerprint in external-proxy tlsSettings

### DIFF
--- a/internal/sub/service.go
+++ b/internal/sub/service.go
@@ -1625,12 +1625,6 @@ func applyExternalProxyTLSToStream(ep map[string]any, stream map[string]any, sec
 	}
 	if fp, ok := ep["fingerprint"].(string); ok && fp != "" {
 		tlsSettings["fingerprint"] = fp
-		settings, _ := tlsSettings["settings"].(map[string]any)
-		if settings == nil {
-			settings = map[string]any{}
-			tlsSettings["settings"] = settings
-		}
-		settings["fingerprint"] = fp
 	}
 	if alpn, ok := externalProxyALPNList(ep["alpn"]); ok {
 		tlsSettings["alpn"] = alpn

--- a/internal/sub/service_test.go
+++ b/internal/sub/service_test.go
@@ -775,6 +775,26 @@ func TestApplyExternalProxyTLSToStream_DoesNotLeakAcrossProxies(t *testing.T) {
 	}
 }
 
+func TestApplyExternalProxyTLSToStream_FingerprintNotDuplicated(t *testing.T) {
+	stream := map[string]any{
+		"security":    "tls",
+		"tlsSettings": map[string]any{},
+	}
+	ep := map[string]any{"dest": "proxy.example.com", "fingerprint": "chrome"}
+
+	applyExternalProxyTLSToStream(ep, stream, "tls")
+
+	ts, _ := stream["tlsSettings"].(map[string]any)
+	if ts["fingerprint"] != "chrome" {
+		t.Fatalf("tlsSettings.fingerprint = %v, want %q", ts["fingerprint"], "chrome")
+	}
+	if settings, ok := ts["settings"].(map[string]any); ok {
+		if got, dup := settings["fingerprint"]; dup {
+			t.Fatalf("fingerprint must not be duplicated into tlsSettings.settings, got %v", got)
+		}
+	}
+}
+
 func TestApplyExternalProxyTLSParams_SetsPinnedPeerCert(t *testing.T) {
 	params := map[string]string{"security": "tls"}
 	ep := map[string]any{


### PR DESCRIPTION
Fixes #6095

`applyExternalProxyTLSToStream` (`internal/sub/service.go`) wrote the external proxy fingerprint to **both** `tlsSettings.fingerprint` and `tlsSettings.settings.fingerprint`. As a result the generated JSON subscription / outbound for an XHTTP Host group with a TLS fingerprint carried the same value twice:

```json
"tlsSettings": {
  "fingerprint": "chrome",
  "serverName": "domain.com",
  "settings": { "fingerprint": "chrome" }
}
```

Every other field in that function writes a single location (`serverName`/`alpn` at the top level; `pinnedPeerCertSha256`/`echConfigList`/`verifyPeerCertByName`/`allowInsecure` under `settings`), and `tlsData` already emits `fingerprint` at the top level. Fingerprint was the only field duplicated, so this keeps `tlsSettings.fingerprint` and drops the redundant `settings.fingerprint`.

Added `TestApplyExternalProxyTLSToStream_FingerprintNotDuplicated` next to the existing external-proxy TLS tests. It fails on `main` (fingerprint present under `settings`) and passes with the change; `go test -race ./internal/sub/` is green with no regressions, and `gofmt` / `go vet` are clean.
