### PR TITLE
fix: stop deleting client_traffics for detached-but-alive clients

### DIFF
--- a/frontend/src/hooks/useClients.ts
+++ b/frontend/src/hooks/useClients.ts
@@ -117,6 +117,24 @@ export function computeClientsSummary(
   return { total: stats.length, active, online, depleted, expiring, deactive };
 }
 
+// A client_stats snapshot shorter than the server's own total means it does
+// not cover every client — computeClientsSummary would then drop the missing
+// ones out of every bucket while total still counts them (#6102). The server
+// summary is always internally consistent (its buckets sum to total), so
+// fall back to it rather than publish an undercount.
+export function pickClientsSummary(
+  serverSummary: ClientsSummary,
+  allClientStats: ClientStatRow[],
+  onlineSet: Set<string>,
+  expireDiffMs: number,
+  trafficDiffBytes: number,
+): ClientsSummary {
+  if (allClientStats.length === 0) return serverSummary;
+  if (serverSummary.total > allClientStats.length) return serverSummary;
+  const live = computeClientsSummary(allClientStats, onlineSet, expireDiffMs, trafficDiffBytes);
+  return { ...live, total: serverSummary.total || live.total };
+}
+
 function buildQS(p: ClientQueryParams): string {
   const sp = new URLSearchParams();
   sp.set('page', String(p.page || 1));
@@ -266,17 +284,14 @@ export function useClients() {
   const pageSize = (defaults.pageSize as number) ?? 0;
 
   // Live summary: the client_stats WS event refreshes allClientStats every few
-  // seconds, so the top counters track reality without a page refresh. Falls
-  // back to the server-computed summary until the first event lands, and keeps
-  // the server's authoritative total for the headline count.
+  // seconds, so the top counters track reality without a page refresh — see
+  // pickClientsSummary for why it isn't always trusted over the server value.
   const [allClientStats, setAllClientStats] = useState<ClientStatRow[]>([]);
   const [clientSpeed, setClientSpeed] = useState<Record<string, ClientSpeedEntry>>({});
-  const summary = useMemo<ClientsSummary>(() => {
-    const serverSummary = listQuery.data?.summary ?? DEFAULT_SUMMARY;
-    if (allClientStats.length === 0) return serverSummary;
-    const live = computeClientsSummary(allClientStats, new Set(onlines), expireDiff, trafficDiff);
-    return { ...live, total: serverSummary.total || live.total };
-  }, [allClientStats, onlines, expireDiff, trafficDiff, listQuery.data?.summary]);
+  const summary = useMemo<ClientsSummary>(
+    () => pickClientsSummary(listQuery.data?.summary ?? DEFAULT_SUMMARY, allClientStats, new Set(onlines), expireDiff, trafficDiff),
+    [allClientStats, onlines, expireDiff, trafficDiff, listQuery.data?.summary],
+  );
 
   const invalidateAll = useCallback(
     () => {

--- a/frontend/src/hooks/useClients.ts
+++ b/frontend/src/hooks/useClients.ts
@@ -117,11 +117,6 @@ export function computeClientsSummary(
   return { total: stats.length, active, online, depleted, expiring, deactive };
 }
 
-// A client_stats snapshot shorter than the server's own total means it does
-// not cover every client — computeClientsSummary would then drop the missing
-// ones out of every bucket while total still counts them (#6102). The server
-// summary is always internally consistent (its buckets sum to total), so
-// fall back to it rather than publish an undercount.
 export function pickClientsSummary(
   serverSummary: ClientsSummary,
   allClientStats: ClientStatRow[],
@@ -283,9 +278,6 @@ export function useClients() {
   const trafficDiff = ((defaults.trafficDiff as number) ?? 0) * 1073741824;
   const pageSize = (defaults.pageSize as number) ?? 0;
 
-  // Live summary: the client_stats WS event refreshes allClientStats every few
-  // seconds, so the top counters track reality without a page refresh — see
-  // pickClientsSummary for why it isn't always trusted over the server value.
   const [allClientStats, setAllClientStats] = useState<ClientStatRow[]>([]);
   const [clientSpeed, setClientSpeed] = useState<Record<string, ClientSpeedEntry>>({});
   const summary = useMemo<ClientsSummary>(

--- a/frontend/src/pages/clients/ClientsPage.tsx
+++ b/frontend/src/pages/clients/ClientsPage.tsx
@@ -205,7 +205,7 @@ export default function ClientsPage() {
 
   const {
     clients, total, filtered,
-    summary: serverSummary,
+    summary,
     allGroups,
     setQuery,
     inbounds, onlines, loading, transitioning, fetched, fetchError, subSettings,
@@ -384,9 +384,6 @@ export default function ClientsPage() {
   // of the file (table dataSource, mobile cards, select-all) doesn't need
   // a rename.
   const filteredClients = clients;
-
-  // Server-computed counts that stay stable as the user paginates/filters.
-  const summary = serverSummary;
 
   // Sort is server-side now; the page already arrives in the requested
   // order, so we just hand it through.

--- a/frontend/src/test/clients-summary.test.ts
+++ b/frontend/src/test/clients-summary.test.ts
@@ -1,7 +1,8 @@
 import { describe, it, expect } from 'vitest';
 
-import { computeClientsSummary } from '@/hooks/useClients';
+import { computeClientsSummary, pickClientsSummary } from '@/hooks/useClients';
 import type { ClientTraffic } from '@/schemas/client';
+import type { ClientsSummary } from '@/schemas/client';
 
 // Parity with web/service/client.go buildClientsSummary: the same client must
 // land in the same bucket whether the count comes from the server (list fetch)
@@ -58,5 +59,32 @@ describe('computeClientsSummary', () => {
     expect(s.active).toBe(1);
     expect(s.expiring).toEqual([]);
     expect(s.depleted).toEqual([]);
+  });
+});
+
+describe('pickClientsSummary', () => {
+  const serverSummary: ClientsSummary = {
+    total: 67, active: 58, online: [], depleted: [], expiring: [], deactive: [],
+  };
+
+  it('keeps the server summary when the snapshot is short of the server total (#6102)', () => {
+    // Only 58 of 67 clients have a client_traffics row (e.g. a client
+    // detached from every inbound but not deleted) — computeClientsSummary
+    // would silently undercount every bucket if trusted here.
+    const shortSnapshot: Row[] = Array.from({ length: 58 }, (_, i) => row({ email: `c${i}@x`, enable: true }));
+    const s = pickClientsSummary(serverSummary, shortSnapshot, new Set(), 3 * DAY, 1 * GB);
+    expect(s).toEqual(serverSummary);
+  });
+
+  it('uses the live recompute when the snapshot covers every client', () => {
+    const fullSnapshot: Row[] = Array.from({ length: 67 }, (_, i) => row({ email: `c${i}@x`, enable: true }));
+    const s = pickClientsSummary(serverSummary, fullSnapshot, new Set(), 3 * DAY, 1 * GB);
+    expect(s.total).toBe(67);
+    expect(s.active).toBe(67);
+  });
+
+  it('falls back to the server summary before the first WS snapshot arrives', () => {
+    const s = pickClientsSummary(serverSummary, [], new Set(), 3 * DAY, 1 * GB);
+    expect(s).toEqual(serverSummary);
   });
 });

--- a/frontend/src/test/clients-summary.test.ts
+++ b/frontend/src/test/clients-summary.test.ts
@@ -1,8 +1,7 @@
 import { describe, it, expect } from 'vitest';
 
 import { computeClientsSummary, pickClientsSummary } from '@/hooks/useClients';
-import type { ClientTraffic } from '@/schemas/client';
-import type { ClientsSummary } from '@/schemas/client';
+import type { ClientTraffic, ClientsSummary } from '@/schemas/client';
 
 // Parity with web/service/client.go buildClientsSummary: the same client must
 // land in the same bucket whether the count comes from the server (list fetch)
@@ -68,9 +67,6 @@ describe('pickClientsSummary', () => {
   };
 
   it('keeps the server summary when the snapshot is short of the server total (#6102)', () => {
-    // Only 58 of 67 clients have a client_traffics row (e.g. a client
-    // detached from every inbound but not deleted) — computeClientsSummary
-    // would silently undercount every bucket if trusted here.
     const shortSnapshot: Row[] = Array.from({ length: 58 }, (_, i) => row({ email: `c${i}@x`, enable: true }));
     const s = pickClientsSummary(serverSummary, shortSnapshot, new Set(), 3 * DAY, 1 * GB);
     expect(s).toEqual(serverSummary);

--- a/internal/web/service/inbound_migration.go
+++ b/internal/web/service/inbound_migration.go
@@ -16,14 +16,14 @@ import (
 	"gorm.io/gorm"
 )
 
+// MigrationRemoveOrphanedTraffics drops client_traffics rows with no owning
+// clients row. It used to key "orphaned" off presence in some inbound's
+// settings.clients[] JSON, which also matched a client detached from every
+// inbound — an intentional, still-alive state (ClientService.Detach) — and
+// deleted its traffic row on every x-ui migrate / backup restore.
 func (s *InboundService) MigrationRemoveOrphanedTraffics() {
 	db := database.GetDB()
-	query := fmt.Sprintf(
-		"DELETE FROM client_traffics WHERE email NOT IN (SELECT %s %s)",
-		database.JSONFieldText("client.value", "email"),
-		database.JSONClientsFromInbound(),
-	)
-	db.Exec(query)
+	db.Exec("DELETE FROM client_traffics WHERE email NOT IN (SELECT email FROM clients)")
 }
 
 func (s *InboundService) MigrationRequirements() {

--- a/internal/web/service/inbound_migration.go
+++ b/internal/web/service/inbound_migration.go
@@ -16,14 +16,21 @@ import (
 	"gorm.io/gorm"
 )
 
-// MigrationRemoveOrphanedTraffics drops client_traffics rows with no owning
-// clients row. It used to key "orphaned" off presence in some inbound's
-// settings.clients[] JSON, which also matched a client detached from every
-// inbound — an intentional, still-alive state (ClientService.Detach) — and
-// deleted its traffic row on every x-ui migrate / backup restore.
 func (s *InboundService) MigrationRemoveOrphanedTraffics() {
 	db := database.GetDB()
-	db.Exec("DELETE FROM client_traffics WHERE email NOT IN (SELECT email FROM clients)")
+	query := fmt.Sprintf(
+		"DELETE FROM client_traffics WHERE email NOT IN (SELECT email FROM clients) AND email NOT IN (SELECT %s %s)",
+		database.JSONFieldText("client.value", "email"),
+		database.JSONClientsFromInbound(),
+	)
+	result := db.Exec(query)
+	if result.Error != nil {
+		logger.Warning("MigrationRemoveOrphanedTraffics failed:", result.Error)
+		return
+	}
+	if result.RowsAffected > 0 {
+		logger.Infof("MigrationRemoveOrphanedTraffics: removed %d orphaned client_traffics row(s)", result.RowsAffected)
+	}
 }
 
 func (s *InboundService) MigrationRequirements() {

--- a/internal/web/service/inbound_migration_test.go
+++ b/internal/web/service/inbound_migration_test.go
@@ -129,69 +129,62 @@ func TestMigrationRequirements_CleansLegacyZeroAddrTag(t *testing.T) {
 	}
 }
 
-func TestMigrationRemoveOrphanedTraffics_KeepsDetachedClientAliveClient(t *testing.T) {
+func TestMigrationRemoveOrphanedTraffics(t *testing.T) {
 	setupConflictDB(t)
 	db := database.GetDB()
+	clientSvc := &ClientService{}
+	inboundSvc := &InboundService{}
 
 	const attachedEmail = "attached@example.com"
+	attachedClient := model.Client{Email: attachedEmail, ID: "11111111-1111-1111-1111-111111111111", SubID: attachedEmail, Enable: true}
+	attachedIb := mkInbound(t, 30003, model.VLESS, clientsSettings(t, []model.Client{attachedClient}))
+	if err := clientSvc.SyncInbound(nil, attachedIb.Id, []model.Client{attachedClient}); err != nil {
+		t.Fatalf("seed attached client: %v", err)
+	}
+	mkTraffic(t, attachedIb.Id, attachedEmail, 0, 0, 0, 0, true)
+
 	const detachedEmail = "detached@example.com"
+	detachedClient := model.Client{Email: detachedEmail, ID: "22222222-2222-2222-2222-222222222222", SubID: detachedEmail, Enable: true}
+	detachedIb := mkInbound(t, 30004, model.VLESS, clientsSettings(t, []model.Client{detachedClient}))
+	if err := clientSvc.SyncInbound(nil, detachedIb.Id, []model.Client{detachedClient}); err != nil {
+		t.Fatalf("seed detached client: %v", err)
+	}
+	mkTraffic(t, detachedIb.Id, detachedEmail, 123, 456, 0, 0, true)
+	detachedRec := lookupClientRecord(t, detachedEmail)
+	if _, err := clientSvc.Detach(inboundSvc, detachedRec.Id, []int{detachedIb.Id}); err != nil {
+		t.Fatalf("Detach: %v", err)
+	}
+
+	const jsonOnlyEmail = "jsononly@example.com"
+	jsonOnlyClient := model.Client{Email: jsonOnlyEmail, ID: "33333333-3333-3333-3333-333333333333", SubID: jsonOnlyEmail, Enable: true}
+	jsonOnlyIb := mkInbound(t, 30005, model.VLESS, clientsSettings(t, []model.Client{jsonOnlyClient}))
+	mkTraffic(t, jsonOnlyIb.Id, jsonOnlyEmail, 0, 0, 0, 0, true)
+
 	const trulyOrphanedEmail = "deleted@example.com"
+	mkTraffic(t, attachedIb.Id, trulyOrphanedEmail, 0, 0, 0, 0, true)
 
-	ib := &model.Inbound{
-		UserId:         1,
-		Tag:            "orphan-traffic-tag",
-		Enable:         true,
-		Port:           30003,
-		Protocol:       model.VLESS,
-		Settings:       `{"clients":[{"email":"` + attachedEmail + `","id":"11111111-1111-1111-1111-111111111111","enable":true}]}`,
-		StreamSettings: `{"network":"tcp","security":"none"}`,
-	}
-	if err := db.Create(ib).Error; err != nil {
-		t.Fatalf("create inbound: %v", err)
-	}
-	attachedRec := &model.ClientRecord{Email: attachedEmail, SubID: "sub-attached", Enable: true}
-	if err := db.Create(attachedRec).Error; err != nil {
-		t.Fatalf("seed attached client record: %v", err)
-	}
-	if err := db.Create(&model.ClientInbound{ClientId: attachedRec.Id, InboundId: ib.Id}).Error; err != nil {
-		t.Fatalf("seed attached client_inbounds link: %v", err)
-	}
-	if err := db.Create(&xray.ClientTraffic{Email: attachedEmail, InboundId: ib.Id, Enable: true}).Error; err != nil {
-		t.Fatalf("seed attached client_traffics: %v", err)
-	}
+	inboundSvc.MigrationRemoveOrphanedTraffics()
 
-	if err := db.Create(&model.ClientRecord{Email: detachedEmail, SubID: "sub-detached", Enable: true}).Error; err != nil {
-		t.Fatalf("seed detached client record: %v", err)
+	cases := []struct {
+		name  string
+		email string
+		want  int64
+	}{
+		{"attached, in clients table and JSON", attachedEmail, 1},
+		{"detached-but-alive, in clients table only", detachedEmail, 1},
+		{"seeder-skipped-but-live, in JSON only", jsonOnlyEmail, 1},
+		{"truly orphaned, in neither", trulyOrphanedEmail, 0},
 	}
-	// DelInboundClientByEmail(keepTraffic=true) never resets InboundId, so a
-	// detached-but-alive client's row still points at its last inbound.
-	if err := db.Create(&xray.ClientTraffic{Email: detachedEmail, InboundId: ib.Id, Enable: true, Up: 123, Down: 456}).Error; err != nil {
-		t.Fatalf("seed detached client_traffics: %v", err)
-	}
-
-	if err := db.Create(&xray.ClientTraffic{Email: trulyOrphanedEmail, InboundId: ib.Id, Enable: true}).Error; err != nil {
-		t.Fatalf("seed truly orphaned client_traffics: %v", err)
-	}
-
-	svc := InboundService{}
-	svc.MigrationRemoveOrphanedTraffics()
-
-	var attachedCount int64
-	db.Model(xray.ClientTraffic{}).Where("email = ?", attachedEmail).Count(&attachedCount)
-	if attachedCount != 1 {
-		t.Errorf("attached client's traffic row: got count %d, want 1", attachedCount)
-	}
-
-	var detachedCount int64
-	db.Model(xray.ClientTraffic{}).Where("email = ?", detachedEmail).Count(&detachedCount)
-	if detachedCount != 1 {
-		t.Errorf("detached-but-alive client's traffic row: got count %d, want 1 (must survive migration)", detachedCount)
-	}
-
-	var orphanedCount int64
-	db.Model(xray.ClientTraffic{}).Where("email = ?", trulyOrphanedEmail).Count(&orphanedCount)
-	if orphanedCount != 0 {
-		t.Errorf("truly orphaned traffic row: got count %d, want 0 (must be removed)", orphanedCount)
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			var got int64
+			if err := db.Model(xray.ClientTraffic{}).Where("email = ?", c.email).Count(&got).Error; err != nil {
+				t.Fatalf("count client_traffics for %s: %v", c.email, err)
+			}
+			if got != c.want {
+				t.Errorf("client_traffics count for %s: got %d, want %d", c.email, got, c.want)
+			}
+		})
 	}
 }
 

--- a/internal/web/service/inbound_migration_test.go
+++ b/internal/web/service/inbound_migration_test.go
@@ -129,6 +129,72 @@ func TestMigrationRequirements_CleansLegacyZeroAddrTag(t *testing.T) {
 	}
 }
 
+func TestMigrationRemoveOrphanedTraffics_KeepsDetachedClientAliveClient(t *testing.T) {
+	setupConflictDB(t)
+	db := database.GetDB()
+
+	const attachedEmail = "attached@example.com"
+	const detachedEmail = "detached@example.com"
+	const trulyOrphanedEmail = "deleted@example.com"
+
+	ib := &model.Inbound{
+		UserId:         1,
+		Tag:            "orphan-traffic-tag",
+		Enable:         true,
+		Port:           30003,
+		Protocol:       model.VLESS,
+		Settings:       `{"clients":[{"email":"` + attachedEmail + `","id":"11111111-1111-1111-1111-111111111111","enable":true}]}`,
+		StreamSettings: `{"network":"tcp","security":"none"}`,
+	}
+	if err := db.Create(ib).Error; err != nil {
+		t.Fatalf("create inbound: %v", err)
+	}
+	attachedRec := &model.ClientRecord{Email: attachedEmail, SubID: "sub-attached", Enable: true}
+	if err := db.Create(attachedRec).Error; err != nil {
+		t.Fatalf("seed attached client record: %v", err)
+	}
+	if err := db.Create(&model.ClientInbound{ClientId: attachedRec.Id, InboundId: ib.Id}).Error; err != nil {
+		t.Fatalf("seed attached client_inbounds link: %v", err)
+	}
+	if err := db.Create(&xray.ClientTraffic{Email: attachedEmail, InboundId: ib.Id, Enable: true}).Error; err != nil {
+		t.Fatalf("seed attached client_traffics: %v", err)
+	}
+
+	if err := db.Create(&model.ClientRecord{Email: detachedEmail, SubID: "sub-detached", Enable: true}).Error; err != nil {
+		t.Fatalf("seed detached client record: %v", err)
+	}
+	// DelInboundClientByEmail(keepTraffic=true) never resets InboundId, so a
+	// detached-but-alive client's row still points at its last inbound.
+	if err := db.Create(&xray.ClientTraffic{Email: detachedEmail, InboundId: ib.Id, Enable: true, Up: 123, Down: 456}).Error; err != nil {
+		t.Fatalf("seed detached client_traffics: %v", err)
+	}
+
+	if err := db.Create(&xray.ClientTraffic{Email: trulyOrphanedEmail, InboundId: ib.Id, Enable: true}).Error; err != nil {
+		t.Fatalf("seed truly orphaned client_traffics: %v", err)
+	}
+
+	svc := InboundService{}
+	svc.MigrationRemoveOrphanedTraffics()
+
+	var attachedCount int64
+	db.Model(xray.ClientTraffic{}).Where("email = ?", attachedEmail).Count(&attachedCount)
+	if attachedCount != 1 {
+		t.Errorf("attached client's traffic row: got count %d, want 1", attachedCount)
+	}
+
+	var detachedCount int64
+	db.Model(xray.ClientTraffic{}).Where("email = ?", detachedEmail).Count(&detachedCount)
+	if detachedCount != 1 {
+		t.Errorf("detached-but-alive client's traffic row: got count %d, want 1 (must survive migration)", detachedCount)
+	}
+
+	var orphanedCount int64
+	db.Model(xray.ClientTraffic{}).Where("email = ?", trulyOrphanedEmail).Count(&orphanedCount)
+	if orphanedCount != 0 {
+		t.Errorf("truly orphaned traffic row: got count %d, want 0 (must be removed)", orphanedCount)
+	}
+}
+
 func TestMigrationRequirements_NormalizesShareAddressFields(t *testing.T) {
 	setupConflictDB(t)
 	db := database.GetDB()


### PR DESCRIPTION
## Summary

Fixes two related bugs behind the reported "Ended/Disabled clients hidden" symptom: a migration that deletes `client_traffics` rows for clients live in only one of the two places that can now hold "this client still exists" (the `clients` table or an inbound's JSON), and a frontend live-recompute that silently drops any client missing a traffic row out of every summary bucket.

## Why

Closes #6102.

The reporter's screenshot shows `Clients 67` but `Ended 0 + Depleting 0 + Disabled 0 + Active 58 = 58` — the buckets don't sum to the total, and the hover popovers that normally list matching emails are empty, leaving the Filter drawer as the only way to reach those clients.

Root cause has two independent parts:

1. **`MigrationRemoveOrphanedTraffics` (`internal/web/service/inbound_migration.go`)** originally keyed "orphaned" off a client's absence from every inbound's `settings.clients[]` JSON — a definition that predates #4469's standalone `clients` table. `ClientService.Detach` intentionally keeps a client's `client_traffics` row when it drops its last inbound attachment (so the client can be re-attached later without losing stats/expiry), but such a client has no entry in any inbound's JSON anymore. Every `x-ui migrate` run or backup restore (`MigrateDB`) therefore deleted its traffic row anyway, even though the client itself was untouched and still listed — reproducing the exact "row exists, `—` under Attached inbounds, invisible to the summary" state from the screenshot. My first pass at this PR simply switched the predicate to key off the `clients` table instead — an automated review on this PR (see the thread below) caught that this trades one gap for a worse one: the one-shot `ClientsTable` seeder (`internal/database/db.go`) skips a client it fails to unmarshal and never retries, so a client that's still live in an inbound's JSON can have no `clients` row at all, and an empty `clients` table (edge case, but reachable) would delete every `client_traffics` row outright. Fixed by unioning both keep-sets — a row survives if it's referenced by either the `clients` table or any inbound's JSON, and is only removed when it's in neither.
2. **`frontend/src/hooks/useClients.ts`** recomputed the clients summary from the `client_stats` WebSocket snapshot as soon as it arrived, without checking whether that snapshot actually covered every client. `allClientStats` is `client_traffics` rows (email-keyed), so any client missing a row for the reason above (or any other reason) silently fell out of every bucket in the recompute while the headline `total` — kept from the server — still counted it. The added guard falls back to the server summary whenever the snapshot is shorter than the server's total; note this is a count comparison, not an exact coverage check (a genuinely orphaned `client_traffics` row — the case #1 prunes, only on migrate/restore — could in theory offset a missing one and let a short snapshot slip past the guard), and it's a deliberately visible trade: when it does trip, the summary cards stop updating live and only refresh on the next list poll, rather than risk showing an undercount.

I went through the whole master/node sync path (`setRemoteTrafficLocked`) separately, since the reporter also described a master+node deployment where clients "completely disappear" after depleting/being disabled there. I could not reproduce that through that path — `disableInvalidClients` only flips `enable=false` both in the DB row and inside the settings JSON, the client stays in the array, and every deletion branch in the node sync is already guarded against exactly this kind of false-positive sweep. Left a comment on the issue asking the reporter to confirm whether `x-ui migrate` or a backup restore happened around when they started seeing it, since that would point at the same bug from a different, more surprising trigger.

## Type of change

- [x] Bug fix

## Areas affected

- [x] Frontend (UI / panel pages)
- [x] Backend (API endpoints, login, settings)
- [x] Statistics / traffic counters
- [x] Database / migrations
- [x] Multi-node (sub-nodes) — investigated, not changed (see above)

## How was this tested?

- `TestMigrationRemoveOrphanedTraffics` (`internal/web/service/inbound_migration_test.go`) covers all four combinations via real code paths, not hand-built rows where a real path exists: a client attached normally (`ClientService.SyncInbound`), a client detached from every inbound but kept alive (driven through the actual `ClientService.Detach(keepTraffic=true)` call), a client present in an inbound's JSON with no `clients` row (the seeder-gap case, built by hand since no production path currently produces it on purpose), and a truly orphaned row in neither. Confirmed each case fails against the wrong predicate (the original bug, and separately the regression from unioning-instead-of-replacing) and passes with the fix.
- Three new cases in `frontend/src/test/clients-summary.test.ts` for the extracted `pickClientsSummary`: falls back to the server summary when the snapshot is shorter than the server's total, uses the live recompute when the snapshot covers every client, and falls back before the first WS snapshot arrives.
- `go build ./...`, `go vet ./...`, `gofmt -l` / `goimports -l` on the changed files — clean. (`golangci-lint` itself couldn't run in my sandbox — the resolvable release is built against Go 1.25 and refuses to lint a go.mod targeting 1.26.5 — but gofmt/goimports cover the formatting side of it.)
- `go test ./...` and `go test -race ./internal/web/service/...` — all green.
- Frontend: `npm run typecheck`, `npm run lint`, full `npm run test` (890 tests), `npm run build`, `npm run build-storybook` — all green.

## Screenshots / recordings

N/A — this is a data-correctness fix, not a visual change. The summary cards' appearance is unchanged; they just stop undercounting (and, in the rare short-snapshot case described above, stop live-updating until the next poll instead).

## Breaking changes

None. `MigrationRemoveOrphanedTraffics` still runs automatically on `x-ui migrate` / backup restore; it just no longer deletes rows it shouldn't.

## Checklist

- [x] I tested the change locally and confirmed the described behavior.
- [x] I added or updated tests for the new behavior.
- [x] `go build ./...` and the test suite pass locally.
- [x] For frontend changes: `npm run lint`, `npm run typecheck`, and `npm run build` pass.
- [ ] I updated the Wiki / README / API docs if user-facing behavior changed. — N/A, no user-facing behavior/docs to update.
- [x] My commits follow the project's existing message style.
- [x] I have no unrelated changes mixed into this PR.
