### PR TITLE
fix: preserve VLESS+WS inbound clients when clients table is empty

### DIFF
--- a/internal/web/service/xray.go
+++ b/internal/web/service/xray.go
@@ -221,10 +221,15 @@ func (s *XrayService) GetXrayConfig() (*xray.Config, error) {
 			settings["peers"] = wgPeers
 			mutated = true
 		} else {
-			_, hadClients := settings["clients"]
-			mutated = hadClients || len(finalClients) > 0
+			existingClients, hadClients := settings["clients"]
+			hasFinalClients := len(finalClients) > 0
+			mutated = hadClients || hasFinalClients
 			if mutated {
-				settings["clients"] = finalClients
+				if hasFinalClients {
+					settings["clients"] = finalClients
+				} else if existingClients != nil {
+					settings["clients"] = existingClients
+				}
 			}
 		}
 


### PR DESCRIPTION
## Problem

When clients are defined in the inbound `settings` JSON (e.g., VLESS+WebSocket inbounds created via database/API) but not in the separate `clients` table, `GetXrayConfig()` overwrites the existing clients with `nil`, resulting in `config.json` showing `"clients": null`.

This causes VLESS+WS inbounds to reject all connections because Xray has no valid client IDs.

## Root Cause

In `internal/web/service/xray.go:224-228`:

```go
_, hadClients := settings["clients"]
mutated = hadClients || len(finalClients) > 0
if mutated {
    settings["clients"] = finalClients  // ← overwrites with nil when finalClients is empty
}
```

`finalClients` is declared as `var finalClients []any` (nil). When the `clients` table has no entries but settings already contains clients, `finalClients` (nil) overwrites the valid clients array.

## Fix

Preserve existing clients from settings when `finalClients` is empty:

```go
existingClients, hadClients := settings["clients"]
hasFinalClients := len(finalClients) > 0
mutated = hadClients || hasFinalClients
if mutated {
    if hasFinalClients {
        settings["clients"] = finalClients
    } else if existingClients != nil {
        settings["clients"] = existingClients
    }
}
```

Closes #6117