### PR TITLE
fix(settings): keep the stored port when a port field is cleared

### DIFF
--- a/frontend/src/pages/settings/GeneralTab.tsx
+++ b/frontend/src/pages/settings/GeneralTab.tsx
@@ -170,7 +170,7 @@ export default function GeneralTab({ allSetting, updateSetting }: GeneralTabProp
 
             <SettingListItem paddings="small" title={t('pages.settings.panelPort')} description={t('pages.settings.panelPortDesc')}>
               <InputNumber value={allSetting.webPort} min={1} max={65535} style={{ width: '100%' }}
-                onChange={(v) => updateSetting({ webPort: Number(v) || 0 })} />
+                onChange={(v) => { if (v != null) updateSetting({ webPort: v }); }} />
             </SettingListItem>
 
             <SettingListItem paddings="small" title={t('pages.settings.panelUrlPath')} description={t('pages.settings.panelUrlPathDesc')}>
@@ -308,7 +308,7 @@ export default function GeneralTab({ allSetting, updateSetting }: GeneralTabProp
             </SettingListItem>
             <SettingListItem paddings="small" title={t('pages.settings.ldap.port')}>
               <InputNumber value={allSetting.ldapPort} min={1} max={65535} style={{ width: '100%' }}
-                onChange={(v) => updateSetting({ ldapPort: Number(v) || 0 })} />
+                onChange={(v) => { if (v != null) updateSetting({ ldapPort: v }); }} />
             </SettingListItem>
             <SettingListItem paddings="small" title={t('pages.settings.ldap.useTls')}>
               <Switch checked={allSetting.ldapUseTLS} onChange={(v) => updateSetting({ ldapUseTLS: v })} />

--- a/frontend/src/pages/settings/SubscriptionGeneralTab.tsx
+++ b/frontend/src/pages/settings/SubscriptionGeneralTab.tsx
@@ -57,7 +57,7 @@ export default function SubscriptionGeneralTab({ allSetting, updateSetting }: Su
             </SettingListItem>
             <SettingListItem paddings="small" title={t('pages.settings.subPort')} description={t('pages.settings.subPortDesc')}>
               <InputNumber value={allSetting.subPort} min={1} max={65535} style={{ width: '100%' }}
-                onChange={(v) => updateSetting({ subPort: Number(v) || 0 })} />
+                onChange={(v) => { if (v != null) updateSetting({ subPort: v }); }} />
             </SettingListItem>
             <SettingListItem paddings="small" title={t('pages.settings.subPath')} description={t('pages.settings.subPathDesc')}>
               <Input

--- a/frontend/src/test/subscription-general-tab.test.tsx
+++ b/frontend/src/test/subscription-general-tab.test.tsx
@@ -12,6 +12,36 @@ function LocationProbe() {
 }
 
 describe('SubscriptionGeneralTab', () => {
+  it('keeps the stored subscription port when the field is cleared', () => {
+    const updateSetting = vi.fn();
+
+    renderWithProviders(
+      <MemoryRouter initialEntries={['/settings#subscription']}>
+        <SubscriptionGeneralTab allSetting={new AllSetting({ subPort: 2096 })} updateSetting={updateSetting} />
+      </MemoryRouter>,
+    );
+
+    const portInput = screen.getByDisplayValue('2096');
+    fireEvent.change(portInput, { target: { value: '' } });
+    fireEvent.blur(portInput);
+
+    expect(updateSetting).not.toHaveBeenCalled();
+  });
+
+  it('forwards typed subscription ports unchanged', () => {
+    const updateSetting = vi.fn();
+
+    renderWithProviders(
+      <MemoryRouter initialEntries={['/settings#subscription']}>
+        <SubscriptionGeneralTab allSetting={new AllSetting({ subPort: 2096 })} updateSetting={updateSetting} />
+      </MemoryRouter>,
+    );
+
+    fireEvent.change(screen.getByDisplayValue('2096'), { target: { value: '8443' } });
+
+    expect(updateSetting).toHaveBeenCalledWith({ subPort: 8443 });
+  });
+
   it('uses router navigation to open subscription format settings', () => {
     const allSetting = new AllSetting({ subClashEnable: true });
 


### PR DESCRIPTION
## Summary

Clearing a port field in panel settings (**panel port**, **subscription listen port**, **LDAP port**) no longer silently saves port `1`; the field snaps back to the last valid value instead.

## Why

Each of these `InputNumber`s fires `onChange(null)` when cleared. The handlers coerced that to `0`, then Ant Design clamped the empty field to `min=1` on blur, and the next save persisted port `1` — with no error at any point (the backend validators `gte=1,lte=65535` accept it). Consequences, reproduced end-to-end on `main` (values verified in the SQLite `settings` table):

- `subPort=1`: subscription links are generated with `:1` and the sub server cannot bind the port.
- `webPort=1`: the panel itself moves to port 1 on restart, locking the admin out until the port is repaired via the `x-ui` CLI.
- `ldapPort=1`: LDAP sync silently points at a dead port.

The other numeric settings are not affected: `smtpPort` already falls back to 587 on clear, and fields whose min value is a legitimate setting (e.g. session max age) merely clamp.

## Type of change

- [x] Bug fix

## Areas affected

- [x] Frontend (UI / panel pages)

## How was this tested?

Regression tests added to the existing `frontend/src/test/subscription-general-tab.test.tsx`:

- clearing the port field (change + blur) never reaches `updateSetting`;
- a typed port still passes through unchanged as `{ subPort: 8443 }`.

Manual verification on a local dev panel (Chromium):

1. Settings → Subscription → Listen Port shows `2096`; select-all + delete + blur: **before** the field showed `1` and Save stored `subPort=1`; **after** it restores `2096`.
2. Settings → General → Panel Port shows `2053`; same clear + blur: restores `2053` instead of `1`.
3. Normal edits (typing a port, stepping) still update and save as before.
4. `npm run lint`, `npm run typecheck`, `npm run build` pass; full frontend vitest suite passes.

## Screenshots / recordings

N/A — no visual change; behavior fix only (repro steps above).

## Breaking changes

None.

## Checklist

- [x] I tested the change locally and confirmed the described behavior.
- [x] I added or updated tests for the new behavior (when applicable).
- [x] `go build ./...` and the test suite pass locally.
- [x] For frontend changes: `npm run lint`, `npm run typecheck`, and `npm run build` pass.
- [ ] I updated the Wiki / README / API docs if user-facing behavior changed.
- [x] My commits follow the project's existing message style.
- [x] I have no unrelated changes mixed into this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
