### PR TITLE
ci: attach provenance and SBOM attestations to the published images

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -55,6 +55,8 @@ jobs:
         with:
           context: .
           push: true
+          provenance: mode=max
+          sbom: true
           platforms: linux/amd64,linux/arm64/v8,linux/arm/v7,linux/arm/v6,linux/386
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
Hi, and thanks for 3x-ui.

`.github/workflows/docker.yml` publishes to both `hsanaeii/3x-ui` on Docker Hub and `ghcr.io/mhsanaei/3x-ui` on every tag, but the pushed manifests carry no provenance or SBOM attestation. Someone pulling the image cannot check that it was built by this workflow, from this repository, at that tag.

That felt worth raising for 3x-ui in particular. It is a panel people deploy on a VPS, usually straight from the image with a one-line install, and it holds the credentials for everything it fronts. Where the image came from is exactly the thing a deployer would want to be able to confirm.

The change is two lines on the single build step:

```yaml
        with:
          ...
          push: true
          provenance: mode=max
          sbom: true
```

I used BuildKit's own attestation support rather than a separate signing action for a specific reason: your step pushes one build to two registries at once, and BuildKit attaches the attestation to the image manifest itself, so Docker Hub and GHCR both get it with no extra plumbing and no second credential. It also means **no permissions change** — `contents: read` and `packages: write` stay exactly as they are, and nothing needs `id-token`.

After a release, anyone can check with:

```
docker buildx imagetools inspect ghcr.io/mhsanaei/3x-ui:<tag> --format '{{ json .Provenance }}'
```

Two things worth knowing before merging:

- `mode=max` records the full build including build arguments. That is normally right for a public image; `provenance: true` produces a smaller record if you would rather.
- Attestations add an extra manifest to the index. Docker Hub and GHCR both handle it, but it is worth knowing if a mirror ever sits in front.

I have not claimed any SLSA level — the attestation is what BuildKit produces, and how the whole build should be characterised is your call.

Disclosure: I used AI assistance to help spot this and prepare the change, and I read the workflow and both push targets myself.
