### PR TITLE
chore(build): stop shipping production sourcemaps inside the binary

### DIFF
--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -174,9 +174,10 @@ export default defineConfig({
     // Everything in outDir is embedded into the Go binary via embed.FS, so
     // production sourcemaps (~18MB across 112 files, 72% of dist) ship inside
     // every release build. Nothing consumes them there; `npm run dev` serves
-    // its own maps regardless of this setting. Flip locally to debug a
-    // production bundle.
-    sourcemap: false,
+    // its own maps regardless of this setting. To debug a minified bundle
+    // (including the XUI_DEBUG serve-from-disk path), build once with
+    // XUI_SOURCEMAP=true — no tracked-file edit to accidentally commit.
+    sourcemap: process.env.XUI_SOURCEMAP === 'true',
     target: 'es2020',
     chunkSizeWarningLimit: 1500,
     rollupOptions: {

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -171,7 +171,12 @@ export default defineConfig({
   build: {
     outDir,
     emptyOutDir: true,
-    sourcemap: true,
+    // Everything in outDir is embedded into the Go binary via embed.FS, so
+    // production sourcemaps (~18MB across 112 files, 72% of dist) ship inside
+    // every release build. Nothing consumes them there; `npm run dev` serves
+    // its own maps regardless of this setting. Flip locally to debug a
+    // production bundle.
+    sourcemap: false,
     target: 'es2020',
     chunkSizeWarningLimit: 1500,
     rollupOptions: {


### PR DESCRIPTION
## Summary

Disable `build.sourcemap` for the production Vite build. Everything in `internal/web/dist` is embedded into the Go binary via `embed.FS`, so the 112 `.map` files (18MB, 72% of dist) currently ship inside every release download.

## Why

Nothing consumes the maps in production: the served pages never reference them and no error-reporting pipeline reads them. `npm run dev` serves its own sourcemaps regardless of this build flag, so developer experience is unchanged. Anyone needing to debug a production bundle can flip the flag locally — the config comment says so.

Measured: `internal/web/dist` 25MB → 6.7MB, which comes straight off the embedded payload of every release binary and every panel download/update.

## Type of change

- [x] Build / CI / tooling

## Areas affected

- [x] Frontend (UI / panel pages)

## How was this tested?

- `npm run build` → zero `.map` files in dist, panel serves and loads normally from the rebuilt embed.
- No test/lint/gen surface touched.

## Screenshots / recordings

N/A.

## Breaking changes

None.

## Checklist

- [x] I tested the change locally and confirmed the described behavior.
- [x] I added or updated tests for the new behavior (not applicable — build flag)
- [x] `go build ./...` and the test suite pass locally.
- [x] For frontend changes: `npm run lint`, `npm run typecheck`, and `npm run build` pass.
- [x] I updated the Wiki / README / API docs if user-facing behavior changed (not applicable)
- [x] My commits follow the project's existing message style.
- [x] I have no unrelated changes mixed into this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)