### PR TITLE
fix(sub): honor trustedProxyCIDRs before letting forwarded headers steer URLs

### DIFF
--- a/internal/sub/forwarded_trust.go
+++ b/internal/sub/forwarded_trust.go
@@ -12,48 +12,28 @@ import (
 	"github.com/mhsanaei/3x-ui/v3/internal/web/service"
 )
 
-// shippedTrustedProxyCIDRs is the factory default of the trustedProxyCIDRs
-// setting, read from the setting service rather than restated here so the gate
-// cannot drift from the value an unconfigured install actually carries.
 var shippedTrustedProxyCIDRs = sync.OnceValue(func() string {
 	return (&service.SettingService{}).GetFactoryDefaults()["trustedProxyCIDRs"]
 })
 
-var forwardedHeaderNames = []string{"X-Forwarded-Host", "X-Forwarded-Proto", "X-Real-IP"}
-
 var warnSuppressedForwardedOnce sync.Once
 
-// forwardedHeadersTrusted reports whether X-Forwarded-* headers on this request
-// may steer the generated subscription URLs. The gate engages only once the
-// operator has moved trustedProxyCIDRs off its shipped default; an install that
-// never touched the setting keeps the legacy behavior. The recover mirrors
-// internal/web/controller/util.go, where a setting read before InitDB panics
-// rather than returning an error.
 func (s *SubService) forwardedHeadersTrusted(c *gin.Context) (trusted bool) {
-	trusted = true
+	trusted = remoteAddrInCIDRs(c.Request.RemoteAddr, shippedTrustedProxyCIDRs())
 	defer func() {
 		_ = recover()
 	}()
 
 	configured, err := s.settingService.GetTrustedProxyCIDRs()
-	if err != nil {
-		return true
+	if err == nil && strings.TrimSpace(configured) != "" {
+		trusted = remoteAddrInCIDRs(c.Request.RemoteAddr, configured)
 	}
-	configured = strings.TrimSpace(configured)
-	if configured == "" || configured == shippedTrustedProxyCIDRs() {
-		return true
-	}
-	return remoteAddrInCIDRs(c.Request.RemoteAddr, configured)
+	return trusted
 }
 
-// warnSuppressedForwardedHeaders makes the gate diagnosable: an operator whose
-// subscription links start carrying the raw request host otherwise has nothing
-// connecting that to the setting they changed. The warning fires once per
-// process so a polling client cannot flood the log; every occurrence is logged
-// at debug level.
 func warnSuppressedForwardedHeaders(c *gin.Context) {
-	present := make([]string, 0, len(forwardedHeaderNames))
-	for _, name := range forwardedHeaderNames {
+	present := make([]string, 0, 3)
+	for _, name := range []string{"X-Forwarded-Host", "X-Forwarded-Proto", "X-Real-IP"} {
 		if c.GetHeader(name) != "" {
 			present = append(present, name)
 		}
@@ -68,9 +48,6 @@ func warnSuppressedForwardedHeaders(c *gin.Context) {
 	})
 }
 
-// remoteAddrInCIDRs reports whether remoteAddr falls inside any CIDR or bare
-// address in the comma-separated list, mirroring the panel-side check in
-// internal/web/controller/util.go.
 func remoteAddrInCIDRs(remoteAddr, cidrs string) bool {
 	host := remoteAddr
 	if h, _, err := net.SplitHostPort(remoteAddr); err == nil {
@@ -80,6 +57,7 @@ func remoteAddrInCIDRs(remoteAddr, cidrs string) bool {
 	if err != nil {
 		return false
 	}
+	addr = addr.Unmap()
 	for value := range strings.SplitSeq(cidrs, ",") {
 		value = strings.TrimSpace(value)
 		if value == "" {

--- a/internal/sub/forwarded_trust.go
+++ b/internal/sub/forwarded_trust.go
@@ -1,0 +1,66 @@
+package sub
+
+import (
+	"net"
+	"net/netip"
+	"strings"
+
+	"github.com/gin-gonic/gin"
+)
+
+// defaultTrustedProxyCIDRs mirrors the shipped default of the trustedProxyCIDRs
+// setting. An operator who never touched that setting still carries this value,
+// which is how forwardedHeadersTrusted tells "unconfigured" from "declared".
+const defaultTrustedProxyCIDRs = "127.0.0.1/32,::1/128"
+
+// forwardedHeadersTrusted reports whether X-Forwarded-* headers on this request
+// may drive the generated subscription URLs.
+//
+// The subscription server has always taken X-Forwarded-Host and
+// X-Forwarded-Proto at face value, so a client can point its own links at any
+// host by sending the header. Enforcing the panel's trustedProxyCIDRs
+// unconditionally would break every deployment whose reverse proxy is not on
+// the loopback default, so the check only engages once an operator has
+// declared a trust boundary by changing the setting away from its default.
+// Unconfigured installs keep the legacy behavior byte for byte.
+func (s *SubService) forwardedHeadersTrusted(c *gin.Context) bool {
+	configured, err := s.settingService.GetTrustedProxyCIDRs()
+	if err != nil {
+		return true
+	}
+	configured = strings.TrimSpace(configured)
+	if configured == "" || configured == defaultTrustedProxyCIDRs {
+		return true
+	}
+	return remoteAddrInCIDRs(c.Request.RemoteAddr, configured)
+}
+
+// remoteAddrInCIDRs reports whether remoteAddr falls inside any CIDR or bare
+// address in the comma-separated list, mirroring the panel-side check in
+// internal/web/controller/util.go.
+func remoteAddrInCIDRs(remoteAddr, cidrs string) bool {
+	host := remoteAddr
+	if h, _, err := net.SplitHostPort(remoteAddr); err == nil {
+		host = h
+	}
+	addr, err := netip.ParseAddr(strings.TrimSpace(host))
+	if err != nil {
+		return false
+	}
+	for value := range strings.SplitSeq(cidrs, ",") {
+		value = strings.TrimSpace(value)
+		if value == "" {
+			continue
+		}
+		if prefix, err := netip.ParsePrefix(value); err == nil {
+			if prefix.Contains(addr) {
+				return true
+			}
+			continue
+		}
+		if proxyIP, err := netip.ParseAddr(value); err == nil && proxyIP.Unmap() == addr.Unmap() {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/sub/forwarded_trust.go
+++ b/internal/sub/forwarded_trust.go
@@ -4,35 +4,68 @@ import (
 	"net"
 	"net/netip"
 	"strings"
+	"sync"
 
 	"github.com/gin-gonic/gin"
+
+	"github.com/mhsanaei/3x-ui/v3/internal/logger"
+	"github.com/mhsanaei/3x-ui/v3/internal/web/service"
 )
 
-// defaultTrustedProxyCIDRs mirrors the shipped default of the trustedProxyCIDRs
-// setting. An operator who never touched that setting still carries this value,
-// which is how forwardedHeadersTrusted tells "unconfigured" from "declared".
-const defaultTrustedProxyCIDRs = "127.0.0.1/32,::1/128"
+// shippedTrustedProxyCIDRs is the factory default of the trustedProxyCIDRs
+// setting, read from the setting service rather than restated here so the gate
+// cannot drift from the value an unconfigured install actually carries.
+var shippedTrustedProxyCIDRs = sync.OnceValue(func() string {
+	return (&service.SettingService{}).GetFactoryDefaults()["trustedProxyCIDRs"]
+})
+
+var forwardedHeaderNames = []string{"X-Forwarded-Host", "X-Forwarded-Proto", "X-Real-IP"}
+
+var warnSuppressedForwardedOnce sync.Once
 
 // forwardedHeadersTrusted reports whether X-Forwarded-* headers on this request
-// may drive the generated subscription URLs.
-//
-// The subscription server has always taken X-Forwarded-Host and
-// X-Forwarded-Proto at face value, so a client can point its own links at any
-// host by sending the header. Enforcing the panel's trustedProxyCIDRs
-// unconditionally would break every deployment whose reverse proxy is not on
-// the loopback default, so the check only engages once an operator has
-// declared a trust boundary by changing the setting away from its default.
-// Unconfigured installs keep the legacy behavior byte for byte.
-func (s *SubService) forwardedHeadersTrusted(c *gin.Context) bool {
+// may steer the generated subscription URLs. The gate engages only once the
+// operator has moved trustedProxyCIDRs off its shipped default; an install that
+// never touched the setting keeps the legacy behavior. The recover mirrors
+// internal/web/controller/util.go, where a setting read before InitDB panics
+// rather than returning an error.
+func (s *SubService) forwardedHeadersTrusted(c *gin.Context) (trusted bool) {
+	trusted = true
+	defer func() {
+		_ = recover()
+	}()
+
 	configured, err := s.settingService.GetTrustedProxyCIDRs()
 	if err != nil {
 		return true
 	}
 	configured = strings.TrimSpace(configured)
-	if configured == "" || configured == defaultTrustedProxyCIDRs {
+	if configured == "" || configured == shippedTrustedProxyCIDRs() {
 		return true
 	}
 	return remoteAddrInCIDRs(c.Request.RemoteAddr, configured)
+}
+
+// warnSuppressedForwardedHeaders makes the gate diagnosable: an operator whose
+// subscription links start carrying the raw request host otherwise has nothing
+// connecting that to the setting they changed. The warning fires once per
+// process so a polling client cannot flood the log; every occurrence is logged
+// at debug level.
+func warnSuppressedForwardedHeaders(c *gin.Context) {
+	present := make([]string, 0, len(forwardedHeaderNames))
+	for _, name := range forwardedHeaderNames {
+		if c.GetHeader(name) != "" {
+			present = append(present, name)
+		}
+	}
+	if len(present) == 0 {
+		return
+	}
+	headers := strings.Join(present, ", ")
+	logger.Debugf("sub: ignoring %s from %s, which is outside trustedProxyCIDRs", headers, c.Request.RemoteAddr)
+	warnSuppressedForwardedOnce.Do(func() {
+		logger.Warningf("sub: ignoring %s from %s because it is outside trustedProxyCIDRs; subscription URLs will use the request host. Add the proxy to that setting, or set subURI, if the generated links look wrong.", headers, c.Request.RemoteAddr)
+	})
 }
 
 // remoteAddrInCIDRs reports whether remoteAddr falls inside any CIDR or bare

--- a/internal/sub/forwarded_trust_test.go
+++ b/internal/sub/forwarded_trust_test.go
@@ -1,0 +1,124 @@
+package sub
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+
+	"github.com/mhsanaei/3x-ui/v3/internal/database"
+	"github.com/mhsanaei/3x-ui/v3/internal/database/model"
+)
+
+func requestFrom(t *testing.T, remoteAddr string, headers map[string]string) *gin.Context {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodGet, "/sub/abc", nil)
+	req.Host = "panel.example.com:2096"
+	req.RemoteAddr = remoteAddr
+	for k, v := range headers {
+		req.Header.Set(k, v)
+	}
+	c, _ := gin.CreateTestContext(httptest.NewRecorder())
+	c.Request = req
+	return c
+}
+
+func setTrustedProxyCIDRs(t *testing.T, value string) {
+	t.Helper()
+	if err := database.GetDB().Create(&model.Setting{Key: "trustedProxyCIDRs", Value: value}).Error; err != nil {
+		t.Fatalf("set trustedProxyCIDRs: %v", err)
+	}
+}
+
+// An install that never touched trustedProxyCIDRs must keep the legacy
+// behavior exactly: the forwarded host still drives the generated URLs, no
+// matter where the request came from. This is the compatibility guarantee for
+// every deployment whose reverse proxy is not on the loopback default.
+func TestResolveRequest_UnconfiguredInstallStillTrustsForwardedHost(t *testing.T) {
+	initSubDB(t)
+	s := &SubService{}
+
+	c := requestFrom(t, "203.0.113.9:51000", map[string]string{
+		"X-Forwarded-Host":  "sub.example.net",
+		"X-Forwarded-Proto": "https",
+	})
+	scheme, host, _, _ := s.ResolveRequest(c)
+
+	if host != "sub.example.net" {
+		t.Fatalf("unconfigured install must keep trusting X-Forwarded-Host, got host %q", host)
+	}
+	if scheme != "https" {
+		t.Fatalf("unconfigured install must keep trusting X-Forwarded-Proto, got scheme %q", scheme)
+	}
+}
+
+// Once the operator declares a trust boundary, a request arriving from outside
+// it can no longer point the generated subscription URLs at a host of its
+// choosing; the request's own Host stands.
+func TestResolveRequest_ConfiguredInstallIgnoresUntrustedForwardedHost(t *testing.T) {
+	initSubDB(t)
+	setTrustedProxyCIDRs(t, "10.0.0.0/8")
+	s := &SubService{}
+
+	c := requestFrom(t, "203.0.113.9:51000", map[string]string{
+		"X-Forwarded-Host":  "attacker.example.net",
+		"X-Forwarded-Proto": "https",
+	})
+	scheme, host, hostWithPort, hostHeader := s.ResolveRequest(c)
+
+	if host != "panel.example.com" {
+		t.Fatalf("forwarded host from an untrusted origin must be ignored, got %q", host)
+	}
+	if hostWithPort != "panel.example.com:2096" || hostHeader != "panel.example.com" {
+		t.Fatalf("every forwarded-host read must be gated, got hostWithPort=%q hostHeader=%q", hostWithPort, hostHeader)
+	}
+	if scheme != "http" {
+		t.Fatalf("forwarded proto from an untrusted origin must be ignored, got %q", scheme)
+	}
+}
+
+// The declared boundary is honored in the affirmative direction too: a request
+// that really does arrive through the configured proxy keeps working.
+func TestResolveRequest_ConfiguredInstallTrustsProxyInsideTheBoundary(t *testing.T) {
+	initSubDB(t)
+	setTrustedProxyCIDRs(t, "10.0.0.0/8")
+	s := &SubService{}
+
+	c := requestFrom(t, "10.1.2.3:44000", map[string]string{
+		"X-Forwarded-Host":  "sub.example.net",
+		"X-Forwarded-Proto": "https",
+	})
+	scheme, host, _, _ := s.ResolveRequest(c)
+
+	if host != "sub.example.net" {
+		t.Fatalf("a request from inside the declared boundary must still be trusted, got %q", host)
+	}
+	if scheme != "https" {
+		t.Fatalf("scheme from inside the declared boundary must be trusted, got %q", scheme)
+	}
+}
+
+func TestRemoteAddrInCIDRs(t *testing.T) {
+	tests := []struct {
+		name       string
+		remoteAddr string
+		cidrs      string
+		want       bool
+	}{
+		{name: "inside cidr", remoteAddr: "10.1.2.3:1234", cidrs: "10.0.0.0/8", want: true},
+		{name: "outside cidr", remoteAddr: "203.0.113.9:1234", cidrs: "10.0.0.0/8", want: false},
+		{name: "bare address entry", remoteAddr: "192.168.1.5:80", cidrs: "192.168.1.5", want: true},
+		{name: "ipv6 loopback", remoteAddr: "[::1]:8080", cidrs: "::1/128", want: true},
+		{name: "no port", remoteAddr: "10.1.2.3", cidrs: "10.0.0.0/8", want: true},
+		{name: "unparsable origin", remoteAddr: "not-an-ip", cidrs: "10.0.0.0/8", want: false},
+		{name: "empty entries skipped", remoteAddr: "10.1.2.3:1", cidrs: " , 10.0.0.0/8 , ", want: true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := remoteAddrInCIDRs(tc.remoteAddr, tc.cidrs); got != tc.want {
+				t.Errorf("remoteAddrInCIDRs(%q, %q) = %v, want %v", tc.remoteAddr, tc.cidrs, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/sub/forwarded_trust_test.go
+++ b/internal/sub/forwarded_trust_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/mhsanaei/3x-ui/v3/internal/database"
 	"github.com/mhsanaei/3x-ui/v3/internal/database/model"
+	"github.com/mhsanaei/3x-ui/v3/internal/web/service"
 )
 
 func requestFrom(t *testing.T, remoteAddr string, headers map[string]string) *gin.Context {
@@ -24,78 +25,148 @@ func requestFrom(t *testing.T, remoteAddr string, headers map[string]string) *gi
 	return c
 }
 
+// setTrustedProxyCIDRs writes the setting row directly, then reads it back
+// through SettingService so the test fails loudly if the service ever stops
+// reading the key this helper writes.
 func setTrustedProxyCIDRs(t *testing.T, value string) {
 	t.Helper()
 	if err := database.GetDB().Create(&model.Setting{Key: "trustedProxyCIDRs", Value: value}).Error; err != nil {
 		t.Fatalf("set trustedProxyCIDRs: %v", err)
 	}
-}
-
-// An install that never touched trustedProxyCIDRs must keep the legacy
-// behavior exactly: the forwarded host still drives the generated URLs, no
-// matter where the request came from. This is the compatibility guarantee for
-// every deployment whose reverse proxy is not on the loopback default.
-func TestResolveRequest_UnconfiguredInstallStillTrustsForwardedHost(t *testing.T) {
-	initSubDB(t)
-	s := &SubService{}
-
-	c := requestFrom(t, "203.0.113.9:51000", map[string]string{
-		"X-Forwarded-Host":  "sub.example.net",
-		"X-Forwarded-Proto": "https",
-	})
-	scheme, host, _, _ := s.ResolveRequest(c)
-
-	if host != "sub.example.net" {
-		t.Fatalf("unconfigured install must keep trusting X-Forwarded-Host, got host %q", host)
+	settingService := service.SettingService{}
+	stored, err := settingService.GetTrustedProxyCIDRs()
+	if err != nil {
+		t.Fatalf("read trustedProxyCIDRs back through SettingService: %v", err)
 	}
-	if scheme != "https" {
-		t.Fatalf("unconfigured install must keep trusting X-Forwarded-Proto, got scheme %q", scheme)
+	if stored != value {
+		t.Fatalf("SettingService reads trustedProxyCIDRs as %q, want %q — the key this helper writes has drifted", stored, value)
 	}
 }
 
-// Once the operator declares a trust boundary, a request arriving from outside
-// it can no longer point the generated subscription URLs at a host of its
-// choosing; the request's own Host stands.
-func TestResolveRequest_ConfiguredInstallIgnoresUntrustedForwardedHost(t *testing.T) {
+func storedAs(value string) *string {
+	return &value
+}
+
+// The gate must engage only for an operator who declared a trust boundary.
+// Every other state — no stored row, an empty row, a row still holding the
+// shipped default — keeps the legacy behavior, where the forwarded host and
+// proto drive the generated subscription URLs. That is the compatibility
+// guarantee for every deployment whose reverse proxy is not on the loopback
+// default, and the assertion that should fail loudest if it ever regresses.
+func TestResolveRequest_ForwardedHeaderTrust(t *testing.T) {
+	tests := []struct {
+		name             string
+		stored           *string
+		remoteAddr       string
+		wantScheme       string
+		wantHost         string
+		wantHostWithPort string
+		wantHostHeader   string
+	}{
+		{
+			name:             "no stored row keeps trusting forwarded headers",
+			stored:           nil,
+			remoteAddr:       "203.0.113.9:51000",
+			wantScheme:       "https",
+			wantHost:         "sub.example.net",
+			wantHostWithPort: "sub.example.net",
+			wantHostHeader:   "sub.example.net",
+		},
+		{
+			name:             "empty stored value keeps trusting forwarded headers",
+			stored:           storedAs(""),
+			remoteAddr:       "203.0.113.9:51000",
+			wantScheme:       "https",
+			wantHost:         "sub.example.net",
+			wantHostWithPort: "sub.example.net",
+			wantHostHeader:   "sub.example.net",
+		},
+		{
+			name:             "stored shipped default keeps trusting forwarded headers",
+			stored:           storedAs(shippedTrustedProxyCIDRs()),
+			remoteAddr:       "203.0.113.9:51000",
+			wantScheme:       "https",
+			wantHost:         "sub.example.net",
+			wantHostWithPort: "sub.example.net",
+			wantHostHeader:   "sub.example.net",
+		},
+		{
+			name:             "declared boundary ignores an origin outside it",
+			stored:           storedAs("10.0.0.0/8"),
+			remoteAddr:       "203.0.113.9:51000",
+			wantScheme:       "http",
+			wantHost:         "panel.example.com",
+			wantHostWithPort: "panel.example.com:2096",
+			wantHostHeader:   "panel.example.com",
+		},
+		{
+			name:             "declared boundary trusts an origin inside it",
+			stored:           storedAs("10.0.0.0/8"),
+			remoteAddr:       "10.1.2.3:44000",
+			wantScheme:       "https",
+			wantHost:         "sub.example.net",
+			wantHostWithPort: "sub.example.net",
+			wantHostHeader:   "sub.example.net",
+		},
+		{
+			name:             "declared boundary ignores an unparsable origin",
+			stored:           storedAs("10.0.0.0/8"),
+			remoteAddr:       "not-an-ip",
+			wantScheme:       "http",
+			wantHost:         "panel.example.com",
+			wantHostWithPort: "panel.example.com:2096",
+			wantHostHeader:   "panel.example.com",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			initSubDB(t)
+			if tc.stored != nil {
+				setTrustedProxyCIDRs(t, *tc.stored)
+			}
+			s := &SubService{}
+
+			c := requestFrom(t, tc.remoteAddr, map[string]string{
+				"X-Forwarded-Host":  "sub.example.net",
+				"X-Forwarded-Proto": "https",
+			})
+			scheme, host, hostWithPort, hostHeader := s.ResolveRequest(c)
+
+			if scheme != tc.wantScheme {
+				t.Errorf("scheme = %q, want %q", scheme, tc.wantScheme)
+			}
+			if host != tc.wantHost {
+				t.Errorf("host = %q, want %q", host, tc.wantHost)
+			}
+			if hostWithPort != tc.wantHostWithPort {
+				t.Errorf("hostWithPort = %q, want %q", hostWithPort, tc.wantHostWithPort)
+			}
+			if hostHeader != tc.wantHostHeader {
+				t.Errorf("hostHeader = %q, want %q", hostHeader, tc.wantHostHeader)
+			}
+		})
+	}
+}
+
+// X-Real-IP is the fallback for both the base host and the displayed header
+// host, so it has to be gated alongside X-Forwarded-Host rather than left as a
+// second way to steer the same fields.
+func TestResolveRequest_GatesRealIPFallback(t *testing.T) {
 	initSubDB(t)
 	setTrustedProxyCIDRs(t, "10.0.0.0/8")
 	s := &SubService{}
 
 	c := requestFrom(t, "203.0.113.9:51000", map[string]string{
-		"X-Forwarded-Host":  "attacker.example.net",
-		"X-Forwarded-Proto": "https",
+		"X-Real-IP": "198.51.100.7",
 	})
-	scheme, host, hostWithPort, hostHeader := s.ResolveRequest(c)
+	_, host, _, hostHeader := s.ResolveRequest(c)
 
 	if host != "panel.example.com" {
-		t.Fatalf("forwarded host from an untrusted origin must be ignored, got %q", host)
+		t.Errorf("host = %q, want the request host — X-Real-IP from an untrusted origin must be ignored", host)
 	}
-	if hostWithPort != "panel.example.com:2096" || hostHeader != "panel.example.com" {
-		t.Fatalf("every forwarded-host read must be gated, got hostWithPort=%q hostHeader=%q", hostWithPort, hostHeader)
-	}
-	if scheme != "http" {
-		t.Fatalf("forwarded proto from an untrusted origin must be ignored, got %q", scheme)
-	}
-}
-
-// The declared boundary is honored in the affirmative direction too: a request
-// that really does arrive through the configured proxy keeps working.
-func TestResolveRequest_ConfiguredInstallTrustsProxyInsideTheBoundary(t *testing.T) {
-	initSubDB(t)
-	setTrustedProxyCIDRs(t, "10.0.0.0/8")
-	s := &SubService{}
-
-	c := requestFrom(t, "10.1.2.3:44000", map[string]string{
-		"X-Forwarded-Host":  "sub.example.net",
-		"X-Forwarded-Proto": "https",
-	})
-	scheme, host, _, _ := s.ResolveRequest(c)
-
-	if host != "sub.example.net" {
-		t.Fatalf("a request from inside the declared boundary must still be trusted, got %q", host)
-	}
-	if scheme != "https" {
-		t.Fatalf("scheme from inside the declared boundary must be trusted, got %q", scheme)
+	if hostHeader != "panel.example.com" {
+		t.Errorf("hostHeader = %q, want the request host", hostHeader)
 	}
 }
 

--- a/internal/sub/forwarded_trust_test.go
+++ b/internal/sub/forwarded_trust_test.go
@@ -25,9 +25,6 @@ func requestFrom(t *testing.T, remoteAddr string, headers map[string]string) *gi
 	return c
 }
 
-// setTrustedProxyCIDRs writes the setting row directly, then reads it back
-// through SettingService so the test fails loudly if the service ever stops
-// reading the key this helper writes.
 func setTrustedProxyCIDRs(t *testing.T, value string) {
 	t.Helper()
 	if err := database.GetDB().Create(&model.Setting{Key: "trustedProxyCIDRs", Value: value}).Error; err != nil {
@@ -47,12 +44,6 @@ func storedAs(value string) *string {
 	return &value
 }
 
-// The gate must engage only for an operator who declared a trust boundary.
-// Every other state — no stored row, an empty row, a row still holding the
-// shipped default — keeps the legacy behavior, where the forwarded host and
-// proto drive the generated subscription URLs. That is the compatibility
-// guarantee for every deployment whose reverse proxy is not on the loopback
-// default, and the assertion that should fail loudest if it ever regresses.
 func TestResolveRequest_ForwardedHeaderTrust(t *testing.T) {
 	tests := []struct {
 		name             string
@@ -64,27 +55,36 @@ func TestResolveRequest_ForwardedHeaderTrust(t *testing.T) {
 		wantHostHeader   string
 	}{
 		{
-			name:             "no stored row keeps trusting forwarded headers",
+			name:             "no stored row trusts only loopback",
 			stored:           nil,
 			remoteAddr:       "203.0.113.9:51000",
-			wantScheme:       "https",
-			wantHost:         "sub.example.net",
-			wantHostWithPort: "sub.example.net",
-			wantHostHeader:   "sub.example.net",
+			wantScheme:       "http",
+			wantHost:         "panel.example.com",
+			wantHostWithPort: "panel.example.com:2096",
+			wantHostHeader:   "panel.example.com",
 		},
 		{
-			name:             "empty stored value keeps trusting forwarded headers",
+			name:             "empty stored value trusts only loopback",
 			stored:           storedAs(""),
 			remoteAddr:       "203.0.113.9:51000",
-			wantScheme:       "https",
-			wantHost:         "sub.example.net",
-			wantHostWithPort: "sub.example.net",
-			wantHostHeader:   "sub.example.net",
+			wantScheme:       "http",
+			wantHost:         "panel.example.com",
+			wantHostWithPort: "panel.example.com:2096",
+			wantHostHeader:   "panel.example.com",
 		},
 		{
-			name:             "stored shipped default keeps trusting forwarded headers",
+			name:             "stored shipped default trusts only loopback",
 			stored:           storedAs(shippedTrustedProxyCIDRs()),
 			remoteAddr:       "203.0.113.9:51000",
+			wantScheme:       "http",
+			wantHost:         "panel.example.com",
+			wantHostWithPort: "panel.example.com:2096",
+			wantHostHeader:   "panel.example.com",
+		},
+		{
+			name:             "factory default trusts loopback",
+			stored:           nil,
+			remoteAddr:       "127.0.0.1:51000",
 			wantScheme:       "https",
 			wantHost:         "sub.example.net",
 			wantHostWithPort: "sub.example.net",
@@ -103,6 +103,15 @@ func TestResolveRequest_ForwardedHeaderTrust(t *testing.T) {
 			name:             "declared boundary trusts an origin inside it",
 			stored:           storedAs("10.0.0.0/8"),
 			remoteAddr:       "10.1.2.3:44000",
+			wantScheme:       "https",
+			wantHost:         "sub.example.net",
+			wantHostWithPort: "sub.example.net",
+			wantHostHeader:   "sub.example.net",
+		},
+		{
+			name:             "declared ipv4 cidr trusts an ipv4 mapped origin",
+			stored:           storedAs("10.0.0.0/8"),
+			remoteAddr:       "[::ffff:10.1.2.3]:44000",
 			wantScheme:       "https",
 			wantHost:         "sub.example.net",
 			wantHostWithPort: "sub.example.net",
@@ -149,9 +158,6 @@ func TestResolveRequest_ForwardedHeaderTrust(t *testing.T) {
 	}
 }
 
-// X-Real-IP is the fallback for both the base host and the displayed header
-// host, so it has to be gated alongside X-Forwarded-Host rather than left as a
-// second way to steer the same fields.
 func TestResolveRequest_GatesRealIPFallback(t *testing.T) {
 	initSubDB(t)
 	setTrustedProxyCIDRs(t, "10.0.0.0/8")
@@ -178,6 +184,7 @@ func TestRemoteAddrInCIDRs(t *testing.T) {
 		want       bool
 	}{
 		{name: "inside cidr", remoteAddr: "10.1.2.3:1234", cidrs: "10.0.0.0/8", want: true},
+		{name: "ipv4 mapped address inside cidr", remoteAddr: "[::ffff:10.1.2.3]:1234", cidrs: "10.0.0.0/8", want: true},
 		{name: "outside cidr", remoteAddr: "203.0.113.9:1234", cidrs: "10.0.0.0/8", want: false},
 		{name: "bare address entry", remoteAddr: "192.168.1.5:80", cidrs: "192.168.1.5", want: true},
 		{name: "ipv6 loopback", remoteAddr: "[::1]:8080", cidrs: "::1/128", want: true},

--- a/internal/sub/service.go
+++ b/internal/sub/service.go
@@ -2486,10 +2486,12 @@ type PageData struct {
 // ResolveRequest extracts scheme and host info from request/headers consistently.
 // ResolveRequest extracts scheme, host, and header information from an HTTP request.
 func (s *SubService) ResolveRequest(c *gin.Context) (scheme string, host string, hostWithPort string, hostHeader string) {
-	// Forwarded headers only steer the generated URLs when the request comes
-	// from a proxy the operator declared trusted; see forwardedHeadersTrusted.
+	trusted := s.forwardedHeadersTrusted(c)
+	if !trusted {
+		warnSuppressedForwardedHeaders(c)
+	}
 	forwarded := func(name string) string {
-		if !s.forwardedHeadersTrusted(c) {
+		if !trusted {
 			return ""
 		}
 		return c.GetHeader(name)

--- a/internal/sub/service.go
+++ b/internal/sub/service.go
@@ -2486,18 +2486,27 @@ type PageData struct {
 // ResolveRequest extracts scheme and host info from request/headers consistently.
 // ResolveRequest extracts scheme, host, and header information from an HTTP request.
 func (s *SubService) ResolveRequest(c *gin.Context) (scheme string, host string, hostWithPort string, hostHeader string) {
+	// Forwarded headers only steer the generated URLs when the request comes
+	// from a proxy the operator declared trusted; see forwardedHeadersTrusted.
+	forwarded := func(name string) string {
+		if !s.forwardedHeadersTrusted(c) {
+			return ""
+		}
+		return c.GetHeader(name)
+	}
+
 	// scheme
 	scheme = "http"
-	if c.Request.TLS != nil || strings.EqualFold(c.GetHeader("X-Forwarded-Proto"), "https") {
+	if c.Request.TLS != nil || strings.EqualFold(forwarded("X-Forwarded-Proto"), "https") {
 		scheme = "https"
 	}
 
 	// base host (no port)
-	if h, err := getHostFromXFH(c.GetHeader("X-Forwarded-Host")); err == nil && h != "" {
+	if h, err := getHostFromXFH(forwarded("X-Forwarded-Host")); err == nil && h != "" {
 		host = h
 	}
 	if host == "" {
-		host = c.GetHeader("X-Real-IP")
+		host = forwarded("X-Real-IP")
 	}
 	if host == "" {
 		var err error
@@ -2508,7 +2517,7 @@ func (s *SubService) ResolveRequest(c *gin.Context) (scheme string, host string,
 	}
 
 	// host:port for URLs
-	hostWithPort = c.GetHeader("X-Forwarded-Host")
+	hostWithPort = forwarded("X-Forwarded-Host")
 	if hostWithPort == "" {
 		hostWithPort = c.Request.Host
 	}
@@ -2517,9 +2526,9 @@ func (s *SubService) ResolveRequest(c *gin.Context) (scheme string, host string,
 	}
 
 	// header display host
-	hostHeader = c.GetHeader("X-Forwarded-Host")
+	hostHeader = forwarded("X-Forwarded-Host")
 	if hostHeader == "" {
-		hostHeader = c.GetHeader("X-Real-IP")
+		hostHeader = forwarded("X-Real-IP")
 	}
 	if hostHeader == "" {
 		hostHeader = host


### PR DESCRIPTION
## Summary

Subscription URLs now apply `trustedProxyCIDRs` with the same trust boundary as panel-generated links. Before this change, a request reaching the subscription server could steer generated hosts and schemes through forwarded headers even when the setting was unset, empty, or still at its default; now those states trust only loopback, while a configured value trusts exactly its listed addresses and CIDRs.

This is an intentional default-behavior change. Deployments using a remote reverse proxy for the subscription endpoint must add that proxy to `trustedProxyCIDRs` or configure `subURI`; this matches the setting's documented meaning and the panel's existing behavior. Rejected forwarded headers are logged at debug level, with one process-level warning when they first affect URL generation.

## Tests

- Table-driven request coverage for unset, empty, factory-default, loopback, custom-CIDR, malformed, and IPv4-mapped proxy origins.
- Coverage that untrusted `X-Real-IP` cannot bypass the forwarded-header gate.
- The local checkout has no Go toolchain, so the Go suite could not be run here.
