### PR TITLE
fix(database): snapshot SQLite backups online

### DIFF
--- a/frontend/src/components/clients/ConfigBlock.css
+++ b/frontend/src/components/clients/ConfigBlock.css
@@ -16,6 +16,10 @@ body.light .config-block .ant-tag.ant-tag-filled.ant-tag-gold {
   color: #874d00;
 }
 
+body.light .config-block-text {
+  color: #595959;
+}
+
 .config-block .ant-collapse-extra {
   display: flex;
   align-items: center;

--- a/go.mod
+++ b/go.mod
@@ -68,7 +68,7 @@ require (
 	github.com/leodido/go-urn v1.5.0 // indirect
 	github.com/lufia/plan9stats v0.0.0-20260627054121-477a66015f15 // indirect
 	github.com/mattn/go-isatty v0.0.24 // indirect
-	github.com/mattn/go-sqlite3 v1.14.48 // indirect
+	github.com/mattn/go-sqlite3 v1.14.48
 	github.com/miekg/dns v1.1.72 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect

--- a/internal/database/db.go
+++ b/internal/database/db.go
@@ -3,6 +3,7 @@ package database
 import (
 	"bytes"
 	"context"
+	"database/sql"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -18,6 +19,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/mattn/go-sqlite3"
 	"github.com/mhsanaei/3x-ui/v3/internal/config"
 	"github.com/mhsanaei/3x-ui/v3/internal/database/model"
 	"github.com/mhsanaei/3x-ui/v3/internal/util/crypto"
@@ -2104,6 +2106,80 @@ func Checkpoint() error {
 		return nil
 	}
 	return db.Exec("PRAGMA wal_checkpoint(TRUNCATE);").Error
+}
+
+func BackupSQLite(dstPath string) (err error) {
+	if IsPostgres() {
+		return errors.New("sqlite backup is unavailable for PostgreSQL")
+	}
+	if db == nil {
+		return errors.New("database is not initialized")
+	}
+	if _, err := os.Lstat(dstPath); err == nil {
+		return fmt.Errorf("sqlite backup destination already exists: %s", dstPath)
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return err
+	}
+	defer func() {
+		if err != nil {
+			_ = os.Remove(dstPath)
+		}
+	}()
+
+	sourceDB, err := db.DB()
+	if err != nil {
+		return err
+	}
+	sourceConn, err := sourceDB.Conn(context.Background())
+	if err != nil {
+		return err
+	}
+	defer sourceConn.Close()
+
+	destinationDB, err := sql.Open("sqlite3", dstPath)
+	if err != nil {
+		return err
+	}
+	defer destinationDB.Close()
+	destinationConn, err := destinationDB.Conn(context.Background())
+	if err != nil {
+		return err
+	}
+	defer destinationConn.Close()
+
+	return sourceConn.Raw(func(sourceDriver any) error {
+		source, ok := sourceDriver.(*sqlite3.SQLiteConn)
+		if !ok {
+			return fmt.Errorf("unexpected SQLite source connection type %T", sourceDriver)
+		}
+		return destinationConn.Raw(func(destinationDriver any) error {
+			destination, ok := destinationDriver.(*sqlite3.SQLiteConn)
+			if !ok {
+				return fmt.Errorf("unexpected SQLite destination connection type %T", destinationDriver)
+			}
+			backup, err := destination.Backup("main", source, "main")
+			if err != nil {
+				return err
+			}
+			finished := false
+			defer func() {
+				if !finished {
+					_ = backup.Finish()
+				}
+			}()
+			for {
+				done, err := backup.Step(128)
+				if err != nil {
+					return err
+				}
+				if done {
+					finished = true
+					return backup.Finish()
+				}
+				time.Sleep(10 * time.Millisecond)
+			}
+		})
+	})
 }
 
 func ValidateSQLiteDB(dbPath string) error {

--- a/internal/database/db.go
+++ b/internal/database/db.go
@@ -19,13 +19,13 @@ import (
 	"strings"
 	"time"
 
-	"github.com/mattn/go-sqlite3"
 	"github.com/mhsanaei/3x-ui/v3/internal/config"
 	"github.com/mhsanaei/3x-ui/v3/internal/database/model"
 	"github.com/mhsanaei/3x-ui/v3/internal/util/crypto"
 	"github.com/mhsanaei/3x-ui/v3/internal/util/random"
 	"github.com/mhsanaei/3x-ui/v3/internal/xray"
 
+	"github.com/mattn/go-sqlite3"
 	"gorm.io/driver/postgres"
 	"gorm.io/driver/sqlite"
 	"gorm.io/gorm"

--- a/internal/database/journal_mode_test.go
+++ b/internal/database/journal_mode_test.go
@@ -2,8 +2,10 @@ package database
 
 import (
 	"bytes"
+	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/mhsanaei/3x-ui/v3/internal/database/model"
@@ -78,5 +80,67 @@ func TestWalCheckpointMakesRawFileBackupComplete(t *testing.T) {
 	}
 	if !bytes.Contains(dump, []byte("walBackupProbe")) {
 		t.Fatal("raw-file backup taken after Checkpoint must contain the latest write")
+	}
+}
+
+func TestBackupSQLiteProducesValidSnapshotDuringWrites(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "x-ui.db")
+	if err := InitDB(dbPath); err != nil {
+		t.Fatalf("InitDB: %v", err)
+	}
+	t.Cleanup(func() { _ = CloseDB() })
+
+	seed := make([]model.Setting, 256)
+	value := strings.Repeat("x", 4096)
+	for i := range seed {
+		seed[i] = model.Setting{Key: fmt.Sprintf("backup-seed-%d", i), Value: value}
+	}
+	if err := db.Create(&seed).Error; err != nil {
+		t.Fatalf("seed database: %v", err)
+	}
+
+	started := make(chan struct{})
+	stop := make(chan struct{})
+	writesDone := make(chan error, 1)
+	go func() {
+		for i := 0; i < 1024; i++ {
+			if err := db.Create(&model.Setting{Key: fmt.Sprintf("backup-write-%d", i), Value: value}).Error; err != nil {
+				writesDone <- err
+				return
+			}
+			if i == 0 {
+				close(started)
+			}
+			select {
+			case <-stop:
+				writesDone <- nil
+				return
+			default:
+			}
+		}
+		writesDone <- nil
+	}()
+
+	<-started
+	backupPath := filepath.Join(t.TempDir(), "backup.db")
+	if err := BackupSQLite(backupPath); err != nil {
+		close(stop)
+		<-writesDone
+		t.Fatalf("BackupSQLite: %v", err)
+	}
+	close(stop)
+	if err := <-writesDone; err != nil {
+		t.Fatalf("concurrent write: %v", err)
+	}
+	if err := ValidateSQLiteDB(backupPath); err != nil {
+		t.Fatalf("validate backup: %v", err)
+	}
+
+	backup, err := DumpSQLiteToBytes(backupPath)
+	if err != nil {
+		t.Fatalf("dump backup: %v", err)
+	}
+	if !bytes.Contains(backup, []byte("backup-seed-0")) {
+		t.Fatal("backup lost data committed before the snapshot")
 	}
 }

--- a/internal/web/service/server.go
+++ b/internal/web/service/server.go
@@ -1303,25 +1303,31 @@ func (s *ServerService) GetDb() ([]byte, error) {
 	if database.IsPostgres() {
 		return s.exportPostgresDB()
 	}
-	// Update by manually trigger a checkpoint operation
-	err := database.Checkpoint()
+	backupPath, err := s.backupSQLite()
 	if err != nil {
 		return nil, err
 	}
-	// Open the file for reading
-	file, err := os.Open(config.GetDBPath())
-	if err != nil {
-		return nil, err
-	}
-	defer file.Close()
+	defer os.Remove(backupPath)
+	return os.ReadFile(backupPath)
+}
 
-	// Read the file contents
-	fileContents, err := io.ReadAll(file)
+func (s *ServerService) backupSQLite() (string, error) {
+	temp, err := os.CreateTemp(filepath.Dir(config.GetDBPath()), ".x-ui-backup-*.db")
 	if err != nil {
-		return nil, err
+		return "", err
 	}
-
-	return fileContents, nil
+	backupPath := temp.Name()
+	if err := temp.Close(); err != nil {
+		_ = os.Remove(backupPath)
+		return "", err
+	}
+	if err := os.Remove(backupPath); err != nil {
+		return "", err
+	}
+	if err := database.BackupSQLite(backupPath); err != nil {
+		return "", err
+	}
+	return backupPath, nil
 }
 
 // BackupFilename returns the filename for a database backup, named after the
@@ -1421,11 +1427,12 @@ func (s *ServerService) GetMigration() ([]byte, string, error) {
 		return data, "x-ui.db", nil
 	}
 
-	// SQLite panel: checkpoint so the .db reflects the latest writes, then dump.
-	if err := database.Checkpoint(); err != nil {
+	backupPath, err := s.backupSQLite()
+	if err != nil {
 		return nil, "", err
 	}
-	data, err := database.DumpSQLiteToBytes(config.GetDBPath())
+	defer os.Remove(backupPath)
+	data, err := database.DumpSQLiteToBytes(backupPath)
 	if err != nil {
 		return nil, "", err
 	}


### PR DESCRIPTION
## Summary

- replace checkpoint-then-read SQLite backups with SQLite’s online backup API
- take SQLite migration dumps from the same consistent snapshot
- cover a snapshot created while writes continue, then reopen it and run `integrity_check`

The previous flow could read the live database file after checkpointing; a concurrent writer could still make that byte copy inconsistent. The backup API copies through SQLite and yields a recoverable snapshot without stopping normal writers for the full copy.

## Validation

- Local Go toolchain is unavailable in this workspace.
- `git diff --check` passed.
- CI will run the new database test, race suite, and full verification.