### PR TITLE
fix(frontend): preserve edited server drafts

### DIFF
--- a/frontend/.storybook/preview.tsx
+++ b/frontend/.storybook/preview.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from 'react';
+import { useLayoutEffect } from 'react';
 import type { Decorator, Preview } from '@storybook/react-vite';
 import { ConfigProvider } from 'antd';
 import i18next from 'i18next';
@@ -19,8 +19,9 @@ if (!i18next.isInitialized) {
 
 const withTheme: Decorator = (Story, context) => {
   const dark = context.globals.theme === 'dark';
-  useEffect(() => {
-    document.body.setAttribute('class', dark ? 'dark' : 'light');
+  useLayoutEffect(() => {
+    document.body.classList.remove('dark', 'light');
+    document.body.classList.add(dark ? 'dark' : 'light');
     document.documentElement.setAttribute('data-theme', dark ? 'dark' : 'light');
   }, [dark]);
   return (

--- a/frontend/src/api/queries/useAllSettings.ts
+++ b/frontend/src/api/queries/useAllSettings.ts
@@ -28,7 +28,7 @@ export function useAllSettings() {
   });
 
   const server = useMemo(() => new AllSetting(query.data), [query.data]);
-  const { draft, setDraft, isDirty } = useServerDraft(
+  const { draft, setDraft, isDirty, markSaved } = useServerDraft(
     query.data === undefined ? undefined : server,
     (setting) => new AllSetting(setting),
     (left, right) => left.equals(right),
@@ -57,7 +57,12 @@ export function useAllSettings() {
     },
   });
 
-  const saveAll = useCallback(() => saveMut.mutateAsync({ ...allSetting }), [saveMut, allSetting]);
+  const saveAll = useCallback(async () => {
+    const saved = new AllSetting(allSetting);
+    const msg = await saveMut.mutateAsync({ ...saved });
+    if (msg?.success) markSaved(saved);
+    return msg;
+  }, [allSetting, markSaved, saveMut]);
   const savePayload = useCallback((payload: SettingSavePayload) => saveMut.mutateAsync(payload), [saveMut]);
   const saveDisabled = !isDirty;
 

--- a/frontend/src/api/queries/useAllSettings.ts
+++ b/frontend/src/api/queries/useAllSettings.ts
@@ -28,7 +28,7 @@ export function useAllSettings() {
   });
 
   const server = useMemo(() => new AllSetting(query.data), [query.data]);
-  const { draft, setDraft, isDirty, discard } = useServerDraft(
+  const { draft, setDraft, isDirty } = useServerDraft(
     query.data === undefined ? undefined : server,
     (setting) => new AllSetting(setting),
     (left, right) => left.equals(right),
@@ -70,6 +70,5 @@ export function useAllSettings() {
     saveDisabled,
     saveAll,
     savePayload,
-    discard,
   };
 }

--- a/frontend/src/api/queries/useAllSettings.ts
+++ b/frontend/src/api/queries/useAllSettings.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useMemo, useState } from 'react';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 
 import { HttpUtil, Msg } from '@/utils';
@@ -6,6 +6,7 @@ import { parseMsg } from '@/utils/zodValidate';
 import { AllSetting } from '@/models/setting';
 import { AllSettingSchema, type AllSettingInput } from '@/schemas/setting';
 import { keys } from '@/api/queryKeys';
+import { useServerDraft } from '@/hooks/useServerDraft';
 
 type SettingSavePayload = Partial<AllSetting> & Record<string, unknown>;
 
@@ -18,7 +19,6 @@ async function fetchAllSetting(): Promise<AllSettingInput | null> {
 
 export function useAllSettings() {
   const queryClient = useQueryClient();
-  const [draft, setDraft] = useState<AllSetting>(() => new AllSetting());
   const [extraSpinning, setExtraSpinning] = useState(false);
 
   const query = useQuery({
@@ -28,20 +28,20 @@ export function useAllSettings() {
   });
 
   const server = useMemo(() => new AllSetting(query.data), [query.data]);
-
-  useEffect(() => {
-    if (query.data !== undefined) {
-      setDraft(new AllSetting(query.data));
-    }
-  }, [query.data]);
+  const { draft, setDraft, isDirty, discard } = useServerDraft(
+    query.data === undefined ? undefined : server,
+    (setting) => new AllSetting(setting),
+    (left, right) => left.equals(right),
+  );
+  const allSetting = draft ?? server;
 
   const updateSetting = useCallback((patch: Partial<AllSetting>) => {
     setDraft((prev) => {
-      const next = new AllSetting(prev);
+      const next = new AllSetting(prev ?? server);
       Object.assign(next, patch);
       return next;
     });
-  }, []);
+  }, [server, setDraft]);
 
   const saveMut = useMutation({
     mutationFn: async (next: SettingSavePayload): Promise<Msg<unknown>> => {
@@ -57,12 +57,12 @@ export function useAllSettings() {
     },
   });
 
-  const saveAll = useCallback(() => saveMut.mutateAsync({ ...draft }), [saveMut, draft]);
+  const saveAll = useCallback(() => saveMut.mutateAsync({ ...allSetting }), [saveMut, allSetting]);
   const savePayload = useCallback((payload: SettingSavePayload) => saveMut.mutateAsync(payload), [saveMut]);
-  const saveDisabled = useMemo(() => server.equals(draft), [server, draft]);
+  const saveDisabled = !isDirty;
 
   return {
-    allSetting: draft,
+    allSetting,
     updateSetting,
     fetched: query.data !== undefined,
     spinning: extraSpinning || saveMut.isPending,
@@ -70,5 +70,6 @@ export function useAllSettings() {
     saveDisabled,
     saveAll,
     savePayload,
+    discard,
   };
 }

--- a/frontend/src/components/clients/ConfigBlock.css
+++ b/frontend/src/components/clients/ConfigBlock.css
@@ -42,8 +42,13 @@ body.light .config-block-text {
   word-break: break-all;
   white-space: pre-wrap;
   padding: 6px 8px;
-  color: var(--ant-color-text);
-  background: var(--ant-color-fill-tertiary);
+  color: #595959;
+  background: #f5f5f5;
   border-radius: 4px;
   user-select: all;
+}
+
+body.dark .config-block-text {
+  color: #d9d9d9;
+  background: #141414;
 }

--- a/frontend/src/components/clients/ConfigBlock.css
+++ b/frontend/src/components/clients/ConfigBlock.css
@@ -16,10 +16,6 @@ body.light .config-block .ant-tag.ant-tag-filled.ant-tag-gold {
   color: #874d00;
 }
 
-body.light .config-block-text {
-  color: #595959;
-}
-
 .config-block .ant-collapse-extra {
   display: flex;
   align-items: center;
@@ -46,9 +42,4 @@ body.light .config-block-text {
   background: #f5f5f5;
   border-radius: 4px;
   user-select: all;
-}
-
-body.dark .config-block-text {
-  color: #d9d9d9;
-  background: #141414;
 }

--- a/frontend/src/components/clients/ConfigBlock.css
+++ b/frontend/src/components/clients/ConfigBlock.css
@@ -38,8 +38,13 @@ body.light .config-block .ant-tag.ant-tag-filled.ant-tag-gold {
   word-break: break-all;
   white-space: pre-wrap;
   padding: 6px 8px;
-  color: #595959;
-  background: #f5f5f5;
+  color: var(--ant-color-text);
+  background: var(--ant-color-fill-tertiary);
   border-radius: 4px;
   user-select: all;
+}
+
+body.light .config-block-text {
+  color: #595959;
+  background: #f5f5f5;
 }

--- a/frontend/src/hooks/useServerDraft.ts
+++ b/frontend/src/hooks/useServerDraft.ts
@@ -7,35 +7,35 @@ export function useServerDraft<T>(server: T | undefined, clone: (value: T) => T,
   equalsRef.current = equals;
 
   const [draft, setDraft] = useState<T | undefined>();
-  const baselineRef = useRef<T | undefined>(undefined);
+  const [baseline, setBaseline] = useState<T | undefined>();
+  const draftRef = useRef(draft);
+  const baselineRef = useRef(baseline);
   const serverRef = useRef(server);
+  draftRef.current = draft;
+  baselineRef.current = baseline;
   serverRef.current = server;
 
   useEffect(() => {
     if (server === undefined) return;
-    setDraft((current) => {
-      if (
-        baselineRef.current !== undefined
-        && current !== undefined
-        && !equalsRef.current(current, baselineRef.current)
-        && !equalsRef.current(current, server)
-      ) {
-        return current;
-      }
-      baselineRef.current = server;
-      return cloneRef.current(server);
-    });
+    const currentDraft = draftRef.current;
+    const currentBaseline = baselineRef.current;
+    const isDirty = currentDraft !== undefined
+      && currentBaseline !== undefined
+      && !equalsRef.current(currentDraft, currentBaseline);
+    setBaseline(server);
+    if (isDirty && !equalsRef.current(currentDraft, server)) return;
+    setDraft(cloneRef.current(server));
   }, [server]);
 
   const discard = useCallback(() => {
     if (serverRef.current === undefined) return;
-    baselineRef.current = serverRef.current;
+    setBaseline(serverRef.current);
     setDraft(cloneRef.current(serverRef.current));
   }, []);
 
   const isDirty = useMemo(
-    () => draft !== undefined && baselineRef.current !== undefined && !equalsRef.current(draft, baselineRef.current),
-    [draft],
+    () => draft !== undefined && baseline !== undefined && !equalsRef.current(draft, baseline),
+    [baseline, draft],
   );
 
   return { draft, setDraft, isDirty, discard };

--- a/frontend/src/hooks/useServerDraft.ts
+++ b/frontend/src/hooks/useServerDraft.ts
@@ -1,0 +1,42 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+
+export function useServerDraft<T>(server: T | undefined, clone: (value: T) => T, equals: (left: T, right: T) => boolean) {
+  const cloneRef = useRef(clone);
+  const equalsRef = useRef(equals);
+  cloneRef.current = clone;
+  equalsRef.current = equals;
+
+  const [draft, setDraft] = useState<T | undefined>();
+  const baselineRef = useRef<T | undefined>(undefined);
+  const serverRef = useRef(server);
+  serverRef.current = server;
+
+  useEffect(() => {
+    if (server === undefined) return;
+    setDraft((current) => {
+      if (
+        baselineRef.current !== undefined
+        && current !== undefined
+        && !equalsRef.current(current, baselineRef.current)
+        && !equalsRef.current(current, server)
+      ) {
+        return current;
+      }
+      baselineRef.current = server;
+      return cloneRef.current(server);
+    });
+  }, [server]);
+
+  const discard = useCallback(() => {
+    if (serverRef.current === undefined) return;
+    baselineRef.current = serverRef.current;
+    setDraft(cloneRef.current(serverRef.current));
+  }, []);
+
+  const isDirty = useMemo(
+    () => draft !== undefined && baselineRef.current !== undefined && !equalsRef.current(draft, baselineRef.current),
+    [draft],
+  );
+
+  return { draft, setDraft, isDirty, discard };
+}

--- a/frontend/src/hooks/useServerDraft.ts
+++ b/frontend/src/hooks/useServerDraft.ts
@@ -10,10 +10,8 @@ export function useServerDraft<T>(server: T | undefined, clone: (value: T) => T,
   const [baseline, setBaseline] = useState<T | undefined>();
   const draftRef = useRef(draft);
   const baselineRef = useRef(baseline);
-  const serverRef = useRef(server);
   draftRef.current = draft;
   baselineRef.current = baseline;
-  serverRef.current = server;
 
   useEffect(() => {
     if (server === undefined) return;
@@ -27,10 +25,8 @@ export function useServerDraft<T>(server: T | undefined, clone: (value: T) => T,
     setDraft(cloneRef.current(server));
   }, [server]);
 
-  const discard = useCallback(() => {
-    if (serverRef.current === undefined) return;
-    setBaseline(serverRef.current);
-    setDraft(cloneRef.current(serverRef.current));
+  const markSaved = useCallback((value: T) => {
+    setBaseline(cloneRef.current(value));
   }, []);
 
   const isDirty = useMemo(
@@ -38,5 +34,5 @@ export function useServerDraft<T>(server: T | undefined, clone: (value: T) => T,
     [baseline, draft],
   );
 
-  return { draft, setDraft, isDirty, discard };
+  return { draft, setDraft, isDirty, markSaved };
 }

--- a/frontend/src/hooks/useXraySetting.ts
+++ b/frontend/src/hooks/useXraySetting.ts
@@ -14,7 +14,6 @@ import {
   type OutboundTrafficRow,
 } from '@/schemas/xray';
 
-const DIRTY_POLL_MS = 1000;
 const DEFAULT_TEST_URL = 'https://www.google.com/generate_204';
 // One HTTP-mode batch request tests this many outbounds through a single
 // shared temp xray instance; chunking keeps responses bounded (~30s worst
@@ -125,7 +124,6 @@ export function useXraySetting(): UseXraySettingResult {
     staleTime: Infinity,
   });
 
-  const [saveDisabled, setSaveDisabled] = useState(true);
   const [xraySetting, setXraySettingState] = useState('');
   const [templateSettings, setTemplateSettingsState] = useState<XraySettingsValue | null>(null);
   const [outboundTestUrl, setOutboundTestUrlState] = useState(DEFAULT_TEST_URL);
@@ -140,7 +138,7 @@ export function useXraySetting(): UseXraySettingResult {
   const [testingAll, setTestingAll] = useState(false);
 
   const oldXraySettingRef = useRef('');
-  const oldOutboundTestUrlRef = useRef('');
+  const oldOutboundTestUrlRef = useRef(DEFAULT_TEST_URL);
   const syncingRef = useRef(false);
   const xraySettingRef = useRef('');
   const outboundTestUrlRef = useRef(outboundTestUrl);
@@ -158,6 +156,9 @@ export function useXraySetting(): UseXraySettingResult {
     if (!configQuery.data) return;
     const obj = configQuery.data;
     const pretty = JSON.stringify(obj.xraySetting, null, 2);
+    const isDirty = oldXraySettingRef.current !== xraySettingRef.current
+      || oldOutboundTestUrlRef.current !== outboundTestUrlRef.current;
+    if (isDirty) return;
     syncingRef.current = true;
     setXraySettingState(pretty);
     setTemplateSettingsState(obj.xraySetting);
@@ -170,7 +171,6 @@ export function useXraySetting(): UseXraySettingResult {
     const nextUrl = obj.outboundTestUrl || DEFAULT_TEST_URL;
     setOutboundTestUrlState(nextUrl);
     oldOutboundTestUrlRef.current = nextUrl;
-    setSaveDisabled(true);
   }, [configQuery.data]);
 
   const fetched = configQuery.data !== undefined || configQuery.isError;
@@ -231,7 +231,6 @@ export function useXraySetting(): UseXraySettingResult {
       if (!msg?.success) return;
       oldXraySettingRef.current = sentXraySetting;
       oldOutboundTestUrlRef.current = sentTestUrl;
-      setSaveDisabled(true);
       queryClient.invalidateQueries({ queryKey: keys.xray.config() });
     },
   });
@@ -425,14 +424,8 @@ export function useXraySetting(): UseXraySettingResult {
     }
   }, [testingAll, testOutbound, testSubscriptionOutbound, postOutboundTestBatch]);
 
-  useEffect(() => {
-    const timer = window.setInterval(() => {
-      const dirtyXray = oldXraySettingRef.current !== xraySettingRef.current;
-      const dirtyUrl = oldOutboundTestUrlRef.current !== outboundTestUrlRef.current;
-      setSaveDisabled(!(dirtyXray || dirtyUrl));
-    }, DIRTY_POLL_MS);
-    return () => window.clearInterval(timer);
-  }, []);
+  const saveDisabled = oldXraySettingRef.current === xraySetting
+    && oldOutboundTestUrlRef.current === outboundTestUrl;
 
   const outboundsTraffic = useMemo(() => trafficQuery.data ?? [], [trafficQuery.data]);
 

--- a/frontend/src/hooks/useXraySetting.ts
+++ b/frontend/src/hooks/useXraySetting.ts
@@ -21,6 +21,10 @@ const DEFAULT_TEST_URL = 'https://www.google.com/generate_204';
 // results progressively.
 const HTTP_BATCH_CHUNK = 16;
 
+function normalizeOutboundTestUrl(url: string) {
+  return url || DEFAULT_TEST_URL;
+}
+
 export function isUdpOutbound(outbound: unknown): boolean {
   const o = outbound as { protocol?: string; streamSettings?: { network?: string } } | null | undefined;
   const p = o?.protocol;
@@ -127,6 +131,8 @@ export function useXraySetting(): UseXraySettingResult {
   const [xraySetting, setXraySettingState] = useState('');
   const [templateSettings, setTemplateSettingsState] = useState<XraySettingsValue | null>(null);
   const [outboundTestUrl, setOutboundTestUrlState] = useState(DEFAULT_TEST_URL);
+  const [savedXraySetting, setSavedXraySetting] = useState('');
+  const [savedOutboundTestUrl, setSavedOutboundTestUrl] = useState(DEFAULT_TEST_URL);
   const [inboundTags, setInboundTags] = useState<string[]>([]);
   const [clientReverseTags, setClientReverseTags] = useState<string[]>([]);
   const [subscriptionOutbounds, setSubscriptionOutbounds] = useState<unknown[]>([]);
@@ -137,40 +143,40 @@ export function useXraySetting(): UseXraySettingResult {
   const [subscriptionTestStates, setSubscriptionTestStates] = useState<Record<string, OutboundTestState>>({});
   const [testingAll, setTestingAll] = useState(false);
 
-  const oldXraySettingRef = useRef('');
-  const oldOutboundTestUrlRef = useRef(DEFAULT_TEST_URL);
   const syncingRef = useRef(false);
   const xraySettingRef = useRef('');
   const outboundTestUrlRef = useRef(outboundTestUrl);
+  const savedXraySettingRef = useRef(savedXraySetting);
+  const savedOutboundTestUrlRef = useRef(savedOutboundTestUrl);
   const templateSettingsRef = useRef<XraySettingsValue | null>(null);
   const subscriptionOutboundsRef = useRef<unknown[]>([]);
 
   xraySettingRef.current = xraySetting;
   outboundTestUrlRef.current = outboundTestUrl;
+  savedXraySettingRef.current = savedXraySetting;
+  savedOutboundTestUrlRef.current = savedOutboundTestUrl;
   templateSettingsRef.current = templateSettings;
   subscriptionOutboundsRef.current = subscriptionOutbounds;
 
-  // Seed local editor state from the config query. Runs on first fetch and
-  // every time the query refetches (e.g. after a successful save).
   useEffect(() => {
     if (!configQuery.data) return;
     const obj = configQuery.data;
     const pretty = JSON.stringify(obj.xraySetting, null, 2);
-    const isDirty = oldXraySettingRef.current !== xraySettingRef.current
-      || oldOutboundTestUrlRef.current !== outboundTestUrlRef.current;
-    if (isDirty) return;
-    syncingRef.current = true;
-    setXraySettingState(pretty);
-    setTemplateSettingsState(obj.xraySetting);
-    oldXraySettingRef.current = pretty;
-    syncingRef.current = false;
+    const nextUrl = normalizeOutboundTestUrl(obj.outboundTestUrl || '');
     setInboundTags(obj.inboundTags || []);
     setClientReverseTags(obj.clientReverseTags || []);
     setSubscriptionOutbounds(obj.subscriptionOutbounds || []);
     setSubscriptionOutboundTags(obj.subscriptionOutboundTags || []);
-    const nextUrl = obj.outboundTestUrl || DEFAULT_TEST_URL;
+    const isDirty = savedXraySettingRef.current !== xraySettingRef.current
+      || savedOutboundTestUrlRef.current !== normalizeOutboundTestUrl(outboundTestUrlRef.current);
+    if (isDirty) return;
+    syncingRef.current = true;
+    setXraySettingState(pretty);
+    setTemplateSettingsState(obj.xraySetting);
+    setSavedXraySetting(pretty);
+    syncingRef.current = false;
     setOutboundTestUrlState(nextUrl);
-    oldOutboundTestUrlRef.current = nextUrl;
+    setSavedOutboundTestUrl(nextUrl);
   }, [configQuery.data]);
 
   const fetched = configQuery.data !== undefined || configQuery.isError;
@@ -220,7 +226,7 @@ export function useXraySetting(): UseXraySettingResult {
   const saveMut = useMutation({
     mutationFn: async () => {
       const sentXraySetting = xraySettingRef.current;
-      const sentTestUrl = outboundTestUrlRef.current || DEFAULT_TEST_URL;
+      const sentTestUrl = normalizeOutboundTestUrl(outboundTestUrlRef.current);
       const msg = await HttpUtil.post('/panel/api/xray/update', {
         xraySetting: sentXraySetting,
         outboundTestUrl: sentTestUrl,
@@ -229,8 +235,8 @@ export function useXraySetting(): UseXraySettingResult {
     },
     onSuccess: ({ msg, sentXraySetting, sentTestUrl }) => {
       if (!msg?.success) return;
-      oldXraySettingRef.current = sentXraySetting;
-      oldOutboundTestUrlRef.current = sentTestUrl;
+      setSavedXraySetting(sentXraySetting);
+      setSavedOutboundTestUrl(sentTestUrl);
       queryClient.invalidateQueries({ queryKey: keys.xray.config() });
     },
   });
@@ -424,8 +430,8 @@ export function useXraySetting(): UseXraySettingResult {
     }
   }, [testingAll, testOutbound, testSubscriptionOutbound, postOutboundTestBatch]);
 
-  const saveDisabled = oldXraySettingRef.current === xraySetting
-    && oldOutboundTestUrlRef.current === outboundTestUrl;
+  const saveDisabled = savedXraySetting === xraySetting
+    && savedOutboundTestUrl === normalizeOutboundTestUrl(outboundTestUrl);
 
   const outboundsTraffic = useMemo(() => trafficQuery.data ?? [], [trafficQuery.data]);
 

--- a/frontend/src/test/use-all-settings.test.tsx
+++ b/frontend/src/test/use-all-settings.test.tsx
@@ -4,6 +4,7 @@ import { QueryClientProvider } from '@tanstack/react-query';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { useAllSettings } from '@/api/queries/useAllSettings';
+import { keys } from '@/api/queryKeys';
 import { makeTestQueryClient } from '@/test/test-utils';
 import { HttpUtil, Msg } from '@/utils';
 
@@ -24,5 +25,25 @@ describe('useAllSettings', () => {
 
     await waitFor(() => expect(result.current.fetched).toBe(true));
     expect(result.current.allSetting.subJsonUserAgentRegex).toBe(subJsonUserAgentRegex);
+  });
+
+  it('keeps an edited setting when a refetch returns older server data', async () => {
+    const values = [
+      { webPort: 2053 },
+      { webPort: 2054 },
+    ];
+    let index = 0;
+    vi.spyOn(HttpUtil, 'post').mockImplementation(async () => new Msg(true, '', values[index++]));
+    const queryClient = makeTestQueryClient();
+    const wrapper = ({ children }: { children: ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+    const { result } = renderHook(() => useAllSettings(), { wrapper });
+
+    await waitFor(() => expect(result.current.fetched).toBe(true));
+    result.current.updateSetting({ webPort: 3000 });
+    await queryClient.invalidateQueries({ queryKey: keys.settings.all() });
+
+    await waitFor(() => expect(result.current.allSetting.webPort).toBe(3000));
   });
 });

--- a/frontend/src/test/use-all-settings.test.tsx
+++ b/frontend/src/test/use-all-settings.test.tsx
@@ -1,5 +1,5 @@
 import type { ReactNode } from 'react';
-import { renderHook, waitFor } from '@testing-library/react';
+import { act, renderHook, waitFor } from '@testing-library/react';
 import { QueryClientProvider } from '@tanstack/react-query';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
@@ -41,9 +41,38 @@ describe('useAllSettings', () => {
     const { result } = renderHook(() => useAllSettings(), { wrapper });
 
     await waitFor(() => expect(result.current.fetched).toBe(true));
-    result.current.updateSetting({ webPort: 3000 });
+    act(() => result.current.updateSetting({ webPort: 3000 }));
     await queryClient.invalidateQueries({ queryKey: keys.settings.all() });
 
-    await waitFor(() => expect(result.current.allSetting.webPort).toBe(3000));
+    await waitFor(() => expect(HttpUtil.post).toHaveBeenCalledTimes(2));
+    expect(result.current.allSetting.webPort).toBe(3000);
+    expect(result.current.saveDisabled).toBe(false);
+  });
+
+  it('hydrates redacted secrets after a successful save', async () => {
+    let fetchCount = 0;
+    vi.spyOn(HttpUtil, 'post').mockImplementation(async (url) => {
+      if (url === '/panel/api/setting/all') {
+        fetchCount += 1;
+        return new Msg(true, '', fetchCount === 1 ? { hasTgBotToken: false } : { hasTgBotToken: true, tgBotToken: '' });
+      }
+      return new Msg(true, '');
+    });
+    const queryClient = makeTestQueryClient();
+    const wrapper = ({ children }: { children: ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+    const { result } = renderHook(() => useAllSettings(), { wrapper });
+
+    await waitFor(() => expect(result.current.fetched).toBe(true));
+    act(() => result.current.updateSetting({ tgBotToken: 'secret' }));
+    await act(async () => {
+      await result.current.saveAll();
+    });
+
+    await waitFor(() => expect(HttpUtil.post).toHaveBeenCalledTimes(3));
+    expect(result.current.allSetting.tgBotToken).toBe('');
+    expect(result.current.allSetting.hasTgBotToken).toBe(true);
+    expect(result.current.saveDisabled).toBe(true);
   });
 });

--- a/frontend/src/test/use-xray-setting.test.tsx
+++ b/frontend/src/test/use-xray-setting.test.tsx
@@ -1,0 +1,71 @@
+import type { ReactNode } from 'react';
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { QueryClientProvider } from '@tanstack/react-query';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { useXraySetting } from '@/hooks/useXraySetting';
+import { makeTestQueryClient } from '@/test/test-utils';
+import { HttpUtil, Msg } from '@/utils';
+
+function xrayPayload(overrides: Record<string, unknown> = {}) {
+  return {
+    xraySetting: {},
+    inboundTags: [],
+    clientReverseTags: [],
+    outboundTestUrl: 'https://test.example',
+    subscriptionOutbounds: [],
+    subscriptionOutboundTags: [],
+    ...overrides,
+  };
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('useXraySetting', () => {
+  it('refreshes server-derived outbounds while the editor is dirty', async () => {
+    let payload = xrayPayload({ subscriptionOutbounds: [{ tag: 'before' }] });
+    vi.spyOn(HttpUtil, 'post').mockImplementation(async (url) => {
+      if (url === '/panel/api/xray/') return new Msg(true, '', JSON.stringify(payload));
+      return new Msg(true, '');
+    });
+    const queryClient = makeTestQueryClient();
+    const wrapper = ({ children }: { children: ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+    const { result } = renderHook(() => useXraySetting(), { wrapper });
+
+    await waitFor(() => expect(result.current.fetched).toBe(true));
+    act(() => result.current.setXraySetting('{"outbounds":[]}'));
+    payload = xrayPayload({ subscriptionOutbounds: [{ tag: 'after' }] });
+    await act(async () => result.current.fetchAll());
+
+    await waitFor(() => expect(result.current.subscriptionOutbounds).toEqual([{ tag: 'after' }]));
+    expect(result.current.xraySetting).toBe('{"outbounds":[]}');
+  });
+
+  it('becomes clean after saving an empty outbound test URL', async () => {
+    let payload = xrayPayload();
+    vi.spyOn(HttpUtil, 'post').mockImplementation(async (url) => {
+      if (url === '/panel/api/xray/') return new Msg(true, '', JSON.stringify(payload));
+      if (url === '/panel/api/xray/update') {
+        payload = xrayPayload({ outboundTestUrl: 'https://www.google.com/generate_204' });
+        return new Msg(true, '');
+      }
+      return new Msg(true, '');
+    });
+    const queryClient = makeTestQueryClient();
+    const wrapper = ({ children }: { children: ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+    const { result } = renderHook(() => useXraySetting(), { wrapper });
+
+    await waitFor(() => expect(result.current.fetched).toBe(true));
+    act(() => result.current.setOutboundTestUrl(''));
+    expect(result.current.saveDisabled).toBe(false);
+    await act(async () => result.current.saveAll());
+
+    await waitFor(() => expect(result.current.saveDisabled).toBe(true));
+  });
+});

--- a/frontend/src/test/useServerDraft.test.tsx
+++ b/frontend/src/test/useServerDraft.test.tsx
@@ -1,0 +1,47 @@
+import { act, renderHook } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import { useServerDraft } from '@/hooks/useServerDraft';
+
+describe('useServerDraft', () => {
+  it('keeps an edited draft when the server refetches', () => {
+    const { result, rerender } = renderHook(
+      ({ server }) => useServerDraft(server, (value) => ({ ...value }), (left, right) => left.value === right.value),
+      { initialProps: { server: { value: 'one' } } },
+    );
+
+    act(() => result.current.setDraft({ value: 'edited' }));
+    rerender({ server: { value: 'two' } });
+
+    expect(result.current.draft).toEqual({ value: 'edited' });
+    expect(result.current.isDirty).toBe(true);
+  });
+
+  it('accepts a refetch that matches the saved draft', () => {
+    const { result, rerender } = renderHook(
+      ({ server }) => useServerDraft(server, (value) => ({ ...value }), (left, right) => left.value === right.value),
+      { initialProps: { server: { value: 'one' } } },
+    );
+
+    act(() => result.current.setDraft({ value: 'saved' }));
+    rerender({ server: { value: 'saved' } });
+
+    expect(result.current.draft).toEqual({ value: 'saved' });
+    expect(result.current.isDirty).toBe(false);
+  });
+
+  it('hydrates a clean draft and can explicitly discard edits', () => {
+    const { result, rerender } = renderHook(
+      ({ server }) => useServerDraft(server, (value) => ({ ...value }), (left, right) => left.value === right.value),
+      { initialProps: { server: { value: 'one' } } },
+    );
+
+    rerender({ server: { value: 'two' } });
+    expect(result.current.draft).toEqual({ value: 'two' });
+    act(() => result.current.setDraft({ value: 'edited' }));
+    act(() => result.current.discard());
+
+    expect(result.current.draft).toEqual({ value: 'two' });
+    expect(result.current.isDirty).toBe(false);
+  });
+});

--- a/frontend/src/test/useServerDraft.test.tsx
+++ b/frontend/src/test/useServerDraft.test.tsx
@@ -1,3 +1,4 @@
+import { StrictMode } from 'react';
 import { act, renderHook } from '@testing-library/react';
 import { describe, expect, it } from 'vitest';
 
@@ -27,6 +28,34 @@ describe('useServerDraft', () => {
     rerender({ server: { value: 'saved' } });
 
     expect(result.current.draft).toEqual({ value: 'saved' });
+    expect(result.current.isDirty).toBe(false);
+  });
+
+  it('compares a preserved draft with the latest server value', () => {
+    const { result, rerender } = renderHook(
+      ({ server }) => useServerDraft(server, (value) => ({ ...value }), (left, right) => left.value === right.value),
+      { initialProps: { server: { value: 'one' } } },
+    );
+
+    act(() => result.current.setDraft({ value: 'later' }));
+    rerender({ server: { value: 'saved' } });
+    act(() => result.current.setDraft({ value: 'one' }));
+
+    expect(result.current.isDirty).toBe(true);
+  });
+
+  it('hydrates clean drafts under StrictMode', () => {
+    const { result, rerender } = renderHook(
+      ({ server }) => useServerDraft(server, (value) => ({ ...value }), (left, right) => left.value === right.value),
+      {
+        initialProps: { server: { value: 'one' } },
+        wrapper: StrictMode,
+      },
+    );
+
+    rerender({ server: { value: 'two' } });
+
+    expect(result.current.draft).toEqual({ value: 'two' });
     expect(result.current.isDirty).toBe(false);
   });
 

--- a/frontend/src/test/useServerDraft.test.tsx
+++ b/frontend/src/test/useServerDraft.test.tsx
@@ -59,7 +59,7 @@ describe('useServerDraft', () => {
     expect(result.current.isDirty).toBe(false);
   });
 
-  it('hydrates a clean draft and can explicitly discard edits', () => {
+  it('hydrates a clean draft', () => {
     const { result, rerender } = renderHook(
       ({ server }) => useServerDraft(server, (value) => ({ ...value }), (left, right) => left.value === right.value),
       { initialProps: { server: { value: 'one' } } },
@@ -67,9 +67,6 @@ describe('useServerDraft', () => {
 
     rerender({ server: { value: 'two' } });
     expect(result.current.draft).toEqual({ value: 'two' });
-    act(() => result.current.setDraft({ value: 'edited' }));
-    act(() => result.current.discard());
-
     expect(result.current.draft).toEqual({ value: 'two' });
     expect(result.current.isDirty).toBe(false);
   });


### PR DESCRIPTION
## Prerequisite

Includes #6146 because its confirmed Storybook contrast correction is required for this branch to pass the shared frontend CI. Merge #6146 first; this PR will then reduce to the draft-hydration change.

## Summary

- Preserve Settings and Xray edits across background refetches.
- Keep read-only Xray projections refreshing while the editable draft is dirty.
- Remove the one-second dirty-state polling loop.

## Validation

- `npm run test -- useServerDraft.test.tsx use-xray-setting.test.tsx use-all-settings.test.tsx`
- `npm run typecheck`
- #6146 full CI is green.