### PR TITLE
fix(frontend): preserve config block themes

### DIFF
--- a/frontend/.storybook/preview.tsx
+++ b/frontend/.storybook/preview.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from 'react';
+import { useLayoutEffect } from 'react';
 import type { Decorator, Preview } from '@storybook/react-vite';
 import { ConfigProvider } from 'antd';
 import i18next from 'i18next';
@@ -19,8 +19,9 @@ if (!i18next.isInitialized) {
 
 const withTheme: Decorator = (Story, context) => {
   const dark = context.globals.theme === 'dark';
-  useEffect(() => {
-    document.body.setAttribute('class', dark ? 'dark' : 'light');
+  useLayoutEffect(() => {
+    document.body.classList.remove('dark', 'light');
+    document.body.classList.add(dark ? 'dark' : 'light');
     document.documentElement.setAttribute('data-theme', dark ? 'dark' : 'light');
   }, [dark]);
   return (

--- a/frontend/src/components/clients/ConfigBlock.css
+++ b/frontend/src/components/clients/ConfigBlock.css
@@ -42,8 +42,13 @@ body.light .config-block-text {
   word-break: break-all;
   white-space: pre-wrap;
   padding: 6px 8px;
-  color: var(--ant-color-text);
-  background: var(--ant-color-fill-tertiary);
+  color: #595959;
+  background: #f5f5f5;
   border-radius: 4px;
   user-select: all;
+}
+
+body.dark .config-block-text {
+  color: #d9d9d9;
+  background: #141414;
 }

--- a/frontend/src/components/clients/ConfigBlock.css
+++ b/frontend/src/components/clients/ConfigBlock.css
@@ -16,10 +16,6 @@ body.light .config-block .ant-tag.ant-tag-filled.ant-tag-gold {
   color: #874d00;
 }
 
-body.light .config-block-text {
-  color: #595959;
-}
-
 .config-block .ant-collapse-extra {
   display: flex;
   align-items: center;
@@ -46,9 +42,4 @@ body.light .config-block-text {
   background: #f5f5f5;
   border-radius: 4px;
   user-select: all;
-}
-
-body.dark .config-block-text {
-  color: #d9d9d9;
-  background: #141414;
 }

--- a/frontend/src/components/clients/ConfigBlock.css
+++ b/frontend/src/components/clients/ConfigBlock.css
@@ -38,8 +38,13 @@ body.light .config-block .ant-tag.ant-tag-filled.ant-tag-gold {
   word-break: break-all;
   white-space: pre-wrap;
   padding: 6px 8px;
-  color: #595959;
-  background: #f5f5f5;
+  color: var(--ant-color-text);
+  background: var(--ant-color-fill-tertiary);
   border-radius: 4px;
   user-select: all;
+}
+
+body.light .config-block-text {
+  color: #595959;
+  background: #f5f5f5;
 }


### PR DESCRIPTION
## Summary

- Keep production ConfigBlock colors token-driven outside light mode.
- Pin the light-mode foreground/background pair at the component boundary so its code text has sufficient contrast.
- Switch Storybook theme setup to additive body classes, preserving Storybook's own classes.

## Validation

- `PLAYWRIGHT_BROWSERS_PATH=0 npx vitest run --project storybook src/components/clients/ConfigBlock.stories.tsx`
- `npm run typecheck`

## Notes

The browser accessibility review identified the low-contrast light-mode code block. The production stylesheet keeps dark and ultra-dark values controlled by Ant Design theme tokens; the explicit colors apply only under `body.light`.