### PR TITLE
fix(frontend): preserve theme body classes

### DIFF
--- a/frontend/.storybook/preview.tsx
+++ b/frontend/.storybook/preview.tsx
@@ -17,7 +17,7 @@ if (!i18next.isInitialized) {
   });
 }
 
-const withTheme: Decorator = (Story, context) => {
+export const withTheme: Decorator = (Story, context) => {
   const dark = context.globals.theme === 'dark';
   useLayoutEffect(() => {
     document.body.classList.remove('dark', 'light');

--- a/frontend/.storybook/preview.tsx
+++ b/frontend/.storybook/preview.tsx
@@ -22,7 +22,7 @@ const withTheme: Decorator = (Story, context) => {
   useLayoutEffect(() => {
     document.body.classList.remove('dark', 'light');
     document.body.classList.add(dark ? 'dark' : 'light');
-    document.documentElement.setAttribute('data-theme', dark ? 'dark' : 'light');
+    document.documentElement.removeAttribute('data-theme');
   }, [dark]);
   return (
     <ConfigProvider theme={buildAntdThemeConfig(dark, false)}>

--- a/frontend/.storybook/preview.tsx
+++ b/frontend/.storybook/preview.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from 'react';
+import { useLayoutEffect } from 'react';
 import type { Decorator, Preview } from '@storybook/react-vite';
 import { ConfigProvider } from 'antd';
 import i18next from 'i18next';
@@ -19,8 +19,9 @@ if (!i18next.isInitialized) {
 
 const withTheme: Decorator = (Story, context) => {
   const dark = context.globals.theme === 'dark';
-  useEffect(() => {
-    document.body.setAttribute('class', dark ? 'dark' : 'light');
+  useLayoutEffect(() => {
+    document.body.classList.remove('dark', 'light');
+    document.body.classList.add(dark ? 'dark' : 'light');
     document.documentElement.setAttribute('data-theme', dark ? 'dark' : 'light');
   }, [dark]);
   return (

--- a/frontend/src/hooks/useTheme.tsx
+++ b/frontend/src/hooks/useTheme.tsx
@@ -1,4 +1,4 @@
-import { createContext, useCallback, useContext, useEffect, useMemo, useState } from 'react';
+import { createContext, useCallback, useContext, useLayoutEffect, useMemo, useState } from 'react';
 import type { ReactNode } from 'react';
 import { theme as antdTheme } from 'antd';
 import type { ThemeConfig } from 'antd';
@@ -13,7 +13,8 @@ function readBool(key: string, fallback: boolean): boolean {
 }
 
 function applyDom(isDark: boolean, isUltra: boolean) {
-  document.body.setAttribute('class', isDark ? 'dark' : 'light');
+  document.body.classList.remove('dark', 'light');
+  document.body.classList.add(isDark ? 'dark' : 'light');
   if (isUltra) {
     document.documentElement.setAttribute('data-theme', 'ultra-dark');
   } else {
@@ -142,7 +143,7 @@ export function ThemeProvider({ children }: { children: ReactNode }) {
   const [isDark, setIsDark] = useState<boolean>(initialDark);
   const [isUltra, setIsUltra] = useState<boolean>(initialUltra);
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     applyDom(isDark, isUltra);
     localStorage.setItem(STORAGE_DARK, String(isDark));
     localStorage.setItem(STORAGE_ULTRA, String(isUltra));

--- a/frontend/src/test/storybook-theme.test.tsx
+++ b/frontend/src/test/storybook-theme.test.tsx
@@ -2,6 +2,7 @@ import { render } from '@testing-library/react';
 import { expect, test } from 'vitest';
 
 import preview from '../../.storybook/preview';
+import { ThemeProvider } from '@/hooks/useTheme';
 
 const decorator = Array.isArray(preview.decorators) ? preview.decorators[0] : preview.decorators;
 
@@ -23,5 +24,15 @@ test('preserves unrelated body classes when applying the Storybook theme', () =>
 
   expect(document.body.classList.contains('storybook-fixture')).toBe(true);
   expect(document.body.classList.contains('light')).toBe(true);
+  document.body.className = '';
+});
+
+test('preserves unrelated body classes when applying the panel theme', () => {
+  document.body.className = 'panel-fixture';
+
+  render(<ThemeProvider><div>Panel</div></ThemeProvider>);
+
+  expect(document.body.classList.contains('panel-fixture')).toBe(true);
+  expect(document.body.classList.contains('dark') || document.body.classList.contains('light')).toBe(true);
   document.body.className = '';
 });

--- a/frontend/src/test/storybook-theme.test.tsx
+++ b/frontend/src/test/storybook-theme.test.tsx
@@ -1,0 +1,27 @@
+import { render } from '@testing-library/react';
+import { expect, test } from 'vitest';
+
+import preview from '../../.storybook/preview';
+
+const decorator = Array.isArray(preview.decorators) ? preview.decorators[0] : preview.decorators;
+
+if (!decorator) throw new Error('Storybook theme decorator is required');
+const storybookDecorator = decorator;
+
+function Story() {
+  return <div>Story</div>;
+}
+
+test('preserves unrelated body classes when applying the Storybook theme', () => {
+  document.body.className = 'storybook-fixture';
+
+  function DecoratedStory() {
+    return storybookDecorator(Story, { globals: { theme: 'light' } } as unknown as Parameters<typeof storybookDecorator>[1]);
+  }
+
+  render(<DecoratedStory />);
+
+  expect(document.body.classList.contains('storybook-fixture')).toBe(true);
+  expect(document.body.classList.contains('light')).toBe(true);
+  document.body.className = '';
+});

--- a/frontend/src/test/storybook-theme.test.tsx
+++ b/frontend/src/test/storybook-theme.test.tsx
@@ -1,31 +1,36 @@
 import { render } from '@testing-library/react';
-import { expect, test } from 'vitest';
+import { afterEach, expect, test } from 'vitest';
 
-import preview from '../../.storybook/preview';
+import { withTheme } from '../../.storybook/preview';
 import { ThemeProvider } from '@/hooks/useTheme';
-
-const decorator = Array.isArray(preview.decorators) ? preview.decorators[0] : preview.decorators;
-
-if (!decorator) throw new Error('Storybook theme decorator is required');
-const storybookDecorator = decorator;
 
 function Story() {
   return <div>Story</div>;
 }
 
+function StorybookTheme({ theme }: { theme: 'light' | 'dark' }) {
+  return withTheme(Story, { globals: { theme } } as Partial<Parameters<typeof withTheme>[1]> as Parameters<typeof withTheme>[1]);
+}
+
+afterEach(() => {
+  document.body.className = '';
+  document.documentElement.removeAttribute('data-theme');
+});
+
 test('preserves unrelated body classes when applying the Storybook theme', () => {
-  document.body.className = 'storybook-fixture';
-
-  function DecoratedStory() {
-    return storybookDecorator(Story, { globals: { theme: 'light' } } as unknown as Parameters<typeof storybookDecorator>[1]);
-  }
-
-  render(<DecoratedStory />);
+  document.body.className = 'storybook-fixture dark';
+  const { rerender } = render(<StorybookTheme theme="light" />);
 
   expect(document.body.classList.contains('storybook-fixture')).toBe(true);
   expect(document.body.classList.contains('light')).toBe(true);
+  expect(document.body.classList.contains('dark')).toBe(false);
   expect(document.documentElement.hasAttribute('data-theme')).toBe(false);
-  document.body.className = '';
+
+  rerender(<StorybookTheme theme="dark" />);
+
+  expect(document.body.classList.contains('storybook-fixture')).toBe(true);
+  expect(document.body.classList.contains('dark')).toBe(true);
+  expect(document.body.classList.contains('light')).toBe(false);
 });
 
 test('preserves unrelated body classes when applying the panel theme', () => {
@@ -35,5 +40,4 @@ test('preserves unrelated body classes when applying the panel theme', () => {
 
   expect(document.body.classList.contains('panel-fixture')).toBe(true);
   expect(document.body.classList.contains('dark') || document.body.classList.contains('light')).toBe(true);
-  document.body.className = '';
 });

--- a/frontend/src/test/storybook-theme.test.tsx
+++ b/frontend/src/test/storybook-theme.test.tsx
@@ -24,6 +24,7 @@ test('preserves unrelated body classes when applying the Storybook theme', () =>
 
   expect(document.body.classList.contains('storybook-fixture')).toBe(true);
   expect(document.body.classList.contains('light')).toBe(true);
+  expect(document.documentElement.hasAttribute('data-theme')).toBe(false);
   document.body.className = '';
 });
 


### PR DESCRIPTION
## Summary

Panel and Storybook theme application now preserve unrelated `<body>` classes instead of replacing the complete class attribute. Theme classes are installed before paint in both paths, and Storybook now mirrors the panel DOM for normal themes by removing `data-theme` rather than inventing `light` or `dark` values.

Regression coverage verifies that the panel and Storybook retain an unrelated body class while applying the selected theme, and that Storybook has no normal-theme `data-theme` attribute.

## Validation

- `npm run test -- storybook-theme.test.tsx`
- `npx vitest run --project storybook src/components/clients/ConfigBlock.stories.tsx`
- `npm run typecheck`
- `npm run lint`