### PR TITLE
fix(link): restore salamander obfuscation when importing a hysteria2 link

### DIFF
--- a/internal/util/link/hysteria2_obfs_test.go
+++ b/internal/util/link/hysteria2_obfs_test.go
@@ -1,0 +1,39 @@
+package link
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestParseHysteria2RestoresSalamanderObfs(t *testing.T) {
+	res, err := ParseLink("hysteria2://auth@example.test:4443?sni=example.test&obfs=salamander&obfs-password=secret123#node")
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	raw, err := json.Marshal(res.Outbound["streamSettings"])
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var stream struct {
+		FinalMask struct {
+			UDP []struct {
+				Type     string `json:"type"`
+				Settings struct {
+					Password string `json:"password"`
+				} `json:"settings"`
+			} `json:"udp"`
+		} `json:"finalmask"`
+	}
+	if err := json.Unmarshal(raw, &stream); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if len(stream.FinalMask.UDP) != 1 {
+		t.Fatalf("finalmask.udp entries = %d, want 1 (obfs was dropped)", len(stream.FinalMask.UDP))
+	}
+	if got := stream.FinalMask.UDP[0].Type; got != "salamander" {
+		t.Fatalf("type = %q, want salamander", got)
+	}
+	if got := stream.FinalMask.UDP[0].Settings.Password; got != "secret123" {
+		t.Fatalf("password = %q, want secret123", got)
+	}
+}

--- a/internal/util/link/outbound.go
+++ b/internal/util/link/outbound.go
@@ -682,7 +682,27 @@ func applyFinalMask(stream map[string]any, p url.Values) {
 		if json.Unmarshal([]byte(fm), &parsed) == nil {
 			sanitizeFinalMaskQuicParams(parsed)
 			stream["finalmask"] = parsed
+			return
 		}
+	}
+	applySalamanderObfs(stream, p)
+}
+
+// applySalamanderObfs restores the obfuscation our own subscriptions emit as the
+// standard obfs fields, which carry no fm= blob to parse.
+func applySalamanderObfs(stream map[string]any, p url.Values) {
+	if p.Get("obfs") != "salamander" {
+		return
+	}
+	pw := p.Get("obfs-password")
+	if pw == "" {
+		return
+	}
+	stream["finalmask"] = map[string]any{
+		"udp": []any{map[string]any{
+			"type":     "salamander",
+			"settings": map[string]any{"password": pw},
+		}},
 	}
 }
 


### PR DESCRIPTION
## Summary
A hysteria2 link produced by this panel loses its obfuscation when imported back: the exporter writes `obfs=salamander` + `obfs-password`, the importer reads only `fm=`.

## Why
`internal/sub/service.go` emits salamander as the standard URI fields and deliberately drops the `fm=<json>` dump — the comment there explains that the non-standard blob breaks mihomo and other Hysteria2 clients. That is the right call for interoperability.

`applyFinalMask` in `internal/util/link/outbound.go` only looks for `fm=`, so nothing restores the obfuscation on the way back in. An outbound built from such a link has no `finalmask`, sends unobfuscated packets to a server that expects salamander, and the handshake fails with no error on either side — no log line, no traffic recorded, nothing to point at the cause.

The round trip is entirely internal: outbound subscriptions and link import both go through this parser, so a panel cannot consume its own subscription output.

## Scope
- `internal/util/link/outbound.go` — `applyFinalMask` returns after a successful `fm=` parse and otherwise falls back to `applySalamanderObfs`, which rebuilds the `finalmask.udp[salamander]` entry from `obfs` / `obfs-password`.
- `internal/util/link/hysteria2_obfs_test.go` — parses a link carrying the standard fields and asserts the password lands in `finalmask`.

## Validation
- `go test ./internal/util/link/ -count=1` green; `go build ./...`, `go vet`, `gofmt -l` clean.
- Verified the test fails without the fix: `finalmask.udp entries = 0, want 1`.

## Risk
Low. `fm=` keeps priority and its behaviour is unchanged; the new path only runs when there is no `fm=` to parse. Only `obfs=salamander` is handled — any other `obfs` value is ignored, as before.
