### PR TITLE
chore(frontend): resolve the high-severity brace-expansion advisory

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -4567,6 +4567,18 @@
         "@swagger-api/apidom-parser-adapter-yaml-1-2": "^1.12.0"
       }
     },
+    "node_modules/@swagger-api/apidom-reference/node_modules/brace-expansion": {
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
     "node_modules/@swagger-api/apidom-reference/node_modules/minimatch": {
       "version": "10.2.6",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.6.tgz",
@@ -5928,6 +5940,7 @@
       "version": "5.0.8",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
       "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -89,7 +89,8 @@
       "react": "^19.0.0"
     },
     "swagger-ui-react": {
-      "js-yaml": "^4.2.0"
+      "js-yaml": "^4.2.0",
+      "brace-expansion": "^5.0.9"
     },
     "@typeschema/valibot": {
       "valibot": "^1.1.0"


### PR DESCRIPTION
## Summary
The `frontend` CI job fails on `main` because `npm audit --omit=dev --audit-level=high` reports GHSA-rgw5-rvv9-x895 in `brace-expansion`. Pin the patched 5.0.9 for the production path.

## Why
`npm audit --omit=dev --audit-level=high` is a hard gate in `ci.yml`, and it is currently red on `main` itself — run [30898275209](https://github.com/MHSanaei/3x-ui/actions/runs/30898275209) on `38838827`. Every pull request inherits the failure, which makes the job useless as a signal: a real advisory introduced by a PR would look exactly like today's noise.

The production path is:

```
swagger-ui-react → swagger-client → @swagger-api/apidom-reference → minimatch@10.2.6 → brace-expansion@5.0.8
```

`5.0.8` is inside the advisory's affected range (`4.0.0 - 5.0.8`); `5.0.9` is the fix.

## Scope
- `frontend/package.json` — `brace-expansion: ^5.0.9` added to the **existing** `swagger-ui-react` overrides block, next to the `js-yaml` override already there.
- `frontend/package-lock.json` — regenerated.

Scoped rather than global on purpose: `eslint-plugin-jsx-a11y` still resolves `minimatch@3`, which requires `brace-expansion@^1.1.7`, and a top-level override would force v5 into that subtree as well. After the change the tree keeps `1.1.16` where it belongs and only the swagger path moves.

## Validation
- `npm ci --ignore-scripts` from the regenerated lockfile, then `npm ls brace-expansion` shows `5.0.9` under the swagger path and `1.1.16` unchanged under `eslint-plugin-jsx-a11y`.
- `npm audit --omit=dev --audit-level=high` → `found 0 vulnerabilities`.
- `npm run typecheck` and `npm run build` both clean.

## Risk
Low. A patch-level bump of a transitive dependency, scoped to one subtree; no source change and no behaviour change in the app.
