### PR TITLE
fix(db): harden freedom outbounds that carry no final rules at all

### DIFF
--- a/internal/database/db.go
+++ b/internal/database/db.go
@@ -1628,6 +1628,14 @@ func isLegacyPrivateOnlyFinalRules(v any) bool {
 	return true
 }
 
+func isUnrestrictedFreedomFinalRules(v any, present bool) bool {
+	if !present || v == nil {
+		return true
+	}
+	rules, ok := v.([]any)
+	return ok && len(rules) == 0
+}
+
 func hardenFreedomFinalRules() error {
 	var setting model.Setting
 	err := db.Model(model.Setting{}).Where("key = ?", "xrayTemplateConfig").First(&setting).Error
@@ -1680,7 +1688,10 @@ func rewriteFreedomFinalRulesPrivateEgress(raw string) (string, bool, error) {
 		if !ok {
 			continue
 		}
-		if !isAllowOnlyFinalRules(settings["finalRules"]) && !isLegacyPrivateOnlyFinalRules(settings["finalRules"]) {
+		finalRules, present := settings["finalRules"]
+		if !isUnrestrictedFreedomFinalRules(finalRules, present) &&
+			!isAllowOnlyFinalRules(finalRules) &&
+			!isLegacyPrivateOnlyFinalRules(finalRules) {
 			continue
 		}
 		settings["finalRules"] = []any{

--- a/internal/database/freedom_finalrules_migration_test.go
+++ b/internal/database/freedom_finalrules_migration_test.go
@@ -24,6 +24,24 @@ func TestRewriteFreedomFinalRulesPrivateEgress(t *testing.T) {
 			wantRules:   hardened,
 		},
 		{
+			name:        "missing finalRules is hardened",
+			raw:         `{"outbounds":[{"protocol":"freedom","settings":{"domainStrategy":"AsIs"},"tag":"direct"}]}`,
+			wantChanged: true,
+			wantRules:   hardened,
+		},
+		{
+			name:        "null finalRules is hardened",
+			raw:         `{"outbounds":[{"protocol":"freedom","settings":{"domainStrategy":"AsIs","finalRules":null},"tag":"direct"}]}`,
+			wantChanged: true,
+			wantRules:   hardened,
+		},
+		{
+			name:        "empty finalRules is hardened",
+			raw:         `{"outbounds":[{"protocol":"freedom","settings":{"domainStrategy":"AsIs","finalRules":[]},"tag":"direct"}]}`,
+			wantChanged: true,
+			wantRules:   hardened,
+		},
+		{
 			name:        "legacy private-only allow is hardened",
 			raw:         `{"outbounds":[{"protocol":"freedom","settings":{"finalRules":[{"action":"allow","ip":["geoip:private"]}]},"tag":"direct"}]}`,
 			wantChanged: true,
@@ -73,6 +91,40 @@ func TestRewriteFreedomFinalRulesPrivateEgress(t *testing.T) {
 				t.Fatalf("finalRules = %s, want %s", gotRules, wantRules)
 			}
 		})
+	}
+}
+
+func TestRewriteFreedomFinalRulesPreservesSplitRouting(t *testing.T) {
+	const raw = `{
+		"outbounds":[{"protocol":"freedom","settings":{"domainStrategy":"AsIs"},"tag":"direct"}],
+		"routing":{"domainStrategy":"AsIs","rules":[
+			{"type":"field","domain":["regexp:.*\\.ru$"],"outboundTag":"direct"},
+			{"type":"field","network":"tcp,udp","outboundTag":"proxy"}
+		]}
+	}`
+	updated, changed, err := rewriteFreedomFinalRulesPrivateEgress(raw)
+	if err != nil {
+		t.Fatalf("rewrite: %v", err)
+	}
+	if !changed {
+		t.Fatal("missing finalRules must be hardened")
+	}
+	var before, after map[string]any
+	if err := json.Unmarshal([]byte(raw), &before); err != nil {
+		t.Fatalf("decode before: %v", err)
+	}
+	if err := json.Unmarshal([]byte(updated), &after); err != nil {
+		t.Fatalf("decode after: %v", err)
+	}
+	beforeRouting, _ := json.Marshal(before["routing"])
+	afterRouting, _ := json.Marshal(after["routing"])
+	if string(afterRouting) != string(beforeRouting) {
+		t.Fatalf("split routing changed:\n got %s\nwant %s", afterRouting, beforeRouting)
+	}
+	outbound := after["outbounds"].([]any)[0].(map[string]any)
+	settings := outbound["settings"].(map[string]any)
+	if settings["domainStrategy"] != "AsIs" {
+		t.Fatalf("freedom domainStrategy=%v want AsIs", settings["domainStrategy"])
 	}
 }
 


### PR DESCRIPTION
## Summary

Let the `FreedomFinalRulesPrivateEgressBlock` seeder also harden `freedom` outbounds that carry no `finalRules` key at all, or an empty one.

## Why

`rewriteFreedomFinalRulesPrivateEgress` only rewrites an outbound when its existing `finalRules` are recognised as one of two shapes: allow-only (`isAllowOnlyFinalRules`) or the legacy private-only rule (`isLegacyPrivateOnlyFinalRules`). Anything else is left untouched, on the reasonable principle of not overwriting a deliberate configuration.

The gap is what falls outside both shapes at the permissive end. A `freedom` outbound with no `finalRules` key, or with `"finalRules": []`, is the *least* restricted configuration there is — nothing constrains its egress, including into private ranges reachable from the host. That case matched neither recogniser, so the seeder skipped it.

The result inverts the intent: the hardening pass fixed outbounds that already had some restriction expressed and walked past the ones that had none.

## Scope

- New `isUnrestrictedFreedomFinalRules(v, present)` returns true when the key is absent, nil, or an empty array — the shapes that express "no restriction" rather than a deliberate policy.
- `rewriteFreedomFinalRulesPrivateEgress` reads `finalRules` with the two-value form so it can distinguish "absent" from "present but empty", and treats both as eligible alongside the two existing shapes.
- A populated `finalRules` that matches neither recogniser is still left alone, unchanged.

## Validation

- `go build ./internal/...` clean.
- `go test ./internal/database/` green on `main` at `ece16559` with this applied, including new cases for the absent and empty-array shapes.
- Cherry-picks onto current `main` without conflict.

## Risk

Low. The seeder runs once and is recorded in `HistoryOfSeeders`, so behaviour for already-seeded installs is unchanged. The widening is strictly toward configurations that expressed no policy; anything with rules the recognisers do not understand keeps being skipped exactly as before.
