### PR TITLE
fix(nodes): validate every certificate in the node mTLS trust bundle

### DIFF
--- a/internal/web/service/node_mtls.go
+++ b/internal/web/service/node_mtls.go
@@ -2,8 +2,6 @@ package service
 
 import (
 	"crypto/tls"
-	"crypto/x509"
-	"encoding/pem"
 	"strings"
 
 	"github.com/mhsanaei/3x-ui/v3/internal/util/common"
@@ -49,12 +47,8 @@ func (s *NodeService) ReloadMasterMtlsClient() error {
 func (s *NodeService) SetNodeMtlsTrustCA(caPem string) error {
 	caPem = strings.TrimSpace(caPem)
 	if caPem != "" {
-		block, _ := pem.Decode([]byte(caPem))
-		if block == nil || block.Type != "CERTIFICATE" {
-			return common.NewError("trust CA must be a PEM-encoded certificate")
-		}
-		if _, err := x509.ParseCertificate(block.Bytes); err != nil {
-			return common.NewError("invalid trust CA certificate: " + err.Error())
+		if _, err := parseCertificateBundlePEM([]byte(caPem)); err != nil {
+			return common.NewError("invalid trust CA certificate bundle: ", err)
 		}
 	}
 	return (&SettingService{}).setString(settingNodeMtlsClientCA, caPem)

--- a/internal/web/service/node_mtls.go
+++ b/internal/web/service/node_mtls.go
@@ -40,10 +40,8 @@ func (s *NodeService) ReloadMasterMtlsClient() error {
 	return nil
 }
 
-// SetNodeMtlsTrustCA stores the CA certificate this panel trusts for incoming
-// node-API client certificates. An empty value clears it (mTLS off). A
-// non-empty value must be a PEM certificate (fail closed). Takes effect on the
-// next panel restart, when the listener's ClientCAs is rebuilt.
+// SetNodeMtlsTrustCA stores the CA certificate bundle trusted for incoming
+// node-API clients. An empty value clears it; changes apply after restart.
 func (s *NodeService) SetNodeMtlsTrustCA(caPem string) error {
 	caPem = strings.TrimSpace(caPem)
 	if caPem != "" {

--- a/internal/web/service/setting_mtls.go
+++ b/internal/web/service/setting_mtls.go
@@ -1,6 +1,7 @@
 package service
 
 import (
+	"bytes"
 	"crypto/sha256"
 	"crypto/tls"
 	"crypto/x509"
@@ -189,9 +190,42 @@ func (s *SettingService) NodeMtlsClientCAPool() (*x509.CertPool, error) {
 	if caPem == "" {
 		return nil, nil
 	}
+	certs, err := parseCertificateBundlePEM([]byte(caPem))
+	if err != nil {
+		return nil, common.NewError("nodeMtlsClientCAPem is not a valid certificate bundle: ", err)
+	}
 	pool := x509.NewCertPool()
-	if !pool.AppendCertsFromPEM([]byte(caPem)) {
-		return nil, common.NewError("nodeMtlsClientCAPem is not a valid certificate")
+	for _, cert := range certs {
+		pool.AddCert(cert)
 	}
 	return pool, nil
+}
+
+// parseCertificateBundlePEM validates every non-whitespace byte of a PEM
+// certificate bundle and returns the certificates it contains.
+// x509.CertPool.AppendCertsFromPEM reports success once it has parsed a single
+// certificate, so a bundle whose later entries are damaged or truncated is
+// accepted with those entries silently missing from the pool.
+func parseCertificateBundlePEM(bundle []byte) ([]*x509.Certificate, error) {
+	rest := bytes.TrimSpace(bundle)
+	if len(rest) == 0 {
+		return nil, common.NewError("certificate bundle is empty")
+	}
+	certs := make([]*x509.Certificate, 0, 1)
+	for len(rest) > 0 {
+		block, next := pem.Decode(rest)
+		if block == nil {
+			return nil, common.NewError("certificate bundle contains malformed or non-PEM data")
+		}
+		if block.Type != "CERTIFICATE" {
+			return nil, common.NewError("certificate bundle contains a non-certificate PEM block")
+		}
+		cert, err := x509.ParseCertificate(block.Bytes)
+		if err != nil {
+			return nil, err
+		}
+		certs = append(certs, cert)
+		rest = bytes.TrimSpace(next)
+	}
+	return certs, nil
 }

--- a/internal/web/service/setting_mtls.go
+++ b/internal/web/service/setting_mtls.go
@@ -7,6 +7,8 @@ import (
 	"crypto/x509"
 	"encoding/hex"
 	"encoding/pem"
+	"errors"
+	"fmt"
 	"strings"
 	"sync"
 
@@ -192,7 +194,7 @@ func (s *SettingService) NodeMtlsClientCAPool() (*x509.CertPool, error) {
 	}
 	certs, err := parseCertificateBundlePEM([]byte(caPem))
 	if err != nil {
-		return nil, common.NewError("nodeMtlsClientCAPem is not a valid certificate bundle: ", err)
+		return nil, fmt.Errorf("nodeMtlsClientCAPem is not a valid certificate bundle: %w", err)
 	}
 	pool := x509.NewCertPool()
 	for _, cert := range certs {
@@ -201,28 +203,28 @@ func (s *SettingService) NodeMtlsClientCAPool() (*x509.CertPool, error) {
 	return pool, nil
 }
 
-// parseCertificateBundlePEM validates every non-whitespace byte of a PEM
-// certificate bundle and returns the certificates it contains.
-// x509.CertPool.AppendCertsFromPEM reports success once it has parsed a single
-// certificate, so a bundle whose later entries are damaged or truncated is
-// accepted with those entries silently missing from the pool.
+// parseCertificateBundlePEM avoids AppendCertsFromPEM because that helper can
+// silently accept a bundle after parsing only its first certificate.
 func parseCertificateBundlePEM(bundle []byte) ([]*x509.Certificate, error) {
 	rest := bytes.TrimSpace(bundle)
 	if len(rest) == 0 {
-		return nil, common.NewError("certificate bundle is empty")
+		return nil, errors.New("certificate bundle is empty")
 	}
 	certs := make([]*x509.Certificate, 0, 1)
 	for len(rest) > 0 {
+		if !bytes.HasPrefix(rest, []byte("-----BEGIN CERTIFICATE-----")) {
+			return nil, errors.New("certificate bundle contains malformed or non-PEM data")
+		}
 		block, next := pem.Decode(rest)
 		if block == nil {
-			return nil, common.NewError("certificate bundle contains malformed or non-PEM data")
+			return nil, errors.New("certificate bundle contains malformed or non-PEM data")
 		}
 		if block.Type != "CERTIFICATE" {
-			return nil, common.NewError("certificate bundle contains a non-certificate PEM block")
+			return nil, errors.New("certificate bundle contains a non-certificate PEM block")
 		}
 		cert, err := x509.ParseCertificate(block.Bytes)
 		if err != nil {
-			return nil, err
+			return nil, errors.New("certificate bundle contains an invalid certificate")
 		}
 		certs = append(certs, cert)
 		rest = bytes.TrimSpace(next)

--- a/internal/web/service/setting_mtls_bundle_test.go
+++ b/internal/web/service/setting_mtls_bundle_test.go
@@ -26,23 +26,25 @@ func TestParseCertificateBundlePEM(t *testing.T) {
 		name      string
 		bundle    string
 		wantCerts int
-		wantErr   bool
+		wantErr   string
 	}{
 		{name: "single certificate", bundle: first, wantCerts: 1},
 		{name: "two certificates", bundle: first + second, wantCerts: 2},
-		{name: "empty", bundle: "", wantErr: true},
-		{name: "whitespace only", bundle: "\n\t  \n", wantErr: true},
-		{name: "second certificate corrupt", bundle: first + corrupt, wantErr: true},
-		{name: "trailing non-PEM data", bundle: first + "not a certificate\n", wantErr: true},
-		{name: "non-certificate block", bundle: first + "-----BEGIN PRIVATE KEY-----\nAAAA\n-----END PRIVATE KEY-----\n", wantErr: true},
+		{name: "empty", bundle: "", wantErr: "certificate bundle is empty"},
+		{name: "whitespace only", bundle: "\n\t  \n", wantErr: "certificate bundle is empty"},
+		{name: "leading non-PEM data", bundle: "junk\n" + first, wantErr: "certificate bundle contains malformed or non-PEM data"},
+		{name: "interstitial non-PEM data", bundle: first + "junk\n" + second, wantErr: "certificate bundle contains malformed or non-PEM data"},
+		{name: "second certificate corrupt", bundle: first + corrupt, wantErr: "certificate bundle contains malformed or non-PEM data"},
+		{name: "trailing non-PEM data", bundle: first + "not a certificate\n", wantErr: "certificate bundle contains malformed or non-PEM data"},
+		{name: "non-certificate block", bundle: first + "-----BEGIN PRIVATE KEY-----\nAAAA\n-----END PRIVATE KEY-----\n", wantErr: "certificate bundle contains malformed or non-PEM data"},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			certs, err := parseCertificateBundlePEM([]byte(tt.bundle))
-			if tt.wantErr {
-				if err == nil {
-					t.Fatalf("parseCertificateBundlePEM() = %d certs, want an error", len(certs))
+			if tt.wantErr != "" {
+				if err == nil || err.Error() != tt.wantErr {
+					t.Fatalf("parseCertificateBundlePEM() error = %v, want %q", err, tt.wantErr)
 				}
 				return
 			}
@@ -65,7 +67,8 @@ func TestNodeMtlsClientCAPoolRejectsPartiallyValidBundle(t *testing.T) {
 	}
 
 	pool, err := s.NodeMtlsClientCAPool()
-	if err == nil {
-		t.Fatalf("NodeMtlsClientCAPool() = %v, want an error for a partially valid bundle", pool)
+	want := "nodeMtlsClientCAPem is not a valid certificate bundle: certificate bundle contains malformed or non-PEM data"
+	if err == nil || err.Error() != want {
+		t.Fatalf("NodeMtlsClientCAPool() = %v, error = %v, want %q", pool, err, want)
 	}
 }

--- a/internal/web/service/setting_mtls_bundle_test.go
+++ b/internal/web/service/setting_mtls_bundle_test.go
@@ -1,0 +1,71 @@
+package service
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/mhsanaei/3x-ui/v3/internal/util/crypto"
+)
+
+func mustNodeCAPEM(t *testing.T, name string) string {
+	t.Helper()
+	ca, err := crypto.GenerateNodeCA(name)
+	if err != nil {
+		t.Fatalf("GenerateNodeCA(%q): %v", name, err)
+	}
+	return string(ca.CertPEM)
+}
+
+func TestParseCertificateBundlePEM(t *testing.T) {
+	first := mustNodeCAPEM(t, "bundle test CA one")
+	second := mustNodeCAPEM(t, "bundle test CA two")
+
+	corrupt := strings.Replace(second, "-----BEGIN CERTIFICATE-----\n", "-----BEGIN CERTIFICATE-----\nAA", 1)
+
+	tests := []struct {
+		name      string
+		bundle    string
+		wantCerts int
+		wantErr   bool
+	}{
+		{name: "single certificate", bundle: first, wantCerts: 1},
+		{name: "two certificates", bundle: first + second, wantCerts: 2},
+		{name: "empty", bundle: "", wantErr: true},
+		{name: "whitespace only", bundle: "\n\t  \n", wantErr: true},
+		{name: "second certificate corrupt", bundle: first + corrupt, wantErr: true},
+		{name: "trailing non-PEM data", bundle: first + "not a certificate\n", wantErr: true},
+		{name: "non-certificate block", bundle: first + "-----BEGIN PRIVATE KEY-----\nAAAA\n-----END PRIVATE KEY-----\n", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			certs, err := parseCertificateBundlePEM([]byte(tt.bundle))
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("parseCertificateBundlePEM() = %d certs, want an error", len(certs))
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("parseCertificateBundlePEM(): %v", err)
+			}
+			if len(certs) != tt.wantCerts {
+				t.Fatalf("parseCertificateBundlePEM() = %d certs, want %d", len(certs), tt.wantCerts)
+			}
+		})
+	}
+}
+
+func TestNodeMtlsClientCAPoolRejectsPartiallyValidBundle(t *testing.T) {
+	s := setupSettingMtlsDB(t)
+
+	valid := mustNodeCAPEM(t, "pool test CA")
+	if err := s.setString("nodeMtlsClientCAPem", valid+"-----BEGIN CERTIFICATE-----\nnot base64\n-----END CERTIFICATE-----\n"); err != nil {
+		t.Fatalf("setString: %v", err)
+	}
+
+	pool, err := s.NodeMtlsClientCAPool()
+	if err == nil {
+		t.Fatalf("NodeMtlsClientCAPool() = %v, want an error for a partially valid bundle", pool)
+	}
+}


### PR DESCRIPTION
## Summary

Parse and validate every certificate in the node mTLS trust bundle instead of only the first one, and reject the bundle if any block is malformed.

## Why

Two places accept the `nodeMtlsClientCAPem` trust bundle, and both are satisfied by a bundle that is only partly valid:

- `NodeMtlsClientCAPool` builds the listener's `ClientCAs` with `x509.CertPool.AppendCertsFromPEM`, which returns `true` as soon as **one** certificate parses. Later entries that are damaged or truncated are skipped, and the pool is returned as if nothing were wrong.
- `SetNodeMtlsTrustCA` validates the value before storing it, but `pem.Decode` returns only the first block and the remainder is discarded, so only the first certificate is ever checked.

Together these mean a bundle can be stored, reported as valid, and then produce a trust pool that is missing certificates nobody was told about.

This matters most during a CA rotation, which is the one time a bundle legitimately holds two certificates. The operator stores `old CA + new CA`, both calls report success, and the new CA is silently absent from the pool. Every node then rejects the panel's new client certificate at once — and the failure surfaces only when the panel next needs the node API, because data-plane traffic does not go through it.

## Scope

- New `parseCertificateBundlePEM` walks the whole bundle, requiring every block to be a parseable `CERTIFICATE`, and rejects an empty bundle, a non-certificate block, and trailing non-PEM bytes.
- `NodeMtlsClientCAPool` builds the pool from the parsed certificates with `AddCert`, so a partially valid bundle is an error rather than a quietly reduced pool.
- `SetNodeMtlsTrustCA` validates through the same helper, so what is accepted on write is exactly what will load on read.
- No schema, API, or configuration change. A bundle that was fully valid before is still accepted and produces the same pool.

## Validation

- `go build ./...`, `go vet`, `golangci-lint run` clean on `main` at `ece16559`.
- `go test ./internal/web/service/` green.
- New table-driven tests cover a single certificate, a valid two-certificate bundle, an empty and whitespace-only bundle, a valid certificate followed by a corrupt one, trailing non-PEM data, and a non-certificate PEM block.
- The pool test was confirmed failing-first: against the previous `AppendCertsFromPEM` implementation it fails, reporting a pool built from one certificate while the second was dropped; it passes with this change.

## Risk

Low. The change is strictly a tightening of validation on a value that is expected to contain only certificates. Existing single-certificate configurations are unaffected.

One behaviour worth calling out: a stored bundle with trailing text after the last certificate used to load, and now will not. Operators who paste output from tools that append human-readable text would see the trust pool fail to build. That failure is currently non-fatal — `web.go` logs a warning and starts the listener without mTLS, falling back to bearer-token auth for the node API — so a bad bundle degrades the node API from two factors to one rather than stopping the panel. I think that fallback deserves to fail closed instead, but it predates this change and I did not want to fold an unrelated behaviour change into a validation fix. Happy to send it separately if you agree.
