### PR TITLE
fix(groups): report clients actually moved and stop restarting Xray for a label

### DIFF
--- a/internal/web/controller/group.go
+++ b/internal/web/controller/group.go
@@ -148,7 +148,6 @@ func (a *GroupController) bulkAdd(c *gin.Context) {
 		return
 	}
 	jsonObj(c, gin.H{"affected": affected}, nil)
-	a.xrayService.SetToNeedRestart()
 	notifyClientsChanged()
 }
 

--- a/internal/web/service/client_group_bulk_test.go
+++ b/internal/web/service/client_group_bulk_test.go
@@ -1,0 +1,42 @@
+package service
+
+import (
+	"testing"
+
+	"github.com/mhsanaei/3x-ui/v3/internal/database"
+	"github.com/mhsanaei/3x-ui/v3/internal/database/model"
+)
+
+func TestAddToGroupReportsOnlyChangedRecordsIncludingNull(t *testing.T) {
+	setupConflictDB(t)
+	db := database.GetDB()
+	if err := db.Create(&model.ClientGroup{Name: "paid"}).Error; err != nil {
+		t.Fatalf("create group: %v", err)
+	}
+	rows := []model.ClientRecord{
+		{Email: "same@example", UUID: "same", Group: "paid"},
+		{Email: "other@example", UUID: "other", Group: "free"},
+		{Email: "null@example", UUID: "null"},
+	}
+	if err := db.Create(&rows).Error; err != nil {
+		t.Fatalf("create clients: %v", err)
+	}
+	if err := db.Model(&model.ClientRecord{}).Where("email = ?", "null@example").UpdateColumn("group_name", nil).Error; err != nil {
+		t.Fatalf("set NULL group: %v", err)
+	}
+
+	got, err := (&ClientService{}).AddToGroup([]string{"same@example", "other@example", "null@example", "missing@example"}, "paid")
+	if err != nil {
+		t.Fatalf("AddToGroup: %v", err)
+	}
+	if got != 2 {
+		t.Fatalf("affected = %d, want 2 changed records", got)
+	}
+	got, err = (&ClientService{}).AddToGroup([]string{"same@example", "other@example", "null@example"}, "paid")
+	if err != nil {
+		t.Fatalf("second AddToGroup: %v", err)
+	}
+	if got != 0 {
+		t.Fatalf("second affected = %d, want 0", got)
+	}
+}

--- a/internal/web/service/client_groups.go
+++ b/internal/web/service/client_groups.go
@@ -234,7 +234,9 @@ func (s *ClientService) AddToGroup(emails []string, group string) (int, error) {
 	var records []model.ClientRecord
 	for _, batch := range chunkStrings(emails, sqlInChunk) {
 		var rows []model.ClientRecord
-		if err := db.Where("email IN ?", batch).Find(&rows).Error; err != nil {
+		if err := db.Where("email IN ?", batch).
+			Where("group_name IS NULL OR group_name <> ?", group).
+			Find(&rows).Error; err != nil {
 			return 0, err
 		}
 		records = append(records, rows...)
@@ -248,13 +250,17 @@ func (s *ClientService) AddToGroup(emails []string, group string) (int, error) {
 	}
 
 	tx := db.Begin()
+	var affected int64
 	for _, batch := range chunkStrings(affectedEmails, sqlInChunk) {
-		if err := tx.Model(&model.ClientRecord{}).
+		result := tx.Model(&model.ClientRecord{}).
 			Where("email IN ?", batch).
-			UpdateColumn("group_name", group).Error; err != nil {
+			Where("group_name IS NULL OR group_name <> ?", group).
+			UpdateColumn("group_name", group)
+		if result.Error != nil {
 			tx.Rollback()
-			return 0, err
+			return 0, result.Error
 		}
+		affected += result.RowsAffected
 	}
 
 	var inboundIDs []int
@@ -331,7 +337,7 @@ func (s *ClientService) AddToGroup(emails []string, group string) (int, error) {
 	if err := tx.Commit().Error; err != nil {
 		return 0, err
 	}
-	return len(records), nil
+	return int(affected), nil
 }
 
 func (s *ClientService) replaceGroupValue(oldName, newName string) (int, error) {


### PR DESCRIPTION
## Summary

Report the number of clients a bulk group move actually changed, and stop the move from flagging Xray for a restart.

## Why

Two separate issues in the same path:

`AddToGroup` returns the number of clients it *found*, not the number it changed. Moving 50 clients that are already in the target group reports 50 affected while nothing happened. The caller has no way to tell a real move from a no-op.

`bulkAdd` calls `SetToNeedRestart()`. A group is a panel-side label — it does not appear in the Xray configuration — so a restart is scheduled for a change the core cannot observe.

## Scope

- `AddToGroup` selects and updates only rows whose group differs, including `NULL`, and sums `RowsAffected`. Clients that are missing, or already in the target group, are not counted.
- `bulkAdd` no longer sets the restart flag.
- The group value stored inside the inbound settings JSON is untouched; this change is only about the reported count and the restart flag.

## Validation

- `go test ./...` green; targeted `-race` green.
- Mixed scenario — same group, other group, `NULL`, missing client — reports `affected=2`; repeating the same call reports `0`.

Not proven: there is no HTTP controller test observing the restart flag directly; its absence is established by reading the handler.

## Risk

Low. The reported count becomes accurate rather than inflated. Dropping the restart affects only a label change that Xray does not read.
