### PR TITLE
fix(nodes): log the inbound the node snapshot removes centrally

### DIFF
--- a/internal/web/service/inbound_node.go
+++ b/internal/web/service/inbound_node.go
@@ -729,6 +729,9 @@ func (s *InboundService) setRemoteTrafficLocked(nodeID int, snap *runtime.Traffi
 		if unmanagedTag(c.Tag) {
 			continue
 		}
+		// This drops the central inbound and its clients' traffic history, so say
+		// so: silent removal is indistinguishable from an inbound never arriving.
+		logger.Warningf("setRemoteTraffic: node %d no longer reports inbound %q (id %d, port %d) — removing it centrally", nodeID, c.Tag, c.Id, c.Port)
 		var goneEmails []string
 		if err := tx.Model(xray.ClientTraffic{}).
 			Where("inbound_id = ?", c.Id).

--- a/internal/web/service/inbound_node_sweep_log_test.go
+++ b/internal/web/service/inbound_node_sweep_log_test.go
@@ -1,0 +1,50 @@
+package service
+
+import (
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/mhsanaei/3x-ui/v3/internal/database"
+	"github.com/mhsanaei/3x-ui/v3/internal/database/model"
+	"github.com/mhsanaei/3x-ui/v3/internal/logger"
+	"github.com/mhsanaei/3x-ui/v3/internal/web/runtime"
+
+	"github.com/op/go-logging"
+)
+
+// Removing a central inbound also drops its clients' traffic history, so the
+// sweep must name what it removed — a silent drop is undiagnosable in the field.
+func TestNodeSnapshotSweepLogsRemovedInbound(t *testing.T) {
+	logger.InitLogger(logging.WARNING)
+	setupBulkDB(t)
+	nodeID, _ := setupNodeRuntime(t)
+
+	gone := nodeInbound(t, nodeID, 31777, nil)
+	survivor := nodeInbound(t, nodeID, 31778, nil)
+
+	// The snapshot reports only the survivor, so the other row is swept.
+	snap := &runtime.TrafficSnapshot{Inbounds: []*model.Inbound{{
+		Tag: survivor.Tag, Port: survivor.Port, Protocol: model.VLESS, Enable: true,
+		Settings: survivor.Settings,
+	}}}
+	if _, err := (&InboundService{}).setRemoteTrafficLocked(nodeID, snap, false); err != nil {
+		t.Fatalf("setRemoteTrafficLocked: %v", err)
+	}
+
+	var remaining int64
+	if err := database.GetDB().Model(model.Inbound{}).Where("id = ?", gone.Id).Count(&remaining).Error; err != nil {
+		t.Fatalf("count swept inbound: %v", err)
+	}
+	if remaining != 0 {
+		t.Fatalf("fixture did not sweep inbound %d; the log assertion below would be meaningless", gone.Id)
+	}
+
+	want := strconv.Itoa(gone.Id)
+	for _, line := range logger.GetLogs(200, "warning") {
+		if strings.Contains(line, gone.Tag) && strings.Contains(line, want) {
+			return
+		}
+	}
+	t.Fatalf("sweep removed inbound %q (id %d) without naming it in the log", gone.Tag, gone.Id)
+}


### PR DESCRIPTION
## Summary

The node-snapshot orphan sweep removes a central inbound and the traffic history of every client attached to it, and writes nothing to the log. This adds one warning naming the node, tag, id and port.

## Why

When a node stops reporting an inbound, the master deletes the central row, its `client_traffics` rows and the per-node baselines. That is the correct behaviour — but it is invisible.

The practical consequence is that two very different situations look identical from the outside: an inbound that was created and then swept, and an inbound that never reached the node at all. Both end as "the inbound I just added is gone", with an empty log either way. Working out which one happened currently means reading `setRemoteTraffic` and reasoning about `snapTags`.

Every neighbouring branch in this function already logs — adoption conflicts, tag collisions, failed central creates. The one branch that destroys data is the quiet one.

## Scope

- `internal/web/service/inbound_node.go`: one `logger.Warningf` before the sweep deletes, after the existing `dirty` / empty-snapshot / kept-tag / unmanaged-tag guards, so it fires only when a removal actually follows.

No behaviour change, no new condition — the same rows are deleted as before.

## Validation

- New `TestNodeSnapshotSweepLogsRemovedInbound` drives a real snapshot that reports one of two node inbounds, asserts the other is actually swept (so the log assertion cannot pass vacuously), and then requires the tag and id to appear in the warning log.
- Mutation-checked: with the log line removed the test fails with `sweep removed inbound "in-31777" (id 1) without naming it in the log`.
- `go build ./internal/...`, `go vet`, `golangci-lint run` (0 issues), `internal/web/service` tests and `make gen-check` all clean.

## Risk

Low. One log line on a path that already runs; nothing else changes. On a node that legitimately drops several inbounds at once this adds one warning per inbound — that seemed preferable to a summary line, since the point is to name exactly what was removed.
