### PR TITLE
fix(node): keep disabled inbounds the node snapshot cannot report

### DIFF
--- a/internal/web/service/inbound_node.go
+++ b/internal/web/service/inbound_node.go
@@ -714,6 +714,12 @@ func (s *InboundService) setRemoteTrafficLocked(nodeID int, snap *runtime.Traffi
 		if dirty {
 			continue
 		}
+		// Disabled inbounds are intentionally absent from the node's runtime
+		// snapshot. Their absence is not evidence of deletion; retain the row,
+		// client history and port reservation until an explicit delete occurs.
+		if !c.Enable {
+			continue
+		}
 		if len(snapTags) == 0 {
 			// A node mid-restart or with a transient DB error can return an empty
 			// inbound list with success=true. Treat "zero inbounds reported" as

--- a/internal/web/service/node_dirty_test.go
+++ b/internal/web/service/node_dirty_test.go
@@ -68,6 +68,43 @@ func TestSetRemoteTraffic_DirtyPreservesConfig(t *testing.T) {
 	}
 }
 
+func TestSetRemoteTraffic_MissingDisabledInboundIsNotSwept(t *testing.T) {
+	setupConflictDB(t)
+	db := database.GetDB()
+	node := &model.Node{Name: "disabled-snapshot", Address: "127.0.0.1", Port: 2096, ApiToken: "tok", Enable: true, Status: "online"}
+	if err := db.Create(node).Error; err != nil {
+		t.Fatal(err)
+	}
+	disabled := &model.Inbound{
+		UserId: 1, NodeID: &node.Id, Tag: "disabled", Enable: false,
+		Port: 24443, Protocol: model.VLESS, Settings: `{"clients":[]}`,
+	}
+	reported := &model.Inbound{
+		UserId: 1, NodeID: &node.Id, Tag: "reported", Enable: true,
+		Port: 24444, Protocol: model.VLESS, Settings: `{"clients":[]}`,
+	}
+	if err := db.Create(disabled).Error; err != nil {
+		t.Fatal(err)
+	}
+	if err := db.Create(reported).Error; err != nil {
+		t.Fatal(err)
+	}
+	snap := &runtime.TrafficSnapshot{Inbounds: []*model.Inbound{{
+		Tag: reported.Tag, Enable: true,
+		Port: reported.Port, Protocol: reported.Protocol, Settings: reported.Settings,
+	}}}
+	if _, err := (&InboundService{}).setRemoteTrafficLocked(node.Id, snap, false); err != nil {
+		t.Fatal(err)
+	}
+	var count int64
+	if err := db.Model(&model.Inbound{}).Where("id=?", disabled.Id).Count(&count).Error; err != nil {
+		t.Fatal(err)
+	}
+	if count != 1 {
+		t.Fatalf("disabled inbound rows=%d, want 1", count)
+	}
+}
+
 // Deleting a *disabled* client attached to a node inbound must still propagate
 // to the node. The node's own DB carries the (disabled) client, so the central
 // panel has to mark the node dirty (→ reconcile) instead of dropping the delete


### PR DESCRIPTION
## Summary

Creating a node inbound with `enable=false` deletes it again within one sync interval. The row, its clients' traffic history and its port reservation are gone, on a healthy node, with nothing in the log.

## Why

`AddInbound` gates the entire node hand-off on the enable flag (`internal/web/service/inbound.go:1078`):

```go
if inbound.Enable {
    if inbound.NodeID != nil {
        markDirty = true
    } else {
        ...push...
    }
}
```

For a disabled node inbound that means two things: it is never sent to the node, **and the node is never marked dirty**, so nothing schedules a later reconcile.

The orphan sweep in `setRemoteTrafficLocked` then runs under exactly the conditions it considers safe — node online, snapshot non-empty, `dirty == false`, tag managed — sees a central row the node does not report, and deletes it. The absence is real; it just means "never delivered", not "deleted on the node".

A later `ReconcileNode` would have pushed it (it selects node inbounds without an enable filter), but the sweep gets there first.

## Scope

Six lines in the sweep plus a regression test: a central inbound with `Enable == false` is not swept.

I want to be explicit about the alternative, because it is arguably the more complete fix: setting `markDirty` for node inbounds regardless of the flag, so the reconcile delivers disabled inbounds too and the node's list agrees with the master. That is a larger behaviour change — it starts pushing configuration that is currently never sent — so this PR takes the conservative half and stops the data loss.

## Validation

- `TestSetRemoteTraffic_MissingDisabledInboundIsNotSwept` omits a disabled inbound from the snapshot and asserts the row survives.
- Mutation-checked: removing the guard turns it red with `disabled inbound rows=0, want 1` — a behavioural failure, not a compile error.
- `go build ./...`, `go vet`, `golangci-lint run` clean; `go test ./internal/web/service` green.

## Risk

Low. The change only narrows what the sweep may delete.

The cost is real and worth stating: an inbound deleted directly on the node while disabled centrally now lingers in the central DB until it is deleted there too. That is the same trade the existing empty-snapshot guard already makes — a stale row beats silent data loss.
