### PR TITLE
fix(frontend): keep the MSW worker in step with the lockfile

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -162,6 +162,9 @@ jobs:
       - name: Install
         run: npm ci
         working-directory: frontend
+      - name: Verify generated MSW worker is current
+        run: git diff --exit-code -- public/mockServiceWorker.js package-lock.json
+        working-directory: frontend
       - name: Lint
         run: npm run lint
         working-directory: frontend

--- a/Makefile
+++ b/Makefile
@@ -41,6 +41,10 @@ lint: lint-go lint-fe ## All linters
 typecheck: ## tsc --noEmit
 	cd $(FRONTEND) && npm run typecheck
 
+.PHONY: msw-worker-check
+msw-worker-check: ## Verify the tracked worker matches the installed MSW runtime
+	cmp $(FRONTEND)/public/mockServiceWorker.js $(FRONTEND)/node_modules/msw/lib/mockServiceWorker.js
+
 .PHONY: test-go
 test-go: dist-stub ## Go tests (shuffle, no cache)
 	go test -shuffle=on -count=1 $(GO_PKGS)
@@ -75,5 +79,5 @@ build-storybook: ## Build the static Storybook (compile-checks all stories)
 # The PR gate. Matches ci.yml: codegen freshness, both linters, typecheck,
 # both test suites, a full build, and the Storybook compile-check.
 .PHONY: verify
-verify: gen-check lint typecheck test build build-storybook ## Full local gate (mirrors CI)
+verify: gen-check lint typecheck msw-worker-check test build build-storybook ## Full local gate (mirrors CI)
 	@echo "verify: OK"

--- a/frontend/public/mockServiceWorker.js
+++ b/frontend/public/mockServiceWorker.js
@@ -7,8 +7,8 @@
  * - Please do NOT modify this file.
  */
 
-const PACKAGE_VERSION = '2.14.7'
-const INTEGRITY_CHECKSUM = '4db4a41e972cec1b64cc569c66952d82'
+const PACKAGE_VERSION = '2.15.0'
+const INTEGRITY_CHECKSUM = '03cb67ac84128e63d7cd722a6e5b7f1e'
 const IS_MOCKED_RESPONSE = Symbol('isMockedResponse')
 const activeClientIds = new Set()
 
@@ -137,8 +137,18 @@ async function handleRequest(event, requestId, requestInterceptedAt) {
   if (client && activeClientIds.has(client.id)) {
     const serializedRequest = await serializeRequest(requestCloneForEvents)
 
+    // Omit the body of server-sent event stream responses.
+    // Cloning such responses would prevent client-side stream cancelations
+    // from reaching the original stream (a teed stream only cancels its
+    // source once both of its branches cancel) and would buffer the
+    // entire stream into the unconsumed clone indefinitely.
+    const isEventStreamResponse = response.headers
+      .get('content-type')
+      ?.toLowerCase()
+      .startsWith('text/event-stream')
+
     // Clone the response so both the client and the library could consume it.
-    const responseClone = response.clone()
+    const responseClone = isEventStreamResponse ? null : response.clone()
 
     sendToClient(
       client,
@@ -151,15 +161,17 @@ async function handleRequest(event, requestId, requestInterceptedAt) {
             ...serializedRequest,
           },
           response: {
-            type: responseClone.type,
-            status: responseClone.status,
-            statusText: responseClone.statusText,
-            headers: Object.fromEntries(responseClone.headers.entries()),
-            body: responseClone.body,
+            type: response.type,
+            status: response.status,
+            statusText: response.statusText,
+            headers: Object.fromEntries(response.headers.entries()),
+            body: responseClone ? responseClone.body : null,
           },
         },
       },
-      responseClone.body ? [serializedRequest.body, responseClone.body] : [],
+      responseClone && responseClone.body
+        ? [serializedRequest.body, responseClone.body]
+        : [],
     )
   }
 


### PR DESCRIPTION
## Summary

`frontend/public/mockServiceWorker.js` is tracked at msw 2.14.7 while `package-lock.json` installs 2.15.0. msw regenerates that worker on postinstall, so a clean `npm ci` rewrites a tracked file and leaves the working tree dirty.

## Why

Every contributor hits it: after the first install, `git status` shows a 30-line diff nobody asked for. It either gets committed as noise or discarded, and the same diff comes back on the next install. `make verify` does not notice, because nothing checks tree cleanliness after install.

The worker is not cosmetic — it is the service worker the browser tests register, so a stale copy means the mocked runtime does not match the version the tests were written against.

## Scope

- regenerate `mockServiceWorker.js` for the locked msw version;
- add `make msw-worker-check`, comparing the tracked worker to `node_modules/msw/lib/mockServiceWorker.js`;
- wire it into `make verify` and add the equivalent step to the frontend CI job.

The check is a `cmp` against the installed package, so it stays correct across future msw bumps: whoever raises the lockfile regenerates the worker in the same commit or CI fails.

## Validation

On a clean checkout of `main`, the tracked worker and the installed one differ (2.14.7 vs 2.15.0, 30 lines). With this change they are byte-identical, `git diff --exit-code` after `npm ci` is clean, and `make msw-worker-check` exits 0.

## Risk

Low, and confined to test infrastructure — the worker is only registered by the browser test setup. If the two ever diverge again, CI now fails with a direct message instead of silently shipping a mismatched mock runtime.
