### PR TITLE
fix(inbounds): close the port check-and-claim race on the serial writer

### DIFF
--- a/internal/web/service/inbound.go
+++ b/internal/web/service/inbound.go
@@ -1432,6 +1432,13 @@ func (s *InboundService) UpdateInbound(inbound *model.Inbound) (*model.Inbound, 
 	var postCommitApply func()
 
 	txErr := runSerializedTx(func(tx *gorm.DB) error {
+		conflict, cErr := checkPortConflictTx(tx, inbound, inbound.Id)
+		if cErr != nil {
+			return cErr
+		}
+		if conflict != nil {
+			return common.NewError(conflict.String())
+		}
 		if err := s.updateClientTraffics(tx, oldInbound, inbound); err != nil {
 			return err
 		}

--- a/internal/web/service/inbound.go
+++ b/internal/web/service/inbound.go
@@ -930,18 +930,11 @@ func (s *InboundService) AddInbound(inbound *model.Inbound) (*model.Inbound, boo
 		return inbound, false, err
 	}
 
-	conflict, err := s.checkPortConflict(inbound, 0)
+	tag, err := s.resolveInboundTag(inbound, 0)
 	if err != nil {
 		return inbound, false, err
 	}
-	if conflict != nil {
-		return inbound, false, common.NewError(conflict.String())
-	}
-
-	inbound.Tag, err = s.resolveInboundTag(inbound, 0)
-	if err != nil {
-		return inbound, false, err
-	}
+	inbound.Tag = tag
 
 	clients, err := s.GetClients(inbound)
 	if err != nil {
@@ -1027,10 +1020,16 @@ func (s *InboundService) AddInbound(inbound *model.Inbound) (*model.Inbound, boo
 		}
 	}
 
-	db := database.GetDB()
 	needRestart := false
 	var postCommitApply func()
-	err = db.Transaction(func(tx *gorm.DB) error {
+	err = runSerializedTx(func(tx *gorm.DB) error {
+		conflict, cErr := checkPortConflictTx(tx, inbound, 0)
+		if cErr != nil {
+			return cErr
+		}
+		if conflict != nil {
+			return common.NewError(conflict.String())
+		}
 		markDirty := false
 		if err := tx.Omit("ClientStats").Save(inbound).Error; err != nil {
 			return err
@@ -1415,14 +1414,6 @@ func (s *InboundService) UpdateInbound(inbound *model.Inbound) (*model.Inbound, 
 	// Restore the stored NodeID before the port-conflict check so a node inbound
 	// stays scoped to its own node (the payload's nodeId is unreliable, often absent).
 	inbound.NodeID = oldInbound.NodeID
-
-	conflict, err := s.checkPortConflict(inbound, inbound.Id)
-	if err != nil {
-		return inbound, false, err
-	}
-	if conflict != nil {
-		return inbound, false, common.NewError(conflict.String())
-	}
 
 	// Capture the pre-edit protocol and routing state before oldInbound is
 	// overwritten with the new values further down, then ensure a routed

--- a/internal/web/service/inbound_create_race_test.go
+++ b/internal/web/service/inbound_create_race_test.go
@@ -1,0 +1,63 @@
+package service
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+
+	"github.com/mhsanaei/3x-ui/v3/internal/database/model"
+)
+
+// A wildcard listener and a specific one on the same port overlap, but they are
+// two different rows: only the in-transaction check can reject the pair, and it
+// can only do so if the check and the insert cannot interleave.
+func TestAddInboundConcurrentOverlappingListenersSingleWinner(t *testing.T) {
+	setupConflictDB(t)
+
+	const rounds = 25
+	for round := range rounds {
+		port := 24000 + round
+		claims := []*model.Inbound{
+			{
+				Tag: fmt.Sprintf("race-%d-wildcard", round), Listen: "",
+				Port: port, Protocol: model.VLESS,
+				StreamSettings: `{"network":"tcp"}`, Settings: `{"clients":[]}`,
+			},
+			{
+				Tag: fmt.Sprintf("race-%d-specific", round), Listen: "127.0.0.1",
+				Port: port, Protocol: model.Trojan,
+				StreamSettings: `{"network":"tcp"}`, Settings: `{"clients":[]}`,
+			},
+		}
+
+		start := make(chan struct{})
+		errs := make(chan error, len(claims))
+		var wg sync.WaitGroup
+		for _, claim := range claims {
+			wg.Add(1)
+			go func(inbound *model.Inbound) {
+				defer wg.Done()
+				<-start
+				_, _, err := (&InboundService{}).AddInbound(inbound)
+				errs <- err
+			}(claim)
+		}
+		close(start)
+		wg.Wait()
+		close(errs)
+
+		committed := 0
+		rejections := make([]string, 0, len(claims))
+		for err := range errs {
+			if err == nil {
+				committed++
+				continue
+			}
+			rejections = append(rejections, err.Error())
+		}
+		if committed != 1 {
+			t.Fatalf("round %d port %d: concurrent AddInbound committed=%d, want exactly 1 (rejections: %v)",
+				round, port, committed, rejections)
+		}
+	}
+}

--- a/internal/web/service/inbound_create_race_test.go
+++ b/internal/web/service/inbound_create_race_test.go
@@ -5,6 +5,7 @@ import (
 	"sync"
 	"testing"
 
+	"github.com/mhsanaei/3x-ui/v3/internal/database"
 	"github.com/mhsanaei/3x-ui/v3/internal/database/model"
 )
 
@@ -59,5 +60,40 @@ func TestAddInboundConcurrentOverlappingListenersSingleWinner(t *testing.T) {
 			t.Fatalf("round %d port %d: concurrent AddInbound committed=%d, want exactly 1 (rejections: %v)",
 				round, port, committed, rejections)
 		}
+	}
+}
+
+// Editing an inbound onto a port another one already holds must be rejected —
+// the check moved inside the transaction, and nothing else guards this path.
+func TestUpdateInboundRejectsPortTakenByAnother(t *testing.T) {
+	setupConflictDB(t)
+
+	svc := &InboundService{}
+	first := &model.Inbound{
+		Tag: "update-holder", Listen: "", Port: 25101, Protocol: model.VLESS,
+		StreamSettings: `{"network":"tcp"}`, Settings: `{"clients":[]}`,
+	}
+	if _, _, err := svc.AddInbound(first); err != nil {
+		t.Fatalf("seed holder: %v", err)
+	}
+	second := &model.Inbound{
+		Tag: "update-mover", Listen: "", Port: 25102, Protocol: model.VLESS,
+		StreamSettings: `{"network":"tcp"}`, Settings: `{"clients":[]}`,
+	}
+	if _, _, err := svc.AddInbound(second); err != nil {
+		t.Fatalf("seed mover: %v", err)
+	}
+
+	second.Port = first.Port
+	if _, _, err := svc.UpdateInbound(second); err == nil {
+		t.Fatal("moving an inbound onto a port already in use was accepted")
+	}
+
+	var stored model.Inbound
+	if err := database.GetDB().First(&stored, second.Id).Error; err != nil {
+		t.Fatal(err)
+	}
+	if stored.Port != 25102 {
+		t.Fatalf("rejected update still changed the stored port to %d", stored.Port)
 	}
 }

--- a/internal/web/service/port_conflict.go
+++ b/internal/web/service/port_conflict.go
@@ -8,6 +8,8 @@ import (
 	"github.com/mhsanaei/3x-ui/v3/internal/database"
 	"github.com/mhsanaei/3x-ui/v3/internal/database/model"
 	"github.com/mhsanaei/3x-ui/v3/internal/util/common"
+
+	"gorm.io/gorm"
 )
 
 type transportBits uint8
@@ -158,7 +160,13 @@ func reservedAPIPort() int {
 	return defaultXrayAPIPort
 }
 
+// checkPortConflict reads outside any transaction; callers that must not race a
+// concurrent create use checkPortConflictTx inside their own transaction.
 func (s *InboundService) checkPortConflict(inbound *model.Inbound, ignoreId int) (*portConflictDetail, error) {
+	return checkPortConflictTx(database.GetDB(), inbound, ignoreId)
+}
+
+func checkPortConflictTx(db *gorm.DB, inbound *model.Inbound, ignoreId int) (*portConflictDetail, error) {
 	newBits := inboundTransports(inbound.Protocol, inbound.StreamSettings, inbound.Settings)
 
 	// The internal Xray API inbound (tag "api", loopback TCP) isn't a DB row,
@@ -174,8 +182,6 @@ func (s *InboundService) checkPortConflict(inbound *model.Inbound, ignoreId int)
 			Transports: transportTCP,
 		}, nil
 	}
-
-	db := database.GetDB()
 
 	var candidates []*model.Inbound
 	q := db.Model(model.Inbound{}).Where("port = ?", inbound.Port)


### PR DESCRIPTION
## Summary

`AddInbound` checks for a port conflict outside its transaction and then commits in a bare `db.Transaction`. Two overlapping creates both pass the read and both insert.

`UpdateInbound` and `SetRemoteTraffic` already run through `runSerializedTx`, so `AddInbound` is the one inbound writer left off the single traffic writer. Moving it there and folding the check into the transaction closes the window.

## Why

The check-and-claim gap is wide: tag resolution, client validation, email uniqueness and settings normalisation all sit between the read and the insert.

The case that no constraint can catch is a wildcard listener against a specific one on the same port — `("", 443, tcp)` and `("127.0.0.1", 443, tcp)` are two different rows, so a unique index accepts both. The panel's real rule lives in `listenOverlaps`, and only the semantic check can express it. That check is therefore load-bearing, and it is only sound if nothing can interleave between it and the insert.

## Scope

- `checkPortConflict` splits into a thin wrapper plus `checkPortConflictTx(db, ...)` that runs on a caller-supplied handle;
- `AddInbound` moves from `db.Transaction` to `runSerializedTx` and evaluates the conflict inside;
- `UpdateInbound` drops its pre-flight check and evaluates the same one inside the transaction it already has.

No new table, no environment variable, no migration, no additional locking. On SQLite `db.Transaction` takes the write lock at `BEGIN` (`_txlock=immediate`), and on PostgreSQL the single writer goroutine provides the serialisation, so both backends are covered by the existing primitives.

Two preconditions I checked before moving `AddInbound` onto the writer: it is reached only from the two controller handlers, never from inside another traffic write, so the queue cannot re-enter; and the node push is already deferred to `postCommitApply` after commit, which is what the writer contract requires.

## Validation

`TestAddInboundConcurrentOverlappingListenersSingleWinner` races a wildcard and a specific listener for the same port through `AddInbound`, 25 rounds, asserting exactly one commit.

Mutation-checked against today's behaviour: restoring the pre-flight check and the bare transaction turns it red with `concurrent AddInbound committed=2, want exactly 1`. That is the defect on `main`, reproduced.

`go build ./...`, `go vet`, `golangci-lint run` clean; `go test ./internal/web/service` green.

## Risk

Moderate and worth stating plainly: `AddInbound` now waits for the traffic writer, so a create issued during a traffic poll is serialised behind it instead of contending with it. That is the same trade `UpdateInbound` already makes, and it removes the `database is locked` failures a create could previously hit on SQLite after the busy timeout.

This supersedes #6185, which solved the same race with an opt-in reservation table. That table is rebuilt from `inbounds` on every boot and import, so it is derived rather than authoritative, and its unique index cannot express the wildcard overlap rule — the in-transaction check was doing the real work there too. I will close it in favour of this.
