### PR TITLE
fix(node): stop stale expiry sync from undoing client extensions (#6228)

### DIFF
--- a/internal/database/dialect.go
+++ b/internal/database/dialect.go
@@ -37,9 +37,27 @@ func GreatestExpr(a, b string) string {
 	return fmt.Sprintf("MAX(%s, %s)", a, b)
 }
 
+// ClientTrafficEnableMergeExpr merges a node-reported enable into
+// client_traffics.enable. Placeholders (in order): nodeEnable, nodeExpiry,
+// nodeExpiry.
+//
+//   - node enable true: keep the master's enable — never re-enable from a stale
+//     snapshot (#4917).
+//   - node enable false with an older absolute expiry than the master: keep the
+//     master's enable — the node is still enforcing a pre-extension deadline
+//     (#6228).
+//   - otherwise adopt the disable.
 func ClientTrafficEnableMergeExpr() string {
 	if IsPostgres() {
-		return "CASE WHEN ?::boolean THEN enable::boolean ELSE false END"
+		return `CASE
+			WHEN ?::boolean THEN enable::boolean
+			WHEN CAST(? AS BIGINT) > 0 AND expiry_time > CAST(? AS BIGINT) THEN enable::boolean
+			ELSE false
+		END`
 	}
-	return "CASE WHEN ? THEN enable ELSE 0 END"
+	return `CASE
+		WHEN ? THEN enable
+		WHEN CAST(? AS BIGINT) > 0 AND expiry_time > CAST(? AS BIGINT) THEN enable
+		ELSE 0
+	END`
 }

--- a/internal/database/dialect.go
+++ b/internal/database/dialect.go
@@ -39,14 +39,7 @@ func GreatestExpr(a, b string) string {
 
 // ClientTrafficEnableMergeExpr merges a node-reported enable into
 // client_traffics.enable. Placeholders (in order): nodeEnable, nodeExpiry,
-// nodeExpiry.
-//
-//   - node enable true: keep the master's enable — never re-enable from a stale
-//     snapshot (#4917).
-//   - node enable false with an older absolute expiry than the master: keep the
-//     master's enable — the node is still enforcing a pre-extension deadline
-//     (#6228).
-//   - otherwise adopt the disable.
+// nodeExpiry. Mirrors staleNodeDisable / #4917 / #6228.
 func ClientTrafficEnableMergeExpr() string {
 	if IsPostgres() {
 		return `CASE
@@ -59,5 +52,15 @@ func ClientTrafficEnableMergeExpr() string {
 		WHEN ? THEN enable
 		WHEN CAST(? AS BIGINT) > 0 AND expiry_time > CAST(? AS BIGINT) THEN enable
 		ELSE 0
+	END`
+}
+
+// ClientTrafficExpiryMergeExpr merges a node-reported expiry into
+// client_traffics.expiry_time. Placeholders (in order): nodeExpiry, nodeExpiry,
+// nodeExpiry. Mirrors mergeActivationExpiry.
+func ClientTrafficExpiryMergeExpr() string {
+	return `CASE
+		WHEN expiry_time > 0 AND (CAST(? AS BIGINT) <= 0 OR CAST(? AS BIGINT) < expiry_time) THEN expiry_time
+		ELSE CAST(? AS BIGINT)
 	END`
 }

--- a/internal/database/dialect.go
+++ b/internal/database/dialect.go
@@ -40,17 +40,23 @@ func GreatestExpr(a, b string) string {
 // ClientTrafficEnableMergeExpr merges a node-reported enable into
 // client_traffics.enable. Placeholders (in order): nodeEnable, nodeExpiry,
 // nodeExpiry. Mirrors staleNodeDisable / #4917 / #6228.
+//
+// A disable with an older absolute expiry is ignored only when the master row
+// is not already over quota (total <= 0 OR up+down < total), so a genuine
+// quota latch still wins even if the node's expiry lags the merged max.
 func ClientTrafficEnableMergeExpr() string {
 	if IsPostgres() {
 		return `CASE
 			WHEN ?::boolean THEN enable::boolean
-			WHEN CAST(? AS BIGINT) > 0 AND expiry_time > CAST(? AS BIGINT) THEN enable::boolean
+			WHEN CAST(? AS BIGINT) > 0 AND expiry_time > CAST(? AS BIGINT)
+				AND (total <= 0 OR up + down < total) THEN enable::boolean
 			ELSE false
 		END`
 	}
 	return `CASE
 		WHEN ? THEN enable
-		WHEN CAST(? AS BIGINT) > 0 AND expiry_time > CAST(? AS BIGINT) THEN enable
+		WHEN CAST(? AS BIGINT) > 0 AND expiry_time > CAST(? AS BIGINT)
+			AND (total <= 0 OR up + down < total) THEN enable
 		ELSE 0
 	END`
 }
@@ -58,6 +64,11 @@ func ClientTrafficEnableMergeExpr() string {
 // ClientTrafficExpiryMergeExpr merges a node-reported expiry into
 // client_traffics.expiry_time. Placeholders (in order): nodeExpiry, nodeExpiry,
 // nodeExpiry. Mirrors mergeActivationExpiry.
+//
+// CAST(? AS BIGINT) is required on Postgres: without it the `<= 0` / `<`
+// comparisons infer int4 from the literal and overflow on real millisecond
+// timestamps. The casts are kept on SQLite too so both dialects share one
+// expression.
 func ClientTrafficExpiryMergeExpr() string {
 	return `CASE
 		WHEN expiry_time > 0 AND (CAST(? AS BIGINT) <= 0 OR CAST(? AS BIGINT) < expiry_time) THEN expiry_time

--- a/internal/web/service/client_locks.go
+++ b/internal/web/service/client_locks.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/mhsanaei/3x-ui/v3/internal/database/model"
 	"github.com/mhsanaei/3x-ui/v3/internal/logger"
+	"github.com/mhsanaei/3x-ui/v3/internal/xray"
 
 	"gorm.io/gorm"
 )
@@ -231,4 +232,77 @@ func stripTombstonedClients(settings string) (string, bool) {
 		return settings, false
 	}
 	return string(b), true
+}
+
+// liftClientLifecycleInSettings applies mergeActivationExpiry / staleNodeDisable
+// to each client entry in a node settings blob before the master adopts it, so a
+// lagging snapshot cannot rewrite central inbound JSON with a pre-extension
+// deadline or enable=false (#6228).
+func liftClientLifecycleInSettings(settings string, trafficByEmail map[string]*xray.ClientTraffic) (string, bool) {
+	if settings == "" || len(trafficByEmail) == 0 {
+		return settings, false
+	}
+	var parsed map[string]any
+	if err := json.Unmarshal([]byte(settings), &parsed); err != nil {
+		return settings, false
+	}
+	clients, _ := parsed["clients"].([]any)
+	if len(clients) == 0 {
+		return settings, false
+	}
+	changed := false
+	for i := range clients {
+		cm, ok := clients[i].(map[string]any)
+		if !ok {
+			continue
+		}
+		email, _ := cm["email"].(string)
+		if email == "" {
+			continue
+		}
+		tr := trafficByEmail[email]
+		if tr == nil {
+			continue
+		}
+		nodeExpiry, hasExpiry := jsonClientInt64(cm["expiryTime"])
+		if !hasExpiry {
+			continue
+		}
+		merged := mergeActivationExpiry(tr.ExpiryTime, nodeExpiry)
+		if merged != nodeExpiry {
+			cm["expiryTime"] = merged
+			changed = true
+		}
+		nodeEnable, _ := cm["enable"].(bool)
+		if !nodeEnable && staleNodeDisable(tr.ExpiryTime, nodeExpiry) && tr.Enable {
+			cm["enable"] = true
+			changed = true
+		}
+		clients[i] = cm
+	}
+	if !changed {
+		return settings, false
+	}
+	parsed["clients"] = clients
+	b, err := json.MarshalIndent(parsed, "", "  ")
+	if err != nil {
+		return settings, false
+	}
+	return string(b), true
+}
+
+func jsonClientInt64(v any) (int64, bool) {
+	switch n := v.(type) {
+	case float64:
+		return int64(n), true
+	case int64:
+		return n, true
+	case int:
+		return int64(n), true
+	case json.Number:
+		i, err := n.Int64()
+		return i, err == nil
+	default:
+		return 0, false
+	}
 }

--- a/internal/web/service/client_locks.go
+++ b/internal/web/service/client_locks.go
@@ -274,7 +274,7 @@ func liftClientLifecycleInSettings(settings string, trafficByEmail map[string]*x
 			changed = true
 		}
 		nodeEnable, _ := cm["enable"].(bool)
-		if !nodeEnable && staleNodeDisable(tr.ExpiryTime, nodeExpiry) && tr.Enable {
+		if !nodeEnable && staleNodeDisable(tr, nodeExpiry) && tr.Enable {
 			cm["enable"] = true
 			changed = true
 		}
@@ -292,17 +292,10 @@ func liftClientLifecycleInSettings(settings string, trafficByEmail map[string]*x
 }
 
 func jsonClientInt64(v any) (int64, bool) {
-	switch n := v.(type) {
-	case float64:
-		return int64(n), true
-	case int64:
-		return n, true
-	case int:
-		return int64(n), true
-	case json.Number:
-		i, err := n.Int64()
-		return i, err == nil
-	default:
+	// json.Unmarshal into map[string]any yields float64 for numbers.
+	n, ok := v.(float64)
+	if !ok {
 		return 0, false
 	}
+	return int64(n), true
 }

--- a/internal/web/service/inbound_node.go
+++ b/internal/web/service/inbound_node.go
@@ -224,14 +224,28 @@ func (s *InboundService) upsertNodeBaseline(tx *gorm.DB, nodeID int, email strin
 // another node already activated.
 //
 // A node may legitimately move an already-activated deadline forward (traffic
-// reset / auto-renew extends it), so any positive node value is still adopted —
-// only an un-activated (<= 0) value is rejected once an absolute deadline
-// exists. Kept in lockstep with the SQL CASE in setRemoteTrafficLocked.
+// reset / auto-renew extends it), so a later absolute value is still adopted.
+// An earlier absolute value is rejected: after an admin extends an expired
+// client on the master, a node that has not yet received the push keeps
+// reporting the previous (past) deadline, and adopting it would undo the
+// extension and make disableInvalidClients remove the client again (#6228).
+// Kept in lockstep with the SQL CASE in setRemoteTrafficLocked.
 func mergeActivationExpiry(existing, node int64) int64 {
-	if existing > 0 && node <= 0 {
+	if existing > 0 && (node <= 0 || node < existing) {
 		return existing
 	}
 	return node
+}
+
+// nodeDisableIsStale reports a node-side enable=false that must not latch the
+// master's client_traffics.enable off. After an expired client is extended on
+// the master, a node still enforcing the previous deadline disables locally and
+// would otherwise one-way-merge that disable onto the master (#4917 / #6228).
+func nodeDisableIsStale(masterExpiry, nodeExpiry int64, nodeEnable bool) bool {
+	if nodeEnable {
+		return false
+	}
+	return masterExpiry > 0 && nodeExpiry > 0 && nodeExpiry < masterExpiry
 }
 
 // nodeClientRenewed reports a node-side auto-renew: an absolute deadline moved
@@ -891,15 +905,20 @@ func (s *InboundService) setRemoteTrafficLocked(nodeID int, snap *runtime.Traffi
 				// expiry_time merge mirrors mergeActivationExpiry: a node that has not
 				// yet seen the client's first connection keeps reporting the negative
 				// "start after first connect" duration, which must never reset the
-				// absolute deadline another node already activated. A positive node
-				// value is still adopted (e.g. auto-renew moves the deadline forward).
-				// CAST(? AS BIGINT): in the `<= 0` comparison Postgres would otherwise
-				// infer int4 from the literal and overflow on real expiry values.
+				// absolute deadline another node already activated. A later absolute
+				// value is still adopted (auto-renew); an earlier absolute value is
+				// rejected so a stale post-expire node snapshot cannot undo a master
+				// extension (#6228). CAST(? AS BIGINT): in the comparisons Postgres
+				// would otherwise infer int4 from the literal and overflow on real
+				// expiry values.
 				if err := tx.Exec(
 					fmt.Sprintf(
 						`UPDATE client_traffics
 						 SET up = %s, down = %s, enable = %s, total = ?,
-						     expiry_time = CASE WHEN expiry_time > 0 AND CAST(? AS BIGINT) <= 0 THEN expiry_time ELSE CAST(? AS BIGINT) END,
+						     expiry_time = CASE
+						       WHEN expiry_time > 0 AND (CAST(? AS BIGINT) <= 0 OR CAST(? AS BIGINT) < expiry_time) THEN expiry_time
+						       ELSE CAST(? AS BIGINT)
+						     END,
 						     reset = ?, last_online = %s
 						 WHERE email = ?`,
 						database.ClampedAddExpr("up"),
@@ -907,8 +926,10 @@ func (s *InboundService) setRemoteTrafficLocked(nodeID int, snap *runtime.Traffi
 						enableExpr,
 						database.GreatestExpr("last_online", "?"),
 					),
-					deltaUp, deltaDown, cs.Enable, cs.Total,
-					cs.ExpiryTime, cs.ExpiryTime, cs.Reset,
+					deltaUp, deltaDown,
+					cs.Enable, cs.ExpiryTime, cs.ExpiryTime,
+					cs.Total,
+					cs.ExpiryTime, cs.ExpiryTime, cs.ExpiryTime, cs.Reset,
 					cs.LastOnline, cs.Email,
 				).Error; err != nil {
 					return false, err
@@ -995,17 +1016,31 @@ func (s *InboundService) setRemoteTrafficLocked(nodeID int, snap *runtime.Traffi
 			logger.Warningf("setRemoteTraffic: parse clients for tag %q failed: %v", snapIb.Tag, gcErr)
 			continue
 		}
-		csEnableByEmail := make(map[string]bool, len(snapIb.ClientStats))
+		csByEmail := make(map[string]xray.ClientTraffic, len(snapIb.ClientStats))
 		for _, cs := range snapIb.ClientStats {
-			csEnableByEmail[cs.Email] = cs.Enable
+			csByEmail[cs.Email] = cs
 		}
 		filtered := clients[:0]
 		for i := range clients {
 			if isClientEmailTombstoned(clients[i].Email) {
 				continue
 			}
-			if cse, hit := csEnableByEmail[clients[i].Email]; hit && !cse {
-				clients[i].Enable = false
+			if existing := centralCSByEmail[clients[i].Email]; existing != nil {
+				// Prefer the merged traffic-row deadline so SyncInbound does not
+				// rewrite client records / links from a stale node settings JSON.
+				clients[i].ExpiryTime = mergeActivationExpiry(existing.ExpiryTime, clients[i].ExpiryTime)
+			}
+			if cs, hit := csByEmail[clients[i].Email]; hit {
+				masterExpiry := clients[i].ExpiryTime
+				if existing := centralCSByEmail[clients[i].Email]; existing != nil {
+					masterExpiry = mergeActivationExpiry(existing.ExpiryTime, cs.ExpiryTime)
+				}
+				if nodeDisableIsStale(masterExpiry, cs.ExpiryTime, cs.Enable) {
+					// Keep the master's enable: the node is disabling against an
+					// older deadline than the shared traffic row already holds.
+				} else if !cs.Enable {
+					clients[i].Enable = false
+				}
 			}
 			filtered = append(filtered, clients[i])
 		}

--- a/internal/web/service/inbound_node.go
+++ b/internal/web/service/inbound_node.go
@@ -223,9 +223,15 @@ func (s *InboundService) upsertNodeBaseline(tx *gorm.DB, nodeID int, email strin
 // keeps reporting the negative duration — which must never reset a deadline
 // another node already activated.
 //
-// A later absolute value is still adopted (auto-renew). An earlier absolute is
-// rejected so a stale post-expire node snapshot cannot undo a master extension
-// (#6228). Lockstep with ClientTrafficExpiryMergeExpr.
+// A later absolute value is still adopted (auto-renew / node-side extend). An
+// earlier absolute is rejected so a stale post-expire node snapshot cannot undo
+// a master extension (#6228). Lockstep with ClientTrafficExpiryMergeExpr.
+//
+// By design this is value-monotonic for absolute deadlines: a node-local
+// shortening is dropped if the master already holds a later absolute, and a
+// lagging node still reporting a later deadline can overwrite a master-side
+// shorten. A monotonic write marker would cover both directions; until then
+// prefer master-side edits (which set config_dirty and push).
 func mergeActivationExpiry(existing, node int64) int64 {
 	if existing > 0 && (node <= 0 || node < existing) {
 		return existing
@@ -234,10 +240,22 @@ func mergeActivationExpiry(existing, node int64) int64 {
 }
 
 // staleNodeDisable is true when a node enable=false carries an older absolute
-// expiry than the master. That disable must not latch master enable off after
-// an extension (#6228); same-expiry quota disables still latch (#4917).
-func staleNodeDisable(masterExpiry, nodeExpiry int64) bool {
-	return masterExpiry > 0 && nodeExpiry > 0 && nodeExpiry < masterExpiry
+// expiry than the master and the master row is not already over quota. That
+// disable must not latch master enable off after an extension (#6228).
+// Same-expiry quota disables still latch (#4917). An older-expiry disable on a
+// master row that is already depleted is also adopted so quota enforcement is
+// not skipped just because a sibling node activated a later deadline.
+func staleNodeDisable(master *xray.ClientTraffic, nodeExpiry int64) bool {
+	if master == nil {
+		return false
+	}
+	if master.ExpiryTime <= 0 || nodeExpiry <= 0 || nodeExpiry >= master.ExpiryTime {
+		return false
+	}
+	if master.Total > 0 && master.Up+master.Down >= master.Total {
+		return false
+	}
+	return true
 }
 
 // nodeClientRenewed reports a node-side auto-renew: an absolute deadline moved
@@ -665,7 +683,12 @@ func (s *InboundService) setRemoteTrafficLocked(nodeID int, snap *runtime.Traffi
 		if deduped, changed := dedupeSettingsClients(adoptedSettings); changed {
 			adoptedSettings = deduped
 		}
-		if lifted, changed := liftClientLifecycleInSettings(adoptedSettings, centralCSByEmail); changed {
+		// Lift after strip/dedupe, but keep the pre-lift blob for the reconcile
+		// fingerprint: RecordAdoptedInbound must reflect what the node reported,
+		// or ReconcileInbound will skip re-pushing the corrected clients.
+		wireSettings := adoptedSettings
+		lifted, liftChanged := liftClientLifecycleInSettings(adoptedSettings, centralCSByEmail)
+		if liftChanged {
 			adoptedSettings = lifted
 		}
 
@@ -685,8 +708,8 @@ func (s *InboundService) setRemoteTrafficLocked(nodeID int, snap *runtime.Traffi
 			updates["traffic_reset"] = snapIb.TrafficReset
 			updates["traffic_reset_day"] = normalizeTrafficResetDay(snapIb.TrafficResetDay)
 			updates["last_traffic_reset_time"] = snapIb.LastTrafficResetTime
-			if adoptedWireChanged(c, snapIb, adoptedSettings) {
-				adoptedInbounds = append(adoptedInbounds, adoptedWireInbound(c, snapIb, adoptedSettings))
+			if !liftChanged && adoptedWireChanged(c, snapIb, wireSettings) {
+				adoptedInbounds = append(adoptedInbounds, adoptedWireInbound(c, snapIb, wireSettings))
 			}
 		}
 		if !inGrace || (snapIb.Up+snapIb.Down) <= (c.Up+c.Down) {
@@ -929,10 +952,10 @@ func (s *InboundService) setRemoteTrafficLocked(nodeID int, snap *runtime.Traffi
 					// Keep the in-memory row aligned with the SQL merge so SyncInbound
 					// below does not re-apply pre-update values from this same call.
 					priorExpiry := existing.ExpiryTime
-					existing.ExpiryTime = mergeActivationExpiry(priorExpiry, cs.ExpiryTime)
-					if !cs.Enable && !staleNodeDisable(priorExpiry, cs.ExpiryTime) {
+					if !cs.Enable && !staleNodeDisable(existing, cs.ExpiryTime) {
 						existing.Enable = false
 					}
+					existing.ExpiryTime = mergeActivationExpiry(priorExpiry, cs.ExpiryTime)
 				}
 			}
 			if err := s.upsertNodeBaseline(tx, nodeID, cs.Email, canon.Up, canon.Down); err != nil {
@@ -1030,19 +1053,15 @@ func (s *InboundService) setRemoteTrafficLocked(nodeID int, snap *runtime.Traffi
 			if existing != nil {
 				clients[i].ExpiryTime = mergeActivationExpiry(existing.ExpiryTime, nodeSettingsExpiry)
 			}
-			if cs, hit := csByEmail[clients[i].Email]; hit && !cs.Enable {
-				masterExpiry := clients[i].ExpiryTime
-				if existing != nil {
-					masterExpiry = existing.ExpiryTime
+			if !clients[i].Enable {
+				nodeExpiry := nodeSettingsExpiry
+				if cs, hit := csByEmail[clients[i].Email]; hit {
+					nodeExpiry = cs.ExpiryTime
 				}
-				if staleNodeDisable(masterExpiry, cs.ExpiryTime) {
+				if staleNodeDisable(existing, nodeExpiry) && existing != nil {
 					// Settings JSON already carries enable=false; restore the
 					// traffic-row enable so SyncInbound does not disable the record.
-					if existing != nil {
-						clients[i].Enable = existing.Enable
-					}
-				} else {
-					clients[i].Enable = false
+					clients[i].Enable = existing.Enable
 				}
 			}
 			filtered = append(filtered, clients[i])

--- a/internal/web/service/inbound_node.go
+++ b/internal/web/service/inbound_node.go
@@ -223,13 +223,9 @@ func (s *InboundService) upsertNodeBaseline(tx *gorm.DB, nodeID int, email strin
 // keeps reporting the negative duration — which must never reset a deadline
 // another node already activated.
 //
-// A node may legitimately move an already-activated deadline forward (traffic
-// reset / auto-renew extends it), so a later absolute value is still adopted.
-// An earlier absolute value is rejected: after an admin extends an expired
-// client on the master, a node that has not yet received the push keeps
-// reporting the previous (past) deadline, and adopting it would undo the
-// extension and make disableInvalidClients remove the client again (#6228).
-// Kept in lockstep with the SQL CASE in setRemoteTrafficLocked.
+// A later absolute value is still adopted (auto-renew). An earlier absolute is
+// rejected so a stale post-expire node snapshot cannot undo a master extension
+// (#6228). Lockstep with ClientTrafficExpiryMergeExpr.
 func mergeActivationExpiry(existing, node int64) int64 {
 	if existing > 0 && (node <= 0 || node < existing) {
 		return existing
@@ -237,14 +233,10 @@ func mergeActivationExpiry(existing, node int64) int64 {
 	return node
 }
 
-// nodeDisableIsStale reports a node-side enable=false that must not latch the
-// master's client_traffics.enable off. After an expired client is extended on
-// the master, a node still enforcing the previous deadline disables locally and
-// would otherwise one-way-merge that disable onto the master (#4917 / #6228).
-func nodeDisableIsStale(masterExpiry, nodeExpiry int64, nodeEnable bool) bool {
-	if nodeEnable {
-		return false
-	}
+// staleNodeDisable is true when a node enable=false carries an older absolute
+// expiry than the master. That disable must not latch master enable off after
+// an extension (#6228); same-expiry quota disables still latch (#4917).
+func staleNodeDisable(masterExpiry, nodeExpiry int64) bool {
 	return masterExpiry > 0 && nodeExpiry > 0 && nodeExpiry < masterExpiry
 }
 
@@ -673,6 +665,9 @@ func (s *InboundService) setRemoteTrafficLocked(nodeID int, snap *runtime.Traffi
 		if deduped, changed := dedupeSettingsClients(adoptedSettings); changed {
 			adoptedSettings = deduped
 		}
+		if lifted, changed := liftClientLifecycleInSettings(adoptedSettings, centralCSByEmail); changed {
+			adoptedSettings = lifted
+		}
 
 		updates := map[string]any{}
 		if !dirty {
@@ -900,30 +895,26 @@ func (s *InboundService) setRemoteTrafficLocked(nodeID int, snap *runtime.Traffi
 				if err := clearGlobalTraffic(tx, cs.Email); err != nil {
 					return false, err
 				}
+				existing.Up = canon.Up
+				existing.Down = canon.Down
+				existing.Enable = cs.Enable
+				existing.Total = cs.Total
+				existing.ExpiryTime = cs.ExpiryTime
+				existing.Reset = cs.Reset
 			} else {
 				enableExpr := database.ClientTrafficEnableMergeExpr()
-				// expiry_time merge mirrors mergeActivationExpiry: a node that has not
-				// yet seen the client's first connection keeps reporting the negative
-				// "start after first connect" duration, which must never reset the
-				// absolute deadline another node already activated. A later absolute
-				// value is still adopted (auto-renew); an earlier absolute value is
-				// rejected so a stale post-expire node snapshot cannot undo a master
-				// extension (#6228). CAST(? AS BIGINT): in the comparisons Postgres
-				// would otherwise infer int4 from the literal and overflow on real
-				// expiry values.
+				expiryExpr := database.ClientTrafficExpiryMergeExpr()
 				if err := tx.Exec(
 					fmt.Sprintf(
 						`UPDATE client_traffics
 						 SET up = %s, down = %s, enable = %s, total = ?,
-						     expiry_time = CASE
-						       WHEN expiry_time > 0 AND (CAST(? AS BIGINT) <= 0 OR CAST(? AS BIGINT) < expiry_time) THEN expiry_time
-						       ELSE CAST(? AS BIGINT)
-						     END,
+						     expiry_time = %s,
 						     reset = ?, last_online = %s
 						 WHERE email = ?`,
 						database.ClampedAddExpr("up"),
 						database.ClampedAddExpr("down"),
 						enableExpr,
+						expiryExpr,
 						database.GreatestExpr("last_online", "?"),
 					),
 					deltaUp, deltaDown,
@@ -933,6 +924,15 @@ func (s *InboundService) setRemoteTrafficLocked(nodeID int, snap *runtime.Traffi
 					cs.LastOnline, cs.Email,
 				).Error; err != nil {
 					return false, err
+				}
+				if existing != nil {
+					// Keep the in-memory row aligned with the SQL merge so SyncInbound
+					// below does not re-apply pre-update values from this same call.
+					priorExpiry := existing.ExpiryTime
+					existing.ExpiryTime = mergeActivationExpiry(priorExpiry, cs.ExpiryTime)
+					if !cs.Enable && !staleNodeDisable(priorExpiry, cs.ExpiryTime) {
+						existing.Enable = false
+					}
 				}
 			}
 			if err := s.upsertNodeBaseline(tx, nodeID, cs.Email, canon.Up, canon.Down); err != nil {
@@ -1025,20 +1025,23 @@ func (s *InboundService) setRemoteTrafficLocked(nodeID int, snap *runtime.Traffi
 			if isClientEmailTombstoned(clients[i].Email) {
 				continue
 			}
-			if existing := centralCSByEmail[clients[i].Email]; existing != nil {
-				// Prefer the merged traffic-row deadline so SyncInbound does not
-				// rewrite client records / links from a stale node settings JSON.
-				clients[i].ExpiryTime = mergeActivationExpiry(existing.ExpiryTime, clients[i].ExpiryTime)
+			existing := centralCSByEmail[clients[i].Email]
+			nodeSettingsExpiry := clients[i].ExpiryTime
+			if existing != nil {
+				clients[i].ExpiryTime = mergeActivationExpiry(existing.ExpiryTime, nodeSettingsExpiry)
 			}
-			if cs, hit := csByEmail[clients[i].Email]; hit {
+			if cs, hit := csByEmail[clients[i].Email]; hit && !cs.Enable {
 				masterExpiry := clients[i].ExpiryTime
-				if existing := centralCSByEmail[clients[i].Email]; existing != nil {
-					masterExpiry = mergeActivationExpiry(existing.ExpiryTime, cs.ExpiryTime)
+				if existing != nil {
+					masterExpiry = existing.ExpiryTime
 				}
-				if nodeDisableIsStale(masterExpiry, cs.ExpiryTime, cs.Enable) {
-					// Keep the master's enable: the node is disabling against an
-					// older deadline than the shared traffic row already holds.
-				} else if !cs.Enable {
+				if staleNodeDisable(masterExpiry, cs.ExpiryTime) {
+					// Settings JSON already carries enable=false; restore the
+					// traffic-row enable so SyncInbound does not disable the record.
+					if existing != nil {
+						clients[i].Enable = existing.Enable
+					}
+				} else {
 					clients[i].Enable = false
 				}
 			}

--- a/internal/web/service/inbound_node.go
+++ b/internal/web/service/inbound_node.go
@@ -545,6 +545,7 @@ func (s *InboundService) setRemoteTrafficLocked(nodeID int, snap *runtime.Traffi
 	}()
 
 	structuralChange := false
+	lifecycleLifted := false
 
 	var adoptedInbounds []*model.Inbound
 
@@ -683,13 +684,15 @@ func (s *InboundService) setRemoteTrafficLocked(nodeID int, snap *runtime.Traffi
 		if deduped, changed := dedupeSettingsClients(adoptedSettings); changed {
 			adoptedSettings = deduped
 		}
-		// Lift after strip/dedupe, but keep the pre-lift blob for the reconcile
-		// fingerprint: RecordAdoptedInbound must reflect what the node reported,
-		// or ReconcileInbound will skip re-pushing the corrected clients.
+		// Lift after strip/dedupe. Fingerprint the pre-lift blob only — never the
+		// lifted form — so ReconcileInbound sees a mismatch against central
+		// (lifted) settings and re-pushes. When a lift ran, also mark the node
+		// dirty: reconcile only runs on the dirty path.
 		wireSettings := adoptedSettings
 		lifted, liftChanged := liftClientLifecycleInSettings(adoptedSettings, centralCSByEmail)
 		if liftChanged {
 			adoptedSettings = lifted
+			lifecycleLifted = true
 		}
 
 		updates := map[string]any{}
@@ -708,7 +711,7 @@ func (s *InboundService) setRemoteTrafficLocked(nodeID int, snap *runtime.Traffi
 			updates["traffic_reset"] = snapIb.TrafficReset
 			updates["traffic_reset_day"] = normalizeTrafficResetDay(snapIb.TrafficResetDay)
 			updates["last_traffic_reset_time"] = snapIb.LastTrafficResetTime
-			if !liftChanged && adoptedWireChanged(c, snapIb, wireSettings) {
+			if liftChanged || adoptedWireChanged(c, snapIb, wireSettings) {
 				adoptedInbounds = append(adoptedInbounds, adoptedWireInbound(c, snapIb, wireSettings))
 			}
 		}
@@ -1053,14 +1056,16 @@ func (s *InboundService) setRemoteTrafficLocked(nodeID int, snap *runtime.Traffi
 			if existing != nil {
 				clients[i].ExpiryTime = mergeActivationExpiry(existing.ExpiryTime, nodeSettingsExpiry)
 			}
-			if !clients[i].Enable {
-				nodeExpiry := nodeSettingsExpiry
-				if cs, hit := csByEmail[clients[i].Email]; hit {
-					nodeExpiry = cs.ExpiryTime
+			if cs, hit := csByEmail[clients[i].Email]; hit && !cs.Enable {
+				if staleNodeDisable(existing, cs.ExpiryTime) {
+					if existing != nil {
+						clients[i].Enable = existing.Enable
+					}
+				} else {
+					clients[i].Enable = false
 				}
-				if staleNodeDisable(existing, nodeExpiry) && existing != nil {
-					// Settings JSON already carries enable=false; restore the
-					// traffic-row enable so SyncInbound does not disable the record.
+			} else if !clients[i].Enable {
+				if staleNodeDisable(existing, nodeSettingsExpiry) && existing != nil {
 					clients[i].Enable = existing.Enable
 				}
 			}
@@ -1151,6 +1156,15 @@ func (s *InboundService) setRemoteTrafficLocked(nodeID int, snap *runtime.Traffi
 		return false, err
 	}
 	committed = true
+
+	if lifecycleLifted && !dirty {
+		// Node still reports pre-extension clients; dirty so the next sync tick
+		// reconciles. Adoption fingerprint was stamped from wireSettings (stale),
+		// so ReconcileInbound mismatches the lifted DB row and actually pushes.
+		if err := (&NodeService{}).MarkNodeDirty(nodeID); err != nil {
+			logger.Warningf("setRemoteTraffic: mark node %d dirty after lifecycle lift failed: %v", nodeID, err)
+		}
+	}
 
 	if len(adoptedInbounds) > 0 {
 		if mgr := runtime.GetManager(); mgr != nil {

--- a/internal/web/service/node_client_expiry_sync_test.go
+++ b/internal/web/service/node_client_expiry_sync_test.go
@@ -255,6 +255,47 @@ func TestNodeStaleExpiryAfterExtend_NotClobbered(t *testing.T) {
 	}
 }
 
+// TestNodeStaleLift_MarksNodeDirtyAndFingerprintsWire: a lifecycle lift must
+// (1) leave the adoption fingerprint on the pre-lift node blob and (2) mark the
+// node dirty so ReconcileInbound actually re-pushes the lifted central settings.
+func TestNodeStaleLift_MarksNodeDirty(t *testing.T) {
+	db := initTrafficTestDB(t)
+	node := &model.Node{Name: "lift-n", Address: "127.0.0.1", Port: 2097, ApiToken: "tok", Enable: true, Status: "online"}
+	if err := db.Create(node).Error; err != nil {
+		t.Fatalf("create node: %v", err)
+	}
+	createNodeInboundWithClient(t, db, node.Id, "n1-in", 41001, "extended")
+	svc := &InboundService{}
+
+	const email = "extended"
+	const expired = earlyAbs
+	const extended = lateAbs
+	staleSettings := fmt.Sprintf(
+		`{"clients":[{"email":%q,"enable":false,"expiryTime":%d}]}`, email, expired)
+
+	syncNodeWithSettings(t, svc, node.Id, "n1-in", staleSettings,
+		xray.ClientTraffic{Email: email, ExpiryTime: expired, Enable: false})
+	if err := db.Model(xray.ClientTraffic{}).Where("email = ?", email).
+		Updates(map[string]any{"expiry_time": extended, "enable": true}).Error; err != nil {
+		t.Fatalf("master extend: %v", err)
+	}
+	if err := db.Model(model.Node{}).Where("id = ?", node.Id).
+		Updates(map[string]any{"config_dirty": false, "config_dirty_at": int64(0)}).Error; err != nil {
+		t.Fatalf("clear dirty: %v", err)
+	}
+
+	syncNodeWithSettings(t, svc, node.Id, "n1-in", staleSettings,
+		xray.ClientTraffic{Email: email, ExpiryTime: expired, Enable: false})
+
+	var n model.Node
+	if err := db.Select("config_dirty").Where("id = ?", node.Id).First(&n).Error; err != nil {
+		t.Fatalf("read node: %v", err)
+	}
+	if !n.ConfigDirty {
+		t.Fatal("lifecycle lift must mark the node dirty so reconcile re-pushes")
+	}
+}
+
 // TestNodeQuotaDisable_SameExpiryStillLatches ensures #4917 stays intact: a
 // node disable for traffic quota (same absolute expiry as the master) must
 // still one-way-merge enable=false onto the master.

--- a/internal/web/service/node_client_expiry_sync_test.go
+++ b/internal/web/service/node_client_expiry_sync_test.go
@@ -1,6 +1,7 @@
 package service
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/mhsanaei/3x-ui/v3/internal/database/model"
@@ -37,7 +38,7 @@ func TestMergeActivationExpiry(t *testing.T) {
 	}
 }
 
-func TestNodeDisableIsStale(t *testing.T) {
+func TestStaleNodeDisable(t *testing.T) {
 	const (
 		early = int64(1000)
 		late  = int64(2000)
@@ -45,20 +46,19 @@ func TestNodeDisableIsStale(t *testing.T) {
 	cases := []struct {
 		name                  string
 		masterExpiry, nodeExp int64
-		nodeEnable, wantStale bool
+		wantStale             bool
 	}{
-		{"node still enabled", late, early, true, false},
-		{"same absolute deadline", late, late, false, false},
-		{"node older than master after extend", late, early, false, true},
-		{"node newer renewal disable", early, late, false, false},
-		{"unactivated node", late, -1, false, false},
-		{"unlimited master", 0, early, false, false},
+		{"same absolute deadline", late, late, false},
+		{"node older than master after extend", late, early, true},
+		{"node newer renewal", early, late, false},
+		{"unactivated node", late, -1, false},
+		{"unlimited master", 0, early, false},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			if got := nodeDisableIsStale(c.masterExpiry, c.nodeExp, c.nodeEnable); got != c.wantStale {
-				t.Fatalf("nodeDisableIsStale(%d,%d,%v) = %v, want %v",
-					c.masterExpiry, c.nodeExp, c.nodeEnable, got, c.wantStale)
+			if got := staleNodeDisable(c.masterExpiry, c.nodeExp); got != c.wantStale {
+				t.Fatalf("staleNodeDisable(%d,%d) = %v, want %v",
+					c.masterExpiry, c.nodeExp, got, c.wantStale)
 			}
 		})
 	}
@@ -147,8 +147,6 @@ func TestNodeFirstConnectExpiry_NotClobbered_WithSettings(t *testing.T) {
 // TestNodeRenewExtendsExpiry guards against over-correcting: a node that renews
 // a client (traffic reset / auto-renew) legitimately moves the deadline FORWARD
 // to a later absolute timestamp, and that must still propagate to the master.
-// The guard rejects un-activated (<= 0) values and earlier absolute deadlines,
-// never a later positive one.
 func TestNodeRenewExtendsExpiry(t *testing.T) {
 	db := initTrafficTestDB(t)
 	createNodeInbound(t, db, 1, "n1-in", 41001)
@@ -170,22 +168,20 @@ func TestNodeRenewExtendsExpiry(t *testing.T) {
 }
 
 // TestNodeStaleExpiryAfterExtend_NotClobbered reproduces #6228: a client expires,
-// the admin extends it on the master (shared client_traffics gets a later
-// deadline and is re-enabled), then a node that still holds the previous
+// the admin extends it on the master, then a node that still holds the previous
 // deadline syncs enable=false + the old expiry. That snapshot must not undo the
-// extension or latch the master disable — otherwise the client is removed again
-// with "due to expiration or traffic limit".
+// extension on traffics, client records, or the adopted inbound settings JSON.
 func TestNodeStaleExpiryAfterExtend_NotClobbered(t *testing.T) {
 	db := initTrafficTestDB(t)
 	createNodeInboundWithClient(t, db, 1, "n1-in", 41001, "extended")
 	svc := &InboundService{}
 
 	const email = "extended"
-	const expired = int64(1786835245763)  // past
-	const extended = int64(1789427245763) // later extension on the master
+	const expired = int64(1786835245763)
+	const extended = int64(1789427245763)
 
-	staleSettings := `{"clients":[{"email":"extended","enable":false,"expiryTime":1786835245763}]}`
-	liveSettings := `{"clients":[{"email":"extended","enable":true,"expiryTime":1789427245763}]}`
+	staleSettings := fmt.Sprintf(
+		`{"clients":[{"email":%q,"enable":false,"expiryTime":%d}]}`, email, expired)
 
 	syncNodeWithSettings(t, svc, 1, "n1-in", staleSettings,
 		xray.ClientTraffic{Email: email, ExpiryTime: expired, Enable: false})
@@ -194,30 +190,60 @@ func TestNodeStaleExpiryAfterExtend_NotClobbered(t *testing.T) {
 			got.ExpiryTime, got.Enable, expired)
 	}
 
-	// Master-side extension (UpdateClientStat / BulkAdjust) lands on the shared row.
 	if err := db.Model(xray.ClientTraffic{}).Where("email = ?", email).
 		Updates(map[string]any{"expiry_time": extended, "enable": true}).Error; err != nil {
-		t.Fatalf("master extend: %v", err)
+		t.Fatalf("master extend traffic: %v", err)
+	}
+	if err := db.Model(&model.ClientRecord{}).Where("email = ?", email).
+		Updates(map[string]any{"expiry_time": extended, "enable": true}).Error; err != nil {
+		t.Fatalf("master extend record: %v", err)
 	}
 
-	// Stale node snapshot still reporting the previous deadline + disable.
 	syncNodeWithSettings(t, svc, 1, "n1-in", staleSettings,
 		xray.ClientTraffic{Email: email, ExpiryTime: expired, Enable: false})
+
 	got := readTraffic(t, db, email)
 	if got.ExpiryTime != extended {
-		t.Fatalf("stale node expiry clobbered the extension: expiry=%d, want %d", got.ExpiryTime, extended)
+		t.Fatalf("stale node expiry clobbered traffics: expiry=%d, want %d", got.ExpiryTime, extended)
 	}
 	if !got.Enable {
-		t.Fatal("stale node disable latched the master enable off after extension")
+		t.Fatal("stale node disable latched traffics.enable off after extension")
 	}
 
-	// A live node that has received the extension may still report it.
-	syncNodeWithSettings(t, svc, 1, "n1-in", liveSettings,
-		xray.ClientTraffic{Email: email, Up: 1, Down: 1, ExpiryTime: extended, Enable: true})
-	got = readTraffic(t, db, email)
-	if got.ExpiryTime != extended || !got.Enable {
-		t.Fatalf("after live sync: expiry=%d enable=%v, want expiry=%d enable=true",
-			got.ExpiryTime, got.Enable, extended)
+	var rec model.ClientRecord
+	if err := db.Where("email = ?", email).First(&rec).Error; err != nil {
+		t.Fatalf("read client record: %v", err)
+	}
+	if rec.ExpiryTime != extended {
+		t.Fatalf("stale SyncInbound clobbered record expiry: %d, want %d", rec.ExpiryTime, extended)
+	}
+	if !rec.Enable {
+		t.Fatal("stale SyncInbound latched clients.enable off after extension")
+	}
+
+	var ib model.Inbound
+	if err := db.Where("tag = ?", "n1-in").First(&ib).Error; err != nil {
+		t.Fatalf("read inbound: %v", err)
+	}
+	clients, err := svc.GetClients(&ib)
+	if err != nil {
+		t.Fatalf("GetClients: %v", err)
+	}
+	var found bool
+	for _, c := range clients {
+		if c.Email != email {
+			continue
+		}
+		found = true
+		if c.ExpiryTime != extended {
+			t.Fatalf("adopted settings kept stale expiry: %d, want %d", c.ExpiryTime, extended)
+		}
+		if !c.Enable {
+			t.Fatal("adopted settings kept enable=false after extension")
+		}
+	}
+	if !found {
+		t.Fatal("client missing from adopted inbound settings after stale sync")
 	}
 }
 
@@ -235,11 +261,6 @@ func TestNodeQuotaDisable_SameExpiryStillLatches(t *testing.T) {
 	syncNode(t, svc, 1, "n1-in", xray.ClientTraffic{
 		Email: email, Up: 10, Down: 10, Total: 100, ExpiryTime: expiry, Enable: true,
 	})
-	if err := db.Model(xray.ClientTraffic{}).Where("email = ?", email).
-		Updates(map[string]any{"enable": true, "up": 10, "down": 10, "total": 100}).Error; err != nil {
-		t.Fatalf("seed master enable: %v", err)
-	}
-
 	syncNode(t, svc, 1, "n1-in", xray.ClientTraffic{
 		Email: email, Up: 60, Down: 50, Total: 100, ExpiryTime: expiry, Enable: false,
 	})

--- a/internal/web/service/node_client_expiry_sync_test.go
+++ b/internal/web/service/node_client_expiry_sync_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/mhsanaei/3x-ui/v3/internal/database"
 	"github.com/mhsanaei/3x-ui/v3/internal/database/model"
 	"github.com/mhsanaei/3x-ui/v3/internal/xray"
 )
@@ -44,21 +45,28 @@ func TestStaleNodeDisable(t *testing.T) {
 		late  = int64(2000)
 	)
 	cases := []struct {
-		name                  string
-		masterExpiry, nodeExp int64
-		wantStale             bool
+		name      string
+		master    *xray.ClientTraffic
+		nodeExp   int64
+		wantStale bool
 	}{
-		{"same absolute deadline", late, late, false},
-		{"node older than master after extend", late, early, true},
-		{"node newer renewal", early, late, false},
-		{"unactivated node", late, -1, false},
-		{"unlimited master", 0, early, false},
+		{"nil master", nil, early, false},
+		{"same absolute deadline", &xray.ClientTraffic{ExpiryTime: late}, late, false},
+		{"node older than master after extend", &xray.ClientTraffic{ExpiryTime: late}, early, true},
+		{"node newer renewal", &xray.ClientTraffic{ExpiryTime: early}, late, false},
+		{"unactivated node", &xray.ClientTraffic{ExpiryTime: late}, -1, false},
+		{"unlimited master", &xray.ClientTraffic{ExpiryTime: 0}, early, false},
+		{"older expiry but master over quota", &xray.ClientTraffic{
+			ExpiryTime: late, Total: 100, Up: 60, Down: 50,
+		}, early, false},
+		{"older expiry under quota still stale", &xray.ClientTraffic{
+			ExpiryTime: late, Total: 100, Up: 10, Down: 10,
+		}, early, true},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			if got := staleNodeDisable(c.masterExpiry, c.nodeExp); got != c.wantStale {
-				t.Fatalf("staleNodeDisable(%d,%d) = %v, want %v",
-					c.masterExpiry, c.nodeExp, got, c.wantStale)
+			if got := staleNodeDisable(c.master, c.nodeExp); got != c.wantStale {
+				t.Fatalf("staleNodeDisable(...) = %v, want %v", got, c.wantStale)
 			}
 		})
 	}
@@ -268,6 +276,139 @@ func TestNodeQuotaDisable_SameExpiryStillLatches(t *testing.T) {
 		t.Fatal("same-expiry node disable must still latch master enable off (#4917)")
 	}
 }
+
+// TestNodeQuotaDisable_OlderExpiryStillLatchesWhenOverQuota: once the master
+// row is already depleted, a node disable must latch even if its expiry lags
+// the merged max — otherwise staleNodeDisable would skip genuine quota cuts.
+func TestNodeQuotaDisable_OlderExpiryStillLatchesWhenOverQuota(t *testing.T) {
+	db := initTrafficTestDB(t)
+	createNodeInbound(t, db, 1, "n1-in", 41001)
+	svc := &InboundService{}
+
+	const email = "quota-lag"
+	const early = int64(1786835245763)
+	const late = int64(1789427245763)
+
+	syncNode(t, svc, 1, "n1-in", xray.ClientTraffic{
+		Email: email, Up: 10, Down: 10, Total: 100, ExpiryTime: late, Enable: true,
+	})
+	if err := db.Model(xray.ClientTraffic{}).Where("email = ?", email).
+		Updates(map[string]any{
+			"expiry_time": late, "enable": true, "up": int64(60), "down": int64(50), "total": int64(100),
+		}).Error; err != nil {
+		t.Fatalf("seed over-quota master: %v", err)
+	}
+
+	syncNode(t, svc, 1, "n1-in", xray.ClientTraffic{
+		Email: email, Up: 60, Down: 50, Total: 100, ExpiryTime: early, Enable: false,
+	})
+	if got := readTraffic(t, db, email); got.Enable {
+		t.Fatal("over-quota master must still adopt node disable despite older node expiry")
+	}
+	if got := readTraffic(t, db, email); got.ExpiryTime != late {
+		t.Fatalf("expiry should stay at master extension: got %d want %d", got.ExpiryTime, late)
+	}
+}
+
+// TestClientTrafficMergeSQLMatchesHelpers pins the dialect SQL expressions
+// against the Go helpers so the in-memory replay after UPDATE cannot drift.
+func TestClientTrafficMergeSQLMatchesHelpers(t *testing.T) {
+	db := initTrafficTestDB(t)
+
+	const email = "sql-merge"
+	cases := []struct {
+		name                      string
+		masterExpiry              int64
+		masterEnable              bool
+		masterUp, masterDown, tot int64
+		nodeExpiry                int64
+		nodeEnable                bool
+		wantExpiry                int64
+		wantEnable                bool
+	}{
+		{
+			name:         "stale expiry+disable after extend",
+			masterExpiry: lateAbs, masterEnable: true,
+			nodeExpiry: earlyAbs, nodeEnable: false,
+			wantExpiry: lateAbs, wantEnable: true,
+		},
+		{
+			name:         "same expiry quota disable",
+			masterExpiry: lateAbs, masterEnable: true,
+			masterUp: 60, masterDown: 50, tot: 100,
+			nodeExpiry: lateAbs, nodeEnable: false,
+			wantExpiry: lateAbs, wantEnable: false,
+		},
+		{
+			name:         "older expiry but master over quota",
+			masterExpiry: lateAbs, masterEnable: true,
+			masterUp: 60, masterDown: 50, tot: 100,
+			nodeExpiry: earlyAbs, nodeEnable: false,
+			wantExpiry: lateAbs, wantEnable: false,
+		},
+		{
+			name:         "renewal extends forward",
+			masterExpiry: earlyAbs, masterEnable: true,
+			nodeExpiry: lateAbs, nodeEnable: true,
+			wantExpiry: lateAbs, wantEnable: true,
+		},
+		{
+			name:         "negative node keeps absolute",
+			masterExpiry: lateAbs, masterEnable: true,
+			nodeExpiry: -2592000000, nodeEnable: true,
+			wantExpiry: lateAbs, wantEnable: true,
+		},
+	}
+
+	enableExpr := database.ClientTrafficEnableMergeExpr()
+	expiryExpr := database.ClientTrafficExpiryMergeExpr()
+	for i, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			rowEmail := fmt.Sprintf("%s-%d", email, i)
+			if err := db.Create(&xray.ClientTraffic{
+				InboundId: 1, Email: rowEmail, Enable: c.masterEnable,
+				ExpiryTime: c.masterExpiry, Up: c.masterUp, Down: c.masterDown, Total: c.tot,
+			}).Error; err != nil {
+				t.Fatalf("seed: %v", err)
+			}
+			master := &xray.ClientTraffic{
+				ExpiryTime: c.masterExpiry, Enable: c.masterEnable,
+				Up: c.masterUp, Down: c.masterDown, Total: c.tot,
+			}
+			wantExpiry := mergeActivationExpiry(c.masterExpiry, c.nodeExpiry)
+			wantEnable := c.masterEnable
+			if !c.nodeEnable && !staleNodeDisable(master, c.nodeExpiry) {
+				wantEnable = false
+			}
+			if wantExpiry != c.wantExpiry || wantEnable != c.wantEnable {
+				t.Fatalf("helper expectation drift: helpers=(%d,%v) fixture=(%d,%v)",
+					wantExpiry, wantEnable, c.wantExpiry, c.wantEnable)
+			}
+
+			if err := db.Exec(
+				fmt.Sprintf(
+					`UPDATE client_traffics SET enable = %s, expiry_time = %s WHERE email = ?`,
+					enableExpr, expiryExpr,
+				),
+				c.nodeEnable, c.nodeExpiry, c.nodeExpiry,
+				c.nodeExpiry, c.nodeExpiry, c.nodeExpiry,
+				rowEmail,
+			).Error; err != nil {
+				t.Fatalf("SQL merge: %v", err)
+			}
+			got := readTraffic(t, db, rowEmail)
+			if got.ExpiryTime != c.wantExpiry || got.Enable != c.wantEnable {
+				t.Fatalf("SQL merge got expiry=%d enable=%v, want expiry=%d enable=%v",
+					got.ExpiryTime, got.Enable, c.wantExpiry, c.wantEnable)
+			}
+		})
+	}
+}
+
+const (
+	earlyAbs = int64(1786835245763)
+	lateAbs  = int64(1789427245763)
+)
 
 // TestNodeActivationLiftsClientRecordExpiry reproduces #5714: the node activates
 // the deadline (positive ClientStats) while its settings JSON still carries the

--- a/internal/web/service/node_client_expiry_sync_test.go
+++ b/internal/web/service/node_client_expiry_sync_test.go
@@ -25,13 +25,40 @@ func TestMergeActivationExpiry(t *testing.T) {
 		{"node still un-activated does not reset deadline", early, dur, early},
 		{"node un-activated zero does not reset deadline", early, 0, early},
 		{"node renewal extends the deadline forward", early, late, late},
-		{"node positive adopted even if earlier", late, early, early},
+		{"stale earlier absolute does not clobber later", late, early, late},
 		{"both un-activated keep node value", dur, dur, dur},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
 			if got := mergeActivationExpiry(c.existing, c.node); got != c.want {
 				t.Fatalf("mergeActivationExpiry(%d,%d) = %d, want %d", c.existing, c.node, got, c.want)
+			}
+		})
+	}
+}
+
+func TestNodeDisableIsStale(t *testing.T) {
+	const (
+		early = int64(1000)
+		late  = int64(2000)
+	)
+	cases := []struct {
+		name                  string
+		masterExpiry, nodeExp int64
+		nodeEnable, wantStale bool
+	}{
+		{"node still enabled", late, early, true, false},
+		{"same absolute deadline", late, late, false, false},
+		{"node older than master after extend", late, early, false, true},
+		{"node newer renewal disable", early, late, false, false},
+		{"unactivated node", late, -1, false, false},
+		{"unlimited master", 0, early, false, false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := nodeDisableIsStale(c.masterExpiry, c.nodeExp, c.nodeEnable); got != c.wantStale {
+				t.Fatalf("nodeDisableIsStale(%d,%d,%v) = %v, want %v",
+					c.masterExpiry, c.nodeExp, c.nodeEnable, got, c.wantStale)
 			}
 		})
 	}
@@ -120,7 +147,8 @@ func TestNodeFirstConnectExpiry_NotClobbered_WithSettings(t *testing.T) {
 // TestNodeRenewExtendsExpiry guards against over-correcting: a node that renews
 // a client (traffic reset / auto-renew) legitimately moves the deadline FORWARD
 // to a later absolute timestamp, and that must still propagate to the master.
-// The guard only rejects un-activated (<= 0) values, never a positive one.
+// The guard rejects un-activated (<= 0) values and earlier absolute deadlines,
+// never a later positive one.
 func TestNodeRenewExtendsExpiry(t *testing.T) {
 	db := initTrafficTestDB(t)
 	createNodeInbound(t, db, 1, "n1-in", 41001)
@@ -138,6 +166,85 @@ func TestNodeRenewExtendsExpiry(t *testing.T) {
 	syncNode(t, svc, 1, "n1-in", xray.ClientTraffic{Email: email, Up: 20, Down: 20, ExpiryTime: renewed, Enable: true})
 	if got := readTraffic(t, db, email).ExpiryTime; got != renewed {
 		t.Fatalf("node renewal did not propagate: expiry = %d, want %d", got, renewed)
+	}
+}
+
+// TestNodeStaleExpiryAfterExtend_NotClobbered reproduces #6228: a client expires,
+// the admin extends it on the master (shared client_traffics gets a later
+// deadline and is re-enabled), then a node that still holds the previous
+// deadline syncs enable=false + the old expiry. That snapshot must not undo the
+// extension or latch the master disable — otherwise the client is removed again
+// with "due to expiration or traffic limit".
+func TestNodeStaleExpiryAfterExtend_NotClobbered(t *testing.T) {
+	db := initTrafficTestDB(t)
+	createNodeInboundWithClient(t, db, 1, "n1-in", 41001, "extended")
+	svc := &InboundService{}
+
+	const email = "extended"
+	const expired = int64(1786835245763)  // past
+	const extended = int64(1789427245763) // later extension on the master
+
+	staleSettings := `{"clients":[{"email":"extended","enable":false,"expiryTime":1786835245763}]}`
+	liveSettings := `{"clients":[{"email":"extended","enable":true,"expiryTime":1789427245763}]}`
+
+	syncNodeWithSettings(t, svc, 1, "n1-in", staleSettings,
+		xray.ClientTraffic{Email: email, ExpiryTime: expired, Enable: false})
+	if got := readTraffic(t, db, email); got.ExpiryTime != expired || got.Enable {
+		t.Fatalf("after expiry: expiry=%d enable=%v, want expiry=%d enable=false",
+			got.ExpiryTime, got.Enable, expired)
+	}
+
+	// Master-side extension (UpdateClientStat / BulkAdjust) lands on the shared row.
+	if err := db.Model(xray.ClientTraffic{}).Where("email = ?", email).
+		Updates(map[string]any{"expiry_time": extended, "enable": true}).Error; err != nil {
+		t.Fatalf("master extend: %v", err)
+	}
+
+	// Stale node snapshot still reporting the previous deadline + disable.
+	syncNodeWithSettings(t, svc, 1, "n1-in", staleSettings,
+		xray.ClientTraffic{Email: email, ExpiryTime: expired, Enable: false})
+	got := readTraffic(t, db, email)
+	if got.ExpiryTime != extended {
+		t.Fatalf("stale node expiry clobbered the extension: expiry=%d, want %d", got.ExpiryTime, extended)
+	}
+	if !got.Enable {
+		t.Fatal("stale node disable latched the master enable off after extension")
+	}
+
+	// A live node that has received the extension may still report it.
+	syncNodeWithSettings(t, svc, 1, "n1-in", liveSettings,
+		xray.ClientTraffic{Email: email, Up: 1, Down: 1, ExpiryTime: extended, Enable: true})
+	got = readTraffic(t, db, email)
+	if got.ExpiryTime != extended || !got.Enable {
+		t.Fatalf("after live sync: expiry=%d enable=%v, want expiry=%d enable=true",
+			got.ExpiryTime, got.Enable, extended)
+	}
+}
+
+// TestNodeQuotaDisable_SameExpiryStillLatches ensures #4917 stays intact: a
+// node disable for traffic quota (same absolute expiry as the master) must
+// still one-way-merge enable=false onto the master.
+func TestNodeQuotaDisable_SameExpiryStillLatches(t *testing.T) {
+	db := initTrafficTestDB(t)
+	createNodeInbound(t, db, 1, "n1-in", 41001)
+	svc := &InboundService{}
+
+	const email = "quota"
+	const expiry = int64(1893456000000)
+
+	syncNode(t, svc, 1, "n1-in", xray.ClientTraffic{
+		Email: email, Up: 10, Down: 10, Total: 100, ExpiryTime: expiry, Enable: true,
+	})
+	if err := db.Model(xray.ClientTraffic{}).Where("email = ?", email).
+		Updates(map[string]any{"enable": true, "up": 10, "down": 10, "total": 100}).Error; err != nil {
+		t.Fatalf("seed master enable: %v", err)
+	}
+
+	syncNode(t, svc, 1, "n1-in", xray.ClientTraffic{
+		Email: email, Up: 60, Down: 50, Total: 100, ExpiryTime: expiry, Enable: false,
+	})
+	if got := readTraffic(t, db, email); got.Enable {
+		t.Fatal("same-expiry node disable must still latch master enable off (#4917)")
 	}
 }
 


### PR DESCRIPTION
## Summary
- After an expired client is extended on the master, a lagging node snapshot could overwrite `client_traffics.expiry_time` with the old deadline and one-way-merge `enable=false`, so the client was removed again with "due to expiration or traffic limit".
- Reject older absolute expiries on node→master merge (still allow forward renewals), ignore stale disables that carry a pre-extension deadline, and lift the same rules into adopted inbound settings / SyncInbound so client records and settings JSON stay consistent.
- Strengthens regression coverage for traffics, `clients`, and inbound settings; keeps same-expiry quota disables latching (#4917).

Fixes #6228

## Test plan
- [x] `go test ./internal/web/service/ -run 'TestMergeActivationExpiry|TestStaleNodeDisable|TestNodeFirstConnect|TestNodeRenew|TestNodeStaleExpiry|TestNodeQuotaDisable|TestNodeActivation'`
- [x] Broader `TestNode*` / `TestBulkAdjust_Reenables*` / global-traffic related suite
- [ ] Multi-node manual: expire client → extend on master → confirm affected node keeps working without detach/reattach
- [ ] Confirm quota disable with same expiry still disables (#4917)


Made with [Cursor](https://cursor.com)