### PR TITLE
fix(node): don't stamp InboundsAdoptedAt when the sync adopted nothing

### DIFF
--- a/internal/web/job/node_traffic_sync_job.go
+++ b/internal/web/job/node_traffic_sync_job.go
@@ -390,6 +390,7 @@ func (j *NodeTrafficSyncJob) syncOne(mgr *runtime.Manager, n *model.Node, doIpSy
 		return nil
 	}
 	snap.ManagedAliases = rt.AdoptedInboundAliases()
+	syncCanAdopt := syncCanAdoptInbounds(n, snap.ManagedAliases)
 	service.FilterNodeSnapshot(n, snap)
 	_, _, dirty, _, _ := j.nodeService.NodeSyncState(n.Id)
 	if !dirty {
@@ -414,7 +415,7 @@ func (j *NodeTrafficSyncJob) syncOne(mgr *runtime.Manager, n *model.Node, doIpSy
 	if changed {
 		j.structural.set()
 	}
-	if !dirty && n.InboundsAdoptedAt == 0 {
+	if !dirty && n.InboundsAdoptedAt == 0 && syncCanAdopt {
 		if markErr := j.nodeService.MarkNodeInboundsAdopted(n.Id); markErr != nil {
 			logger.Warningf("node traffic sync: mark inbounds adopted for %s failed: %v", n.Name, markErr)
 		}
@@ -474,4 +475,17 @@ func (j *NodeTrafficSyncJob) syncOne(mgr *runtime.Manager, n *model.Node, doIpSy
 		}
 	}
 	return active
+}
+
+// syncCanAdoptInbounds reports whether this sync can perform the "first
+// clean adoption" that InboundsAdoptedAt records. In selected mode the
+// snapshot filter keeps only selected tags and adopted aliases, so with
+// neither the merge adopts nothing — stamping the flag then would arm the
+// reconcile sweep against the node's pre-existing inbounds on their first
+// real sync (#6283).
+func syncCanAdoptInbounds(n *model.Node, adoptedAliases []string) bool {
+	if n == nil || n.InboundSyncMode != "selected" {
+		return true
+	}
+	return len(n.InboundTags) > 0 || len(adoptedAliases) > 0
 }

--- a/internal/web/job/node_traffic_sync_job.go
+++ b/internal/web/job/node_traffic_sync_job.go
@@ -477,12 +477,8 @@ func (j *NodeTrafficSyncJob) syncOne(mgr *runtime.Manager, n *model.Node, doIpSy
 	return active
 }
 
-// syncCanAdoptInbounds reports whether this sync can perform the "first
-// clean adoption" that InboundsAdoptedAt records. In selected mode the
-// snapshot filter keeps only selected tags and adopted aliases, so with
-// neither the merge adopts nothing — stamping the flag then would arm the
-// reconcile sweep against the node's pre-existing inbounds on their first
-// real sync (#6283).
+// Whether this sync can perform the "first clean adoption" that
+// InboundsAdoptedAt records (#6283).
 func syncCanAdoptInbounds(n *model.Node, adoptedAliases []string) bool {
 	if n == nil || n.InboundSyncMode != "selected" {
 		return true

--- a/internal/web/job/node_traffic_sync_job_test.go
+++ b/internal/web/job/node_traffic_sync_job_test.go
@@ -1,10 +1,74 @@
 package job
 
 import (
+	"sync"
 	"testing"
 
 	"github.com/mhsanaei/3x-ui/v3/internal/database/model"
 )
+
+func TestAtomicBool_DefaultIsFalse(t *testing.T) {
+	var a atomicBool
+	if a.takeAndReset() {
+		t.Fatal("default atomicBool should report false")
+	}
+}
+
+func TestAtomicBool_SetThenTakeReturnsTrueOnce(t *testing.T) {
+	var a atomicBool
+	a.set()
+	if !a.takeAndReset() {
+		t.Fatal("takeAndReset after set should return true")
+	}
+	if a.takeAndReset() {
+		t.Fatal("second takeAndReset should return false (state was reset)")
+	}
+}
+
+func TestAtomicBool_SetIsIdempotent(t *testing.T) {
+	var a atomicBool
+	a.set()
+	a.set()
+	a.set()
+	if !a.takeAndReset() {
+		t.Fatal("repeated set should still leave the flag true")
+	}
+	if a.takeAndReset() {
+		t.Fatal("flag should be cleared after the first take")
+	}
+}
+
+func TestAtomicBool_ConcurrentSettersExactlyOneTakeWins(t *testing.T) {
+	var a atomicBool
+	const setters = 100
+	const readers = 20
+
+	var wg sync.WaitGroup
+	for range setters {
+		wg.Go(func() {
+			a.set()
+		})
+	}
+	wg.Wait()
+
+	trueCount := 0
+	var rwg sync.WaitGroup
+	var mu sync.Mutex
+	for range readers {
+		rwg.Go(func() {
+			if a.takeAndReset() {
+				mu.Lock()
+				trueCount++
+				mu.Unlock()
+			}
+		})
+	}
+	rwg.Wait()
+
+	if trueCount != 1 {
+		t.Fatalf("expected exactly one reader to observe true, got %d", trueCount)
+	}
+}
 
 // Regression (#6283): a node onboarded in selected mode with an empty tag
 // list empties its snapshot via FilterNodeSnapshot before the merge sees it,

--- a/internal/web/job/node_traffic_sync_job_test.go
+++ b/internal/web/job/node_traffic_sync_job_test.go
@@ -1,69 +1,48 @@
 package job
 
 import (
-	"sync"
 	"testing"
+
+	"github.com/mhsanaei/3x-ui/v3/internal/database/model"
 )
 
-func TestAtomicBool_DefaultIsFalse(t *testing.T) {
-	var a atomicBool
-	if a.takeAndReset() {
-		t.Fatal("default atomicBool should report false")
+// Regression (#6283): a node onboarded in selected mode with an empty tag
+// list empties its snapshot via FilterNodeSnapshot before the merge sees it,
+// so that sync adopts nothing and must not stamp InboundsAdoptedAt.
+func TestSyncCanAdoptInbounds(t *testing.T) {
+	cases := []struct {
+		name     string
+		node     *model.Node
+		aliases  []string
+		expected bool
+	}{
+		{"all mode always adopts", &model.Node{InboundSyncMode: "all"}, nil, true},
+		{
+			"selected with tags adopts",
+			&model.Node{InboundSyncMode: "selected", InboundTags: []string{"in-443-tcp"}},
+			nil,
+			true,
+		},
+		{
+			"selected empty with adopted alias adopts",
+			&model.Node{InboundSyncMode: "selected"},
+			[]string{"in-443-tcp"},
+			true,
+		},
+		{
+			// The reported bug: registering in selected mode and choosing
+			// tags afterwards stamped adoption while adopting nothing.
+			"selected empty with no aliases adopts nothing",
+			&model.Node{InboundSyncMode: "selected"},
+			nil,
+			false,
+		},
 	}
-}
-
-func TestAtomicBool_SetThenTakeReturnsTrueOnce(t *testing.T) {
-	var a atomicBool
-	a.set()
-	if !a.takeAndReset() {
-		t.Fatal("takeAndReset after set should return true")
-	}
-	if a.takeAndReset() {
-		t.Fatal("second takeAndReset should return false (state was reset)")
-	}
-}
-
-func TestAtomicBool_SetIsIdempotent(t *testing.T) {
-	var a atomicBool
-	a.set()
-	a.set()
-	a.set()
-	if !a.takeAndReset() {
-		t.Fatal("repeated set should still leave the flag true")
-	}
-	if a.takeAndReset() {
-		t.Fatal("flag should be cleared after the first take")
-	}
-}
-
-func TestAtomicBool_ConcurrentSettersExactlyOneTakeWins(t *testing.T) {
-	var a atomicBool
-	const setters = 100
-	const readers = 20
-
-	var wg sync.WaitGroup
-	for range setters {
-		wg.Go(func() {
-			a.set()
-		})
-	}
-	wg.Wait()
-
-	trueCount := 0
-	var rwg sync.WaitGroup
-	var mu sync.Mutex
-	for range readers {
-		rwg.Go(func() {
-			if a.takeAndReset() {
-				mu.Lock()
-				trueCount++
-				mu.Unlock()
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := syncCanAdoptInbounds(c.node, c.aliases); got != c.expected {
+				t.Fatalf("syncCanAdoptInbounds(%+v, %v) = %v, want %v", c.node, c.aliases, got, c.expected)
 			}
 		})
-	}
-	rwg.Wait()
-
-	if trueCount != 1 {
-		t.Fatalf("expected exactly one reader to observe true, got %d", trueCount)
 	}
 }


### PR DESCRIPTION
Fixes #6283.

## Root cause

`syncOne` stamps `InboundsAdoptedAt` on any clean sync, but in **selected mode with an empty tag list** the snapshot is emptied by `FilterNodeSnapshot` before `SetRemoteTraffic` sees it — the sync adopts nothing, the flag is stamped anyway, and the reconcile sweep (gated on the flag since `200ea091`, the fix for #5898) then treats the node's unadopted pre-existing inbounds as "deleted locally" and removes them. Registering a working node first and choosing tags afterwards — the natural safe order — destroys the node's inbounds, exactly as the issue's state table shows.

## Fix

Gate the stamp on the sync actually being able to adopt: the new `syncCanAdoptInbounds(n, adoptedAliases)` requires, in selected mode, at least one selected tag **or** adopted alias (both are admitted by the snapshot filter); other modes always adopt. The natural follow-up sync — after the operator selects tags — then performs the real first adoption and stamps the flag correctly.

## Test

`TestSyncCanAdoptInbounds` (table-driven): all mode adopts; selected+tags adopts; selected-empty+alias adopts; **selected-empty+no-aliases adopts nothing** (the reported bug). Both `internal/web/service` and `internal/web/job` packages pass their full suites.
