### PR TITLE
feat(amneziawg): add AmneziaWG as an outbound protocol

### DIFF
--- a/frontend/src/lib/xray/outbound-form-adapter.ts
+++ b/frontend/src/lib/xray/outbound-form-adapter.ts
@@ -1,11 +1,13 @@
 import { XHttpXmuxSchema } from '@/schemas/protocols/stream/xhttp';
 import { OutboundDomainStrategySchema } from '@/schemas/protocols/outbound';
+import { AmneziaWGOutboundSettingsSchema } from '@/schemas/protocols/outbound';
 import { normalizeStreamSettingsForWire } from '@/lib/xray/stream-wire-normalize';
 import { Wireguard } from '@/utils';
 import type { Sniffing, SniffingDest } from '@/schemas/primitives';
 import type { OutboundDomainStrategy } from '@/schemas/protocols/outbound';
 
 import type {
+  AmneziaWGOutboundFormSettings,
   DnsOutboundFormSettings,
   DnsRuleForm,
   FreedomFinalRuleForm,
@@ -370,6 +372,102 @@ function loopbackFromWire(raw: Raw): LoopbackOutboundFormSettings {
   };
 }
 
+function amneziawgPeerFromWire(p: unknown): AmneziaWGOutboundFormSettings['peers'][number] {
+  const pp = asObject(p);
+  const allowed = asArray(pp.allowedIPs).map((x) => asString(x));
+  return {
+    publicKey: asString(pp.publicKey),
+    presharedKey: asString(pp.presharedKey),
+    allowedIPs: allowed.length > 0 ? allowed : ['0.0.0.0/0', '::/0'],
+    endpoint: asString(pp.endpoint),
+    keepAlive: asNumber(pp.keepAlive, 0),
+  };
+}
+
+// The form state IS the wire shape; hydrate only to apply defaults for keys
+// an older template may omit.
+function amneziawgFromWire(raw: Raw): AmneziaWGOutboundFormSettings {
+  return AmneziaWGOutboundSettingsSchema.parse({
+    mtu: asNumber(raw.mtu, 1420),
+    secretKey: asString(raw.secretKey),
+    address: asArray(raw.address).map((x) => asString(x)),
+    listenPort: asNumber(raw.listenPort, 0),
+    jc: asNumber(raw.jc, 0),
+    jmin: asNumber(raw.jmin, 40),
+    jmax: asNumber(raw.jmax, 100),
+    s1: asNumber(raw.s1, 15),
+    s2: asNumber(raw.s2, 80),
+    s3: asNumber(raw.s3, 12),
+    s4: asNumber(raw.s4, 12),
+    h1: asString(raw.h1),
+    h2: asString(raw.h2),
+    h3: asString(raw.h3),
+    h4: asString(raw.h4),
+    i1: asString(raw.i1),
+    i2: asString(raw.i2),
+    i3: asString(raw.i3),
+    i4: asString(raw.i4),
+    i5: asString(raw.i5),
+    headerProtectionKey: asString(raw.headerProtectionKey),
+    contentPaddingAddition: asString(raw.contentPaddingAddition),
+    rekeyAfterTime: asString(raw.rekeyAfterTime),
+    rekeyTimeout: asString(raw.rekeyTimeout),
+    rejectAfterTime: asString(raw.rejectAfterTime),
+    keepaliveTimeout: asString(raw.keepaliveTimeout),
+    maxHandshakeAttempts: asString(raw.maxHandshakeAttempts),
+    randomTrailers: raw.randomTrailers === undefined ? true : asBool(raw.randomTrailers),
+    disableCookies: raw.disableCookies === undefined ? true : asBool(raw.disableCookies),
+    peers: asArray(raw.peers).map(amneziawgPeerFromWire),
+  });
+}
+
+function amneziawgToWire(s: AmneziaWGOutboundFormSettings): Raw {
+  const out: Raw = {
+    mtu: s.mtu || undefined,
+    secretKey: s.secretKey,
+    address: s.address,
+    jc: s.jc,
+    jmin: s.jmin,
+    jmax: s.jmax,
+    s1: s.s1,
+    s2: s.s2,
+    s3: s.s3,
+    s4: s.s4,
+    h1: s.h1,
+    h2: s.h2,
+    h3: s.h3,
+    h4: s.h4,
+    randomTrailers: s.randomTrailers,
+    disableCookies: s.disableCookies,
+    peers: s.peers.map((p) => ({
+      publicKey: p.publicKey,
+      presharedKey: p.presharedKey.length > 0 ? p.presharedKey : undefined,
+      allowedIPs: p.allowedIPs.length > 0 ? p.allowedIPs : undefined,
+      endpoint: p.endpoint,
+      keepAlive: p.keepAlive || undefined,
+    })),
+  };
+  if (s.listenPort > 0) out.listenPort = s.listenPort;
+  const optionalStrings = [
+    'i1',
+    'i2',
+    'i3',
+    'i4',
+    'i5',
+    'headerProtectionKey',
+    'contentPaddingAddition',
+    'rekeyAfterTime',
+    'rekeyTimeout',
+    'rejectAfterTime',
+    'keepaliveTimeout',
+    'maxHandshakeAttempts',
+  ] as const;
+  for (const k of optionalStrings) {
+    if (s[k].length > 0) out[k] = s[k];
+  }
+  return out;
+}
+
 function muxFromWire(raw: unknown): MuxForm {
   const m = asObject(raw);
   return {
@@ -449,6 +547,9 @@ export function rawOutboundToFormValues(raw: RawOutboundRow): OutboundFormValues
       break;
     case 'wireguard':
       typed = { protocol: 'wireguard', settings: wireguardFromWire(settings) };
+      break;
+    case 'amneziawg':
+      typed = { protocol: 'amneziawg', settings: amneziawgFromWire(settings) };
       break;
     case 'hysteria':
       typed = { protocol: 'hysteria', settings: hysteriaFromWire(settings) };
@@ -735,6 +836,9 @@ export function formValuesToWirePayload(values: OutboundFormValues): WireOutboun
       break;
     case 'wireguard':
       settings = wireguardToWire(values.settings);
+      break;
+    case 'amneziawg':
+      settings = amneziawgToWire(values.settings);
       break;
     case 'hysteria':
       settings = hysteriaToWire(values.settings);

--- a/frontend/src/pages/xray/outbounds/OutboundFormModal.tsx
+++ b/frontend/src/pages/xray/outbounds/OutboundFormModal.tsx
@@ -45,6 +45,7 @@ import {
   VmessFields,
   WireguardFields,
 } from './protocols';
+import { AmneziawgFields } from './protocols';
 import {
   GrpcForm,
   HttpUpgradeForm,
@@ -453,6 +454,7 @@ export default function OutboundFormModal({
                       )}
 
                       {protocol === 'wireguard' && <WireguardFields />}
+                      {protocol === 'amneziawg' && <AmneziawgFields />}
 
                       {streamAllowed && network && (
                         <>

--- a/frontend/src/pages/xray/outbounds/protocols/amneziawg.tsx
+++ b/frontend/src/pages/xray/outbounds/protocols/amneziawg.tsx
@@ -1,0 +1,228 @@
+import { useTranslation } from 'react-i18next';
+import { Button, Form, Input, InputNumber, Space, Switch } from 'antd';
+import { MinusOutlined, PlusOutlined, ReloadOutlined } from '@ant-design/icons';
+import { useFieldArray, useFormContext } from 'react-hook-form';
+
+import { Wireguard } from '@/utils';
+import { activateOnKey } from '@/utils/a11y';
+import { InputAddon } from '@/components/ui';
+import { FormField } from '@/components/form/rhf';
+
+// Fields for the panel's amneziawg OUTBOUND pseudo-protocol. Reuses the
+// inbound AmneziaWG i18n keys: every label names the identical protocol
+// parameter (jc/s1/h1/...), and both ends of a tunnel must carry the same
+// values, so one label set serves both forms.
+export default function AmneziawgFields() {
+  const { t } = useTranslation();
+  const { control, setValue } = useFormContext();
+  const {
+    fields: peerFields,
+    append: appendPeer,
+    remove: removePeer,
+  } = useFieldArray({ control, name: 'settings.peers' });
+
+  return (
+    <>
+      <FormField label={t('pages.xray.amneziawg.mtu')} name={['settings', 'mtu']}>
+        <InputNumber min={0} style={{ width: '100%' }} />
+      </FormField>
+      <FormField
+        label={t('pages.xray.amneziawg.listenPort')}
+        name={['settings', 'listenPort']}
+        extra={t('pages.xray.amneziawg.listenPortHint')}
+      >
+        <InputNumber min={0} max={65535} style={{ width: '100%' }} />
+      </FormField>
+      <Form.Item label={t('pages.inbounds.privatekey')}>
+        <FormField name={['settings', 'secretKey']} noStyle>
+          <Input
+            aria-label={t('pages.inbounds.privatekey')}
+            style={{ width: 'calc(100% - 32px)' }}
+          />
+        </FormField>
+        <Button
+          icon={<ReloadOutlined />}
+          aria-label={t('regenerate')}
+          onClick={() => {
+            const pair = Wireguard.generateKeypair();
+            setValue('settings.secretKey', pair.privateKey);
+          }}
+        />
+      </Form.Item>
+      <Form.Item label={t('pages.inbounds.address')} required>
+        <FormField name={['settings', 'address', 0]} noStyle>
+          <Input placeholder="10.8.0.2/32" aria-label={t('pages.inbounds.address')} />
+        </FormField>
+      </Form.Item>
+      <FormField
+        name={['settings', 'headerProtectionKey']}
+        label={t('pages.xray.amneziawg.headerProtectionKey')}
+        extra={t('pages.xray.amneziawg.headerProtectionKeyHint')}
+      >
+        <Input />
+      </FormField>
+
+      <Form.Item label={t('pages.xray.amneziawg.obfuscation')}>
+        <span className="text-xs text-gray-400">
+          {t('pages.xray.amneziawg.outboundObfuscationHint')}
+        </span>
+      </Form.Item>
+      <ObfNumber name="jc" label={t('pages.xray.amneziawg.jc')} min={0} />
+      <ObfNumber name="jmin" label={t('pages.xray.amneziawg.jmin')} min={0} />
+      <ObfNumber name="jmax" label={t('pages.xray.amneziawg.jmax')} min={0} />
+      <ObfNumber name="s1" label={t('pages.xray.amneziawg.s1')} min={0} />
+      <ObfNumber name="s2" label={t('pages.xray.amneziawg.s2')} min={0} />
+      <ObfNumber name="s3" label={t('pages.xray.amneziawg.s3')} min={0} max={64} />
+      <ObfNumber name="s4" label={t('pages.xray.amneziawg.s4')} min={0} max={32} />
+      <ObfText name="h1" label={t('pages.xray.amneziawg.h1')} placeholder="100-800" />
+      <ObfText name="h2" label={t('pages.xray.amneziawg.h2')} placeholder="900-1600" />
+      <ObfText name="h3" label={t('pages.xray.amneziawg.h3')} placeholder="1700-2400" />
+      <ObfText name="h4" label={t('pages.xray.amneziawg.h4')} placeholder="2500-3200" />
+      <ObfText name="i1" label={t('pages.xray.amneziawg.i1')} placeholder="<r 64>" />
+      <ObfText
+        name="contentPaddingAddition"
+        label={t('pages.xray.amneziawg.contentPaddingAddition')}
+        placeholder="8-64"
+      />
+
+      <Form.Item label={t('pages.inbounds.form.peers')}>
+        <Button
+          size="small"
+          type="primary"
+          icon={<PlusOutlined />}
+          aria-label={t('add')}
+          onClick={() =>
+            appendPeer({
+              publicKey: '',
+              presharedKey: '',
+              allowedIPs: ['0.0.0.0/0', '::/0'],
+              endpoint: '',
+              keepAlive: 25,
+            })
+          }
+        />
+      </Form.Item>
+      {peerFields.map((field, index) => (
+        <div key={field.id}>
+          <Form.Item wrapperCol={{ md: { span: 14, offset: 8 } }}>
+            <div className="item-heading">
+              <span>{t('pages.inbounds.info.peerNumber', { n: index + 1 })}</span>
+              {peerFields.length > 1 && (
+                <MinusOutlined
+                  className="danger-icon"
+                  role="button"
+                  tabIndex={0}
+                  aria-label={t('remove')}
+                  onClick={() => removePeer(index)}
+                  onKeyDown={activateOnKey(() => removePeer(index))}
+                />
+              )}
+            </div>
+          </Form.Item>
+          <FormField
+            label={t('pages.xray.wireguard.endpoint')}
+            name={['settings', 'peers', index, 'endpoint']}
+          >
+            <Input placeholder="203.0.113.7:51820" />
+          </FormField>
+          <FormField
+            label={t('pages.inbounds.publicKey')}
+            name={['settings', 'peers', index, 'publicKey']}
+          >
+            <Input />
+          </FormField>
+          <FormField label="PSK" name={['settings', 'peers', index, 'presharedKey']}>
+            <Input />
+          </FormField>
+          <PeerAllowedIPs peerIndex={index} />
+          <FormField
+            label={t('pages.inbounds.info.keepAlive')}
+            name={['settings', 'peers', index, 'keepAlive']}
+          >
+            <InputNumber min={0} />
+          </FormField>
+        </div>
+      ))}
+
+      <FormField
+        name={['settings', 'randomTrailers']}
+        label={t('pages.xray.amneziawg.randomTrailers')}
+        valueProp="checked"
+      >
+        <Switch />
+      </FormField>
+      <FormField
+        name={['settings', 'disableCookies']}
+        label={t('pages.xray.amneziawg.disableCookies')}
+        valueProp="checked"
+      >
+        <Switch />
+      </FormField>
+    </>
+  );
+}
+
+function PeerAllowedIPs({ peerIndex }: { peerIndex: number }) {
+  const { t } = useTranslation();
+  const { control } = useFormContext();
+  const { fields, append, remove } = useFieldArray({
+    control,
+    name: `settings.peers.${peerIndex}.allowedIPs`,
+  });
+  return (
+    <Form.Item label={t('pages.xray.wireguard.allowedIPs')}>
+      {fields.map((field, ipIdx) => (
+        <Space.Compact key={field.id} block style={{ marginBottom: 4 }}>
+          <FormField noStyle name={['settings', 'peers', peerIndex, 'allowedIPs', ipIdx]}>
+            <Input aria-label={t('pages.xray.wireguard.allowedIPs')} />
+          </FormField>
+          {fields.length > 1 && (
+            <InputAddon ariaLabel={t('remove')} onClick={() => remove(ipIdx)}>
+              <MinusOutlined />
+            </InputAddon>
+          )}
+        </Space.Compact>
+      ))}
+      <Button
+        size="small"
+        icon={<PlusOutlined />}
+        aria-label={t('add')}
+        onClick={() => append('')}
+      />
+    </Form.Item>
+  );
+}
+
+function ObfNumber({
+  name,
+  label,
+  min,
+  max,
+}: {
+  name: string;
+  label: string;
+  min?: number;
+  max?: number;
+}) {
+  return (
+    <FormField label={label} name={['settings', name] as never}>
+      <InputNumber min={min} max={max} style={{ width: '100%' }} />
+    </FormField>
+  );
+}
+
+function ObfText({
+  name,
+  label,
+  placeholder,
+}: {
+  name: string;
+  label: string;
+  placeholder?: string;
+}) {
+  return (
+    <FormField label={label} name={['settings', name] as never}>
+      <Input placeholder={placeholder} />
+    </FormField>
+  );
+}

--- a/frontend/src/pages/xray/outbounds/protocols/index.ts
+++ b/frontend/src/pages/xray/outbounds/protocols/index.ts
@@ -6,6 +6,7 @@ export { default as ShadowsocksFields } from './shadowsocks';
 export { default as HttpFields } from './http';
 export { default as SocksFields } from './socks';
 export { default as WireguardFields } from './wireguard';
+export { default as AmneziawgFields } from './amneziawg';
 export { default as FreedomFields } from './freedom';
 export { default as LoopbackFields } from './loopback';
 export { default as BlackholeFields } from './blackhole';

--- a/frontend/src/schemas/forms/outbound-form.ts
+++ b/frontend/src/schemas/forms/outbound-form.ts
@@ -6,6 +6,7 @@ import { VmessSecuritySchema } from '@/schemas/protocols/shared/vmess';
 import { SecuritySettingsSchema } from '@/schemas/protocols/security';
 import { NetworkSettingsSchema, StreamExtrasSchema } from '@/schemas/protocols/stream';
 import {
+  AmneziaWGOutboundSettingsSchema,
   BlackholeResponseTypeSchema,
   DNSRuleActionSchema,
   FreedomFinalRuleActionSchema,
@@ -111,6 +112,11 @@ export const WireguardOutboundFormSettingsSchema = z.object({
 });
 export type WireguardOutboundFormSettings = z.infer<typeof WireguardOutboundFormSettingsSchema>;
 
+// Re-export under the form name: the form state IS the wire shape (flat
+// obfuscation fields, same as the inbound server block), so no rename layer.
+export const AmneziaWGOutboundFormSettingsSchema = AmneziaWGOutboundSettingsSchema;
+export type AmneziaWGOutboundFormSettings = z.infer<typeof AmneziaWGOutboundFormSettingsSchema>;
+
 // Hysteria outbound carries the connect target only; transport-layer knobs
 // (auth, congestion, up/down, hop port, timeouts) ride on stream.hysteria.
 export const HysteriaOutboundFormSettingsSchema = z.object({
@@ -192,6 +198,7 @@ export const OutboundFormSettingsSchema = z.discriminatedUnion('protocol', [
   z.object({ protocol: z.literal('socks'), settings: SocksOutboundFormSettingsSchema }),
   z.object({ protocol: z.literal('http'), settings: HttpOutboundFormSettingsSchema }),
   z.object({ protocol: z.literal('wireguard'), settings: WireguardOutboundFormSettingsSchema }),
+  z.object({ protocol: z.literal('amneziawg'), settings: AmneziaWGOutboundFormSettingsSchema }),
   z.object({ protocol: z.literal('hysteria'), settings: HysteriaOutboundFormSettingsSchema }),
   z.object({ protocol: z.literal('freedom'), settings: FreedomOutboundFormSettingsSchema }),
   z.object({ protocol: z.literal('blackhole'), settings: BlackholeOutboundFormSettingsSchema }),

--- a/frontend/src/schemas/primitives/outbound-protocol.ts
+++ b/frontend/src/schemas/primitives/outbound-protocol.ts
@@ -7,6 +7,7 @@ export const OutboundProtocols = Object.freeze({
   Trojan: 'trojan',
   Shadowsocks: 'shadowsocks',
   Wireguard: 'wireguard',
+  AmneziaWG: 'amneziawg',
   Hysteria: 'hysteria',
   Socks: 'socks',
   HTTP: 'http',

--- a/frontend/src/schemas/protocols/outbound/amneziawg.ts
+++ b/frontend/src/schemas/protocols/outbound/amneziawg.ts
@@ -1,0 +1,49 @@
+import { z } from 'zod';
+
+// Wire format of an "amneziawg" OUTBOUND's settings block, stored verbatim
+// inside the panel's Xray template. At config generation the backend swaps
+// the whole entry for a loopback socks bridge (internal/web/service/
+// xray_amneziawg_outbound.go); this schema is what the form edits and what
+// the backend validates (internal/amneziawg.ValidateAmneziaWGOutbound).
+export const AmneziaWGOutboundPeerSchema = z.object({
+  publicKey: z.string().default(''),
+  presharedKey: z.string().default(''),
+  allowedIPs: z.array(z.string()).default(['0.0.0.0/0', '::/0']),
+  endpoint: z.string().default(''),
+  keepAlive: z.number().int().min(0).default(0),
+});
+export type AmneziaWGOutboundPeer = z.infer<typeof AmneziaWGOutboundPeerSchema>;
+
+export const AmneziaWGOutboundSettingsSchema = z.object({
+  mtu: z.number().int().min(0).default(1420),
+  secretKey: z.string().default(''),
+  address: z.array(z.string()).default([]),
+  listenPort: z.number().int().min(0).max(65535).default(0),
+  jc: z.number().int().min(0).default(0),
+  jmin: z.number().int().min(0).default(40),
+  jmax: z.number().int().min(0).default(100),
+  s1: z.number().int().min(0).default(15),
+  s2: z.number().int().min(0).default(80),
+  s3: z.number().int().min(0).max(64).default(12),
+  s4: z.number().int().min(0).max(32).default(12),
+  h1: z.string().default(''),
+  h2: z.string().default(''),
+  h3: z.string().default(''),
+  h4: z.string().default(''),
+  i1: z.string().default(''),
+  i2: z.string().default(''),
+  i3: z.string().default(''),
+  i4: z.string().default(''),
+  i5: z.string().default(''),
+  headerProtectionKey: z.string().default(''),
+  contentPaddingAddition: z.string().default(''),
+  rekeyAfterTime: z.string().default(''),
+  rekeyTimeout: z.string().default(''),
+  rejectAfterTime: z.string().default(''),
+  keepaliveTimeout: z.string().default(''),
+  maxHandshakeAttempts: z.string().default(''),
+  randomTrailers: z.boolean().default(true),
+  disableCookies: z.boolean().default(true),
+  peers: z.array(AmneziaWGOutboundPeerSchema).default([]),
+});
+export type AmneziaWGOutboundSettings = z.infer<typeof AmneziaWGOutboundSettingsSchema>;

--- a/frontend/src/schemas/protocols/outbound/index.ts
+++ b/frontend/src/schemas/protocols/outbound/index.ts
@@ -1,6 +1,7 @@
 import { z } from 'zod';
 
 import { BlackholeOutboundSettingsSchema } from './blackhole';
+import { AmneziaWGOutboundSettingsSchema } from './amneziawg';
 import { DNSOutboundSettingsSchema } from './dns';
 import { FreedomOutboundSettingsSchema } from './freedom';
 import { HttpOutboundSettingsSchema } from './http';
@@ -14,6 +15,7 @@ import { VmessOutboundSettingsSchema } from './vmess';
 import { WireguardOutboundSettingsSchema } from './wireguard';
 
 export * from './blackhole';
+export * from './amneziawg';
 export * from './dns';
 export * from './freedom';
 export * from './http';
@@ -32,6 +34,7 @@ export const OutboundSettingsSchema = z.discriminatedUnion('protocol', [
   z.object({ protocol: z.literal('trojan'), settings: TrojanOutboundSettingsSchema }),
   z.object({ protocol: z.literal('shadowsocks'), settings: ShadowsocksOutboundSettingsSchema }),
   z.object({ protocol: z.literal('wireguard'), settings: WireguardOutboundSettingsSchema }),
+  z.object({ protocol: z.literal('amneziawg'), settings: AmneziaWGOutboundSettingsSchema }),
   z.object({ protocol: z.literal('hysteria'), settings: HysteriaOutboundSettingsSchema }),
   z.object({ protocol: z.literal('http'), settings: HttpOutboundSettingsSchema }),
   z.object({ protocol: z.literal('socks'), settings: SocksOutboundSettingsSchema }),

--- a/frontend/src/test/amneziawg-outbound-adapter.test.ts
+++ b/frontend/src/test/amneziawg-outbound-adapter.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from 'vitest';
+
+import { formValuesToWirePayload, rawOutboundToFormValues } from '@/lib/xray/outbound-form-adapter';
+import type { AmneziaWGOutboundFormSettings } from '@/schemas/forms/outbound-form';
+
+// The amneziawg OUTBOUND pseudo-protocol: form -> wire -> form must be
+// lossless, and the emitted payload must stay a protocol:"amneziawg" row
+// (the backend swaps it for its socks bridge at config generation).
+describe('amneziawg outbound adapter', () => {
+  const wire = {
+    mtu: 1380,
+    secretKey: '6Nn0ZB4C1Pj3TBEsXgLv7VdmSnYXGxS+HhVBDhvGgHE=',
+    address: ['10.8.0.2/32'],
+    listenPort: 40001,
+    jc: 5,
+    jmin: 40,
+    jmax: 90,
+    s1: 20,
+    s2: 90,
+    s3: 15,
+    s4: 13,
+    h1: '100-800',
+    h2: '900-1600',
+    h3: '1700-2400',
+    h4: '2500-3200',
+    i1: '<r 64>',
+    contentPaddingAddition: '8-40',
+    randomTrailers: true,
+    disableCookies: false,
+    peers: [
+      {
+        publicKey: 'Qk9fWqDqC7LzKpYvJq0m2b1tq8eF3uY6oPpRrSsTtUu=',
+        presharedKey: 'cHNo',
+        allowedIPs: ['0.0.0.0/0', '::/0'],
+        endpoint: '203.0.113.7:51820',
+        keepAlive: 25,
+      },
+    ],
+  };
+
+  it('hydrates defaults when the template omits optional keys', () => {
+    const values = rawOutboundToFormValues({ protocol: 'amneziawg', tag: 'awg-x' });
+    expect(values.protocol).toBe('amneziawg');
+    const s = values.settings as AmneziaWGOutboundFormSettings;
+    expect(s.mtu).toBe(1420);
+    expect(s.randomTrailers).toBe(true);
+    expect(s.disableCookies).toBe(true);
+    expect(s.peers).toEqual([]);
+    expect(values.tag).toBe('awg-x');
+  });
+
+  it('round-trips wire -> form -> wire losslessly', () => {
+    const values = rawOutboundToFormValues({ protocol: 'amneziawg', tag: 'awg-x', settings: wire });
+    const payload = formValuesToWirePayload(values);
+    expect(payload.protocol).toBe('amneziawg');
+    expect(payload.tag).toBe('awg-x');
+    // undefined-valued optionals are dropped by JSON semantics; compare the
+    // meaningful fields directly.
+    expect((payload.settings as Record<string, unknown>).mtu).toBe(1380);
+    expect((payload.settings as Record<string, unknown>).listenPort).toBe(40001);
+    expect((payload.settings as Record<string, unknown>).i1).toBe('<r 64>');
+    expect((payload.settings as Record<string, unknown>).peers).toEqual(wire.peers);
+    expect((payload.settings as Record<string, unknown>).disableCookies).toBe(false);
+  });
+
+  it('omits empty optional strings and zero listenPort from the payload', () => {
+    const values = rawOutboundToFormValues({ protocol: 'amneziawg', settings: wire });
+    const awg = values.settings as AmneziaWGOutboundFormSettings;
+    awg.i1 = '';
+    awg.listenPort = 0;
+    const payload = formValuesToWirePayload(values);
+    const s = payload.settings as Record<string, unknown>;
+    expect(s.i1).toBeUndefined();
+    expect(s.listenPort).toBeUndefined();
+    // always-present booleans survive so a true->false edit is diffable
+    expect(s.randomTrailers).toBe(true);
+  });
+
+  it('is included in every protocol-capability gate like wireguard (non-stream, non-mux)', () => {
+    const values = rawOutboundToFormValues({
+      protocol: 'amneziawg',
+      settings: wire,
+      streamSettings: { network: 'tcp', tcpSettings: {} },
+    });
+    const payload = formValuesToWirePayload(values);
+    // Non-stream protocol keeps only sockopt; here there is none.
+    expect(payload.streamSettings).toBeUndefined();
+  });
+});

--- a/internal/amneziawg/outbound.go
+++ b/internal/amneziawg/outbound.go
@@ -1,0 +1,273 @@
+package amneziawg
+
+import (
+	"encoding/json"
+	"fmt"
+	"net"
+	"net/netip"
+	"strconv"
+	"strings"
+
+	"github.com/mhsanaei/3x-ui/v3/internal/util/wireguard"
+)
+
+// OutboundPeer describes one remote AmneziaWG server this outbound dials.
+// PublicKey is the SERVER's public key; AllowedIPs selects which destinations
+// ride the tunnel; Endpoint is the server's "host:port".
+type OutboundPeer struct {
+	PublicKey    string
+	PresharedKey string
+	AllowedIPs   []string
+	Endpoint     string
+	KeepAlive    int
+}
+
+// OutboundInstance is the desired runtime configuration of one AmneziaWG
+// outbound: a client-mode interface dialing the remote endpoint -- the mirror
+// image of Instance (server mode), consumed by internal/amneziawgnet's
+// outbound Manager.
+type OutboundInstance struct {
+	Tag         string
+	Address     []string
+	MTU         int
+	PrivateKey  string
+	Obfuscation Obfuscation31
+	Peers       []OutboundPeer
+	ListenPort  int
+}
+
+// OutboundSettings is the Settings JSON stored on an "amneziawg" outbound row
+// in the Xray template. Field names match ServerSettings' flat obfuscation
+// keys so one parameter set pastes cleanly between an inbound's server block
+// and an outbound's settings (both ends of a tunnel must carry identical
+// values). tools/openapigen is not involved: this shape never crosses the
+// OpenAPI boundary, it travels inside the template JSON string.
+type OutboundSettings struct {
+	MTU        int      `json:"mtu,omitempty"`
+	SecretKey  string   `json:"secretKey"`
+	Address    []string `json:"address"`
+	ListenPort int      `json:"listenPort,omitempty"`
+
+	// Flat Obfuscation31 mirror -- see OutboundSettings' doc comment.
+	Jc   int    `json:"jc"`
+	Jmin int    `json:"jmin"`
+	Jmax int    `json:"jmax"`
+	S1   int    `json:"s1"`
+	S2   int    `json:"s2"`
+	S3   int    `json:"s3"`
+	S4   int    `json:"s4"`
+	H1   string `json:"h1"`
+	H2   string `json:"h2"`
+	H3   string `json:"h3"`
+	H4   string `json:"h4"`
+	I1   string `json:"i1,omitempty"`
+	I2   string `json:"i2,omitempty"`
+	I3   string `json:"i3,omitempty"`
+	I4   string `json:"i4,omitempty"`
+	I5   string `json:"i5,omitempty"`
+
+	HeaderProtectionKey    string `json:"headerProtectionKey,omitempty"`
+	ContentPaddingAddition string `json:"contentPaddingAddition,omitempty"`
+	RekeyAfterTime         string `json:"rekeyAfterTime,omitempty"`
+	RekeyTimeout           string `json:"rekeyTimeout,omitempty"`
+	RejectAfterTime        string `json:"rejectAfterTime,omitempty"`
+	KeepaliveTimeout       string `json:"keepaliveTimeout,omitempty"`
+	MaxHandshakeAttempts   string `json:"maxHandshakeAttempts,omitempty"`
+	RandomTrailers         bool   `json:"randomTrailers"`
+	DisableCookies         bool   `json:"disableCookies"`
+
+	Peers []OutboundSettingsPeer `json:"peers"`
+}
+
+// OutboundSettingsPeer is one entry of OutboundSettings.Peers.
+type OutboundSettingsPeer struct {
+	PublicKey    string   `json:"publicKey"`
+	PresharedKey string   `json:"presharedKey,omitempty"`
+	AllowedIPs   []string `json:"allowedIPs"`
+	Endpoint     string   `json:"endpoint"`
+	KeepAlive    int      `json:"keepAlive,omitempty"`
+}
+
+// Obfuscation folds the flat wire fields back into the grouped type, matching
+// ServerSettings.Obfuscation.
+func (s OutboundSettings) Obfuscation() Obfuscation31 {
+	return Obfuscation31{
+		Jc: s.Jc, Jmin: s.Jmin, Jmax: s.Jmax,
+		S1: s.S1, S2: s.S2, S3: s.S3, S4: s.S4,
+		H1: s.H1, H2: s.H2, H3: s.H3, H4: s.H4,
+		I1: s.I1, I2: s.I2, I3: s.I3, I4: s.I4, I5: s.I5,
+		HeaderProtectionKey:    s.HeaderProtectionKey,
+		ContentPaddingAddition: s.ContentPaddingAddition,
+		RekeyAfterTime:         s.RekeyAfterTime,
+		RekeyTimeout:           s.RekeyTimeout,
+		RejectAfterTime:        s.RejectAfterTime,
+		KeepaliveTimeout:       s.KeepaliveTimeout,
+		MaxHandshakeAttempts:   s.MaxHandshakeAttempts,
+		RandomTrailers:         s.RandomTrailers,
+		DisableCookies:         s.DisableCookies,
+	}
+}
+
+// IsAmneziaWGOutbound reports whether a raw outbound JSON object from the
+// Xray template carries the panel's amneziawg pseudo-protocol.
+func IsAmneziaWGOutbound(raw []byte) bool {
+	var probe struct {
+		Protocol string `json:"protocol"`
+	}
+	if err := json.Unmarshal(raw, &probe); err != nil {
+		return false
+	}
+	return probe.Protocol == "amneziawg"
+}
+
+// outboundSettingsOf extracts the nested "settings" block from a raw
+// amneziawg template outbound.
+func outboundSettingsOf(raw []byte) (json.RawMessage, bool) {
+	var wrapper struct {
+		Settings json.RawMessage `json:"settings"`
+	}
+	if err := json.Unmarshal(raw, &wrapper); err != nil || len(wrapper.Settings) == 0 {
+		return nil, false
+	}
+	return wrapper.Settings, true
+}
+
+// InstanceFromOutbound derives a client-mode OutboundInstance from one raw
+// template outbound (protocol must already be "amneziawg") and its tag.
+// Returns false when settings are unusable: unparseable, no usable address,
+// invalid keys, or no peer with a valid key + endpoint + at least one
+// AllowedIPs entry.
+func InstanceFromOutbound(tag string, raw []byte) (OutboundInstance, bool) {
+	settingsRaw, ok := outboundSettingsOf(raw)
+	if !ok {
+		return OutboundInstance{}, false
+	}
+	var parsed OutboundSettings
+	if err := json.Unmarshal(settingsRaw, &parsed); err != nil {
+		return OutboundInstance{}, false
+	}
+	inst := OutboundInstance{
+		Tag:        tag,
+		Address:    parsed.Address,
+		MTU:        parsed.MTU,
+		PrivateKey: parsed.SecretKey,
+		ListenPort: parsed.ListenPort,
+		Obfuscation: Obfuscation31{
+			Jc: parsed.Jc, Jmin: parsed.Jmin, Jmax: parsed.Jmax,
+			S1: parsed.S1, S2: parsed.S2, S3: parsed.S3, S4: parsed.S4,
+			H1: parsed.H1, H2: parsed.H2, H3: parsed.H3, H4: parsed.H4,
+			I1: parsed.I1, I2: parsed.I2, I3: parsed.I3, I4: parsed.I4, I5: parsed.I5,
+			HeaderProtectionKey:    parsed.HeaderProtectionKey,
+			ContentPaddingAddition: parsed.ContentPaddingAddition,
+			RekeyAfterTime:         parsed.RekeyAfterTime,
+			RekeyTimeout:           parsed.RekeyTimeout,
+			RejectAfterTime:        parsed.RejectAfterTime,
+			KeepaliveTimeout:       parsed.KeepaliveTimeout,
+			MaxHandshakeAttempts:   parsed.MaxHandshakeAttempts,
+			RandomTrailers:         parsed.RandomTrailers,
+			DisableCookies:         parsed.DisableCookies,
+		},
+	}
+	for _, p := range parsed.Peers {
+		if p.PublicKey == "" || len(p.AllowedIPs) == 0 || p.Endpoint == "" {
+			continue
+		}
+		inst.Peers = append(inst.Peers, OutboundPeer(p))
+	}
+	if len(inst.Address) == 0 || len(inst.Peers) == 0 {
+		return OutboundInstance{}, false
+	}
+	return inst, true
+}
+
+// validateEndpoint accepts "host:port" (or "[v6]:port") with a numeric port
+// in range and a host free of control characters -- amneziawg-go resolves the
+// host itself, so no IP-format restriction here beyond sanity.
+func validateEndpoint(ep string) error {
+	if ep == "" {
+		return fmt.Errorf("endpoint is required")
+	}
+	if err := ValidateConfigValue("endpoint", ep); err != nil {
+		return err
+	}
+	host, portS, err := net.SplitHostPort(ep)
+	if err != nil {
+		return fmt.Errorf("invalid endpoint %q: must be host:port", ep)
+	}
+	port, err := strconv.Atoi(portS)
+	if err != nil || port <= 0 || port > 65535 {
+		return fmt.Errorf("invalid endpoint %q: bad port", ep)
+	}
+	if strings.TrimSpace(host) == "" {
+		return fmt.Errorf("invalid endpoint %q: empty host", ep)
+	}
+	return nil
+}
+
+// validateTunnelAddresses requires every entry to be a parseable IP prefix
+// (the outbound's own tunnel address(es), e.g. "10.8.1.2/32").
+func validateTunnelAddresses(addrs []string) error {
+	if len(addrs) == 0 {
+		return fmt.Errorf("at least one tunnel address is required")
+	}
+	for _, a := range addrs {
+		prefix, err := netip.ParsePrefix(a)
+		if err != nil {
+			return fmt.Errorf("invalid tunnel address %q: %w", a, err)
+		}
+		_ = prefix
+	}
+	return nil
+}
+
+// ValidateAmneziaWGOutbound checks one raw template outbound's settings the
+// way normalizeAmneziaWGSettings checks an inbound: enough that a bad entry
+// can neither break the embedded device's UAPI apply nor smuggle control
+// characters into anything rendered downstream.
+func ValidateAmneziaWGOutbound(tag string, raw []byte) error {
+	settingsRaw, ok := outboundSettingsOf(raw)
+	if !ok {
+		return fmt.Errorf("amneziawg outbound %q: missing settings block", tag)
+	}
+	var parsed OutboundSettings
+	if err := json.Unmarshal(settingsRaw, &parsed); err != nil {
+		return fmt.Errorf("amneziawg outbound %q: invalid settings: %w", tag, err)
+	}
+	if err := validateTunnelAddresses(parsed.Address); err != nil {
+		return fmt.Errorf("amneziawg outbound %q: %w", tag, err)
+	}
+	if _, err := wireguard.KeyToHex(parsed.SecretKey); err != nil {
+		return fmt.Errorf("amneziawg outbound %q: invalid privateKey: %w", tag, err)
+	}
+	if err := ValidateObfuscation(parsed.Obfuscation()); err != nil {
+		return fmt.Errorf("amneziawg outbound %q: %w", tag, err)
+	}
+	if err := validateHeaderProtectionKey(parsed.HeaderProtectionKey); err != nil {
+		return fmt.Errorf("amneziawg outbound %q: %w", tag, err)
+	}
+	if len(parsed.Peers) == 0 {
+		return fmt.Errorf("amneziawg outbound %q: at least one peer is required", tag)
+	}
+	for i, p := range parsed.Peers {
+		if _, err := wireguard.KeyToHex(p.PublicKey); err != nil {
+			return fmt.Errorf("amneziawg outbound %q: peer %d: invalid publicKey: %w", tag, i, err)
+		}
+		if p.PresharedKey != "" {
+			if _, err := wireguard.KeyToHex(p.PresharedKey); err != nil {
+				return fmt.Errorf("amneziawg outbound %q: peer %d: invalid presharedKey: %w", tag, i, err)
+			}
+		}
+		if err := validateEndpoint(p.Endpoint); err != nil {
+			return fmt.Errorf("amneziawg outbound %q: peer %d: %w", tag, i, err)
+		}
+		if len(p.AllowedIPs) == 0 {
+			return fmt.Errorf("amneziawg outbound %q: peer %d: at least one allowedIPs entry is required", tag, i)
+		}
+		for _, a := range p.AllowedIPs {
+			if _, err := netip.ParsePrefix(strings.TrimSpace(a)); err != nil {
+				return fmt.Errorf("amneziawg outbound %q: peer %d: invalid allowedIP %q: %w", tag, i, a, err)
+			}
+		}
+	}
+	return nil
+}

--- a/internal/amneziawg/outbound_test.go
+++ b/internal/amneziawg/outbound_test.go
@@ -1,0 +1,201 @@
+package amneziawg
+
+import (
+	"encoding/json"
+	"testing"
+
+	wgutil "github.com/mhsanaei/3x-ui/v3/internal/util/wireguard"
+)
+
+// validOutboundJSON is a fully valid amneziawg outbound settings payload.
+func validOutboundJSON(t *testing.T) []byte {
+	t.Helper()
+	raw := map[string]any{
+		"mtu":       1420,
+		"secretKey": validPrivKey(t),
+		"address":   []string{"10.8.0.2/32"},
+		"jc":        4,
+		"jmin":      40,
+		"jmax":      100,
+		"s1":        15,
+		"s2":        80,
+		"s3":        12,
+		"s4":        12,
+		"h1":        "100-800",
+		"h2":        "900-1600",
+		"h3":        "1700-2400",
+		"h4":        "2500-3200",
+		"peers": []map[string]any{{
+			"publicKey":  validPubKey(t),
+			"allowedIPs": []string{"0.0.0.0/0", "::/0"},
+			"endpoint":   "203.0.113.7:51820",
+			"keepAlive":  25,
+		}},
+	}
+	bs, err := json.Marshal(raw)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return bs
+}
+
+func validPubKey(t *testing.T) string {
+	t.Helper()
+	_, pub, err := wgutil.GenerateWireguardKeypair()
+	if err != nil {
+		t.Fatal(err)
+	}
+	return pub
+}
+
+func validPrivKey(t *testing.T) string {
+	t.Helper()
+	priv, _, err := wgutil.GenerateWireguardKeypair()
+	if err != nil {
+		t.Fatal(err)
+	}
+	return priv
+}
+
+func TestInstanceFromOutbound_OK(t *testing.T) {
+	wrapped, err := json.Marshal(map[string]any{
+		"protocol": "amneziawg",
+		"tag":      "awg-out-test",
+		"settings": json.RawMessage(validOutboundJSON(t)),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	inst, ok := InstanceFromOutbound("awg-out-test", wrapped)
+	if !ok {
+		t.Fatal("InstanceFromOutbound returned false for a valid outbound")
+	}
+	if inst.Tag != "awg-out-test" {
+		t.Fatalf("Tag = %q, want awg-out-test", inst.Tag)
+	}
+	if len(inst.Peers) != 1 {
+		t.Fatalf("len(Peers) = %d, want 1", len(inst.Peers))
+	}
+	p := inst.Peers[0]
+	if p.Endpoint != "203.0.113.7:51820" {
+		t.Fatalf("Endpoint = %q", p.Endpoint)
+	}
+	if p.KeepAlive != 25 {
+		t.Fatalf("KeepAlive = %d, want 25", p.KeepAlive)
+	}
+	if len(p.AllowedIPs) != 2 {
+		t.Fatalf("AllowedIPs = %v", p.AllowedIPs)
+	}
+	if inst.MTU != 1420 {
+		t.Fatalf("MTU = %d, want 1420", inst.MTU)
+	}
+	if inst.Obfuscation.Jc != 4 || inst.Obfuscation.S1 != 15 {
+		t.Fatalf("Obfuscation not carried: %+v", inst.Obfuscation)
+	}
+}
+
+func TestInstanceFromOutbound_RejectsIncompletePeer(t *testing.T) {
+	m := validOutboundMapT(t)
+	m["address"] = []any{}
+	bs, _ := json.Marshal(m)
+	wrapped, _ := json.Marshal(map[string]any{"protocol": "amneziawg", "settings": json.RawMessage(bs)})
+	if _, ok := InstanceFromOutbound("t", wrapped); ok {
+		t.Fatal("expected false when address list is empty")
+	}
+
+	m2 := validOutboundMapT(t)
+	m2["peers"].([]any)[0].(map[string]any)["endpoint"] = ""
+	bs2, _ := json.Marshal(m2)
+	wrapped2, _ := json.Marshal(map[string]any{"protocol": "amneziawg", "settings": json.RawMessage(bs2)})
+	// The only peer is incomplete -> skipped -> zero usable peers -> false,
+	// mirroring InstanceFromInbound's "nothing to serve" contract.
+	if _, ok := InstanceFromOutbound("t", wrapped2); ok {
+		t.Fatal("outbound whose only peer lacks an endpoint must be unusable")
+	}
+
+	// With a second, complete peer the instance stays usable and only the
+	// broken entry disappears.
+	m3 := validOutboundMapT(t)
+	brokenPeer := validOutboundMapT(t)["peers"].([]any)[0].(map[string]any)
+	brokenPeer["endpoint"] = ""
+	m3["peers"] = []any{brokenPeer, validOutboundMapT(t)["peers"].([]any)[0]}
+	bs3, _ := json.Marshal(m3)
+	wrapped3, _ := json.Marshal(map[string]any{"protocol": "amneziawg", "settings": json.RawMessage(bs3)})
+	inst, ok := InstanceFromOutbound("t", wrapped3)
+	if !ok {
+		t.Fatal("one good peer should keep the outbound usable")
+	}
+	if len(inst.Peers) != 1 {
+		t.Fatalf("broken peer must be dropped; got %d peers", len(inst.Peers))
+	}
+}
+
+func TestValidateAmneziaWGOutbound_AcceptsValidAndRejectsBroken(t *testing.T) {
+	if err := ValidateAmneziaWGOutbound("t", wrapOutboundSettings(validOutboundJSON(t))); err != nil {
+		t.Fatalf("valid outbound rejected: %v", err)
+	}
+
+	cases := []struct {
+		name   string
+		breakF func(m map[string]any)
+	}{
+		{"bad endpoint no port", func(m map[string]any) { peer(m)["endpoint"] = "203.0.113.7" }},
+		{"endpoint control char", func(m map[string]any) { peer(m)["endpoint"] = "host:51820\nPostUp=x" }},
+		{"empty allowedIPs", func(m map[string]any) { peer(m)["allowedIPs"] = []string{} }},
+		{"no peers", func(m map[string]any) { m["peers"] = []any{} }},
+		{"bad allowedIP", func(m map[string]any) { peer(m)["allowedIPs"] = []string{"not-a-prefix"} }},
+		{"no address", func(m map[string]any) { m["address"] = []any{} }},
+		{"bad jc/jmin order", func(m map[string]any) { m["jmin"] = 200; m["jmax"] = 100 }},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			m := validOutboundMapT(t)
+			tc.breakF(m)
+			bs, _ := json.Marshal(m)
+			if err := ValidateAmneziaWGOutbound("t", wrapOutboundSettings(bs)); err == nil {
+				t.Fatalf("%s: expected error, got nil", tc.name)
+			}
+		})
+	}
+}
+
+// wrapOutboundSettings embeds a settings payload the way the template stores
+// it: as the nested "settings" of an amneziawg outbound row.
+func wrapOutboundSettings(settings json.RawMessage) []byte {
+	bs, err := json.Marshal(map[string]any{
+		"protocol": "amneziawg",
+		"tag":      "t",
+		"settings": settings,
+	})
+	if err != nil {
+		panic(err)
+	}
+	return bs
+}
+
+func peer(m map[string]any) map[string]any {
+	return m["peers"].([]any)[0].(map[string]any)
+}
+
+func validOutboundMapT(t *testing.T) map[string]any {
+	t.Helper()
+	var m map[string]any
+	if err := json.Unmarshal(validOutboundJSON(t), &m); err != nil {
+		t.Fatal(err)
+	}
+	return m
+}
+
+func TestIsAmneziaWGOutbound(t *testing.T) {
+	yes := []byte(`{"protocol":"amneziawg","tag":"x"}`)
+	if !IsAmneziaWGOutbound(yes) {
+		t.Fatal("amneziawg protocol not detected")
+	}
+	no := []byte(`{"protocol":"freedom","tag":"x"}`)
+	if IsAmneziaWGOutbound(no) {
+		t.Fatal("freedom misdetected as amneziawg")
+	}
+	if IsAmneziaWGOutbound([]byte(`{broken`)) {
+		t.Fatal("garbage misdetected as amneziawg")
+	}
+}

--- a/internal/amneziawgnet/client_device.go
+++ b/internal/amneziawgnet/client_device.go
@@ -1,0 +1,145 @@
+package amneziawgnet
+
+import (
+	"fmt"
+	"strings"
+
+	awgconn "github.com/amnezia-vpn/amneziawg-go/v3/conn"
+	"github.com/amnezia-vpn/amneziawg-go/v3/device"
+
+	"github.com/mhsanaei/3x-ui/v3/internal/amneziawg"
+	"github.com/mhsanaei/3x-ui/v3/internal/util/wireguard"
+)
+
+// buildClientUAPIConfig renders an amneziawg.OutboundInstance (plus opts' AWG
+// 3.0 fields) as a UAPI "set" string for a CLIENT-mode interface: the same
+// device lines buildUAPIConfig emits, but per-peer endpoint= and
+// persistent_keepalive_seconds= added -- the fields a dialer needs that a
+// listener never sees. listen_port is emitted only when inst.ListenPort > 0
+// (a client normally lets the kernel pick its UDP source port).
+func buildClientUAPIConfig(inst amneziawg.OutboundInstance, opts DeviceOptions) (string, error) {
+	var b strings.Builder
+
+	privHex, err := wireguard.KeyToHex(inst.PrivateKey)
+	if err != nil {
+		return "", fmt.Errorf("invalid private key: %w", err)
+	}
+	fmt.Fprintf(&b, "private_key=%s\n", privHex)
+	if inst.ListenPort > 0 {
+		fmt.Fprintf(&b, "listen_port=%d\n", inst.ListenPort)
+	}
+	b.WriteString("replace_peers=true\n")
+
+	o := inst.Obfuscation
+	fmt.Fprintf(&b, "jc=%d\njmin=%d\njmax=%d\n", o.Jc, o.Jmin, o.Jmax)
+	fmt.Fprintf(&b, "s1=%d\ns2=%d\ns3=%d\ns4=%d\n", o.S1, o.S2, o.S3, o.S4)
+	writeOptionalLine(&b, "h1", o.H1)
+	writeOptionalLine(&b, "h2", o.H2)
+	writeOptionalLine(&b, "h3", o.H3)
+	writeOptionalLine(&b, "h4", o.H4)
+	writeOptionalLine(&b, "i1", o.I1)
+	writeOptionalLine(&b, "i2", o.I2)
+	writeOptionalLine(&b, "i3", o.I3)
+	writeOptionalLine(&b, "i4", o.I4)
+	writeOptionalLine(&b, "i5", o.I5)
+
+	if opts.HeaderProtectionKey != "" {
+		hpHex, err := wireguard.KeyToHex(opts.HeaderProtectionKey)
+		if err != nil {
+			return "", fmt.Errorf("invalid header protection key: %w", err)
+		}
+		fmt.Fprintf(&b, "header_protection_key=%s\n", hpHex)
+	}
+	if opts.ContentPaddingAddition != "" {
+		fmt.Fprintf(&b, "content_padding_addition=%s\n", opts.ContentPaddingAddition)
+	}
+	if opts.RekeyAfterTime != "" {
+		fmt.Fprintf(&b, "rekey_after_time=%s\n", opts.RekeyAfterTime)
+	}
+	if opts.RekeyTimeout != "" {
+		fmt.Fprintf(&b, "rekey_timeout=%s\n", opts.RekeyTimeout)
+	}
+	if opts.RejectAfterTime != "" {
+		fmt.Fprintf(&b, "reject_after_time=%s\n", opts.RejectAfterTime)
+	}
+	if opts.KeepaliveTimeout != "" {
+		fmt.Fprintf(&b, "keepalive_timeout=%s\n", opts.KeepaliveTimeout)
+	}
+	if opts.MaxHandshakeAttempts != "" {
+		fmt.Fprintf(&b, "max_handshake_attempts=%s\n", opts.MaxHandshakeAttempts)
+	}
+	fmt.Fprintf(&b, "random_trailers=%t\n", opts.RandomTrailers)
+	fmt.Fprintf(&b, "disable_cookies=%t\n", opts.DisableCookies)
+
+	for _, p := range inst.Peers {
+		pubHex, err := wireguard.KeyToHex(p.PublicKey)
+		if err != nil {
+			return "", fmt.Errorf("peer %q: invalid public key: %w", p.Endpoint, err)
+		}
+		fmt.Fprintf(&b, "public_key=%s\n", pubHex)
+		if p.PresharedKey != "" {
+			pskHex, err := wireguard.KeyToHex(p.PresharedKey)
+			if err != nil {
+				return "", fmt.Errorf("peer %q: invalid preshared key: %w", p.Endpoint, err)
+			}
+			fmt.Fprintf(&b, "preshared_key=%s\n", pskHex)
+		}
+		fmt.Fprintf(&b, "endpoint=%s\n", p.Endpoint)
+		if p.KeepAlive > 0 {
+			fmt.Fprintf(&b, "persistent_keepalive_seconds=%d\n", p.KeepAlive)
+		}
+		for _, allowedIP := range p.AllowedIPs {
+			fmt.Fprintf(&b, "allowed_ip=%s\n", allowedIP)
+		}
+	}
+
+	return b.String(), nil
+}
+
+// newUnconfiguredClientDevice builds the tun/netstack/device trio for a
+// client-mode instance without configuring it. Same construction and same
+// handler-registration ordering rules as newUnconfiguredDevice.
+func newUnconfiguredClientDevice(inst amneziawg.OutboundInstance, opts DeviceOptions) (*Device, error) {
+	addrs, err := hostAddresses(inst.Address)
+	if err != nil {
+		return nil, fmt.Errorf("amneziawgnet: %w", err)
+	}
+
+	mtu := inst.MTU
+	if mtu <= 0 {
+		mtu = defaultMTU
+	}
+
+	tun, gstack, err := createNetTUNWithStack(addrs, mtu)
+	if err != nil {
+		return nil, fmt.Errorf("amneziawgnet: create netstack: %w", err)
+	}
+
+	logger := opts.Logger
+	if logger == nil {
+		logger = device.NewLogger(device.LogLevelSilent, fmt.Sprintf("(awg-out %s) ", inst.Tag))
+	}
+	dev := device.NewDevice(tun, awgconn.NewDefaultBind(), logger)
+
+	return &Device{Device: dev, Stack: gstack, localAddrs: addrs}, nil
+}
+
+// ConfigureClient applies inst/opts to a client-mode device via UAPI and
+// brings the interface up. Same single-call and handler-ordering contract as
+// Configure.
+func (d *Device) ConfigureClient(inst amneziawg.OutboundInstance, opts DeviceOptions) error {
+	conf, err := buildClientUAPIConfig(inst, opts)
+	if err != nil {
+		d.Close()
+		return fmt.Errorf("amneziawgnet: %w", err)
+	}
+	if err := d.IpcSet(conf); err != nil {
+		d.Close()
+		return fmt.Errorf("amneziawgnet: IpcSet for outbound %q: %w", inst.Tag, err)
+	}
+	if err := d.Up(); err != nil {
+		d.Close()
+		return fmt.Errorf("amneziawgnet: bring up outbound %q: %w", inst.Tag, err)
+	}
+	return nil
+}

--- a/internal/amneziawgnet/device.go
+++ b/internal/amneziawgnet/device.go
@@ -74,7 +74,17 @@ type DeviceOptions struct {
 type Device struct {
 	*device.Device
 	Stack *stack.Stack
+
+	// localAddrs snapshots the interface addresses the netstack was built
+	// with (hostAddresses of the Instance's Address list). gVisor exposes no
+	// read-back for them, and WriteUDPReply-style raw injection needs a
+	// same-family source address; set once by newUnconfiguredDevice /
+	// newUnconfiguredClientDevice, read-only afterwards.
+	localAddrs []netip.Addr
 }
+
+// LocalAddresses returns the configured tunnel-local address(es).
+func (d *Device) LocalAddresses() []netip.Addr { return d.localAddrs }
 
 // NewDevice constructs, configures, and brings up an embedded AmneziaWG
 // interface for inst in one call: a gVisor-backed tun.Device sized to
@@ -138,7 +148,7 @@ func newUnconfiguredDevice(inst amneziawg.Instance, opts DeviceOptions) (*Device
 	}
 	dev := device.NewDevice(tun, awgconn.NewDefaultBind(), logger)
 
-	return &Device{Device: dev, Stack: gstack}, nil
+	return &Device{Device: dev, Stack: gstack, localAddrs: addrs}, nil
 }
 
 // Configure applies inst/opts to d via UAPI and brings the interface up.

--- a/internal/amneziawgnet/egress.go
+++ b/internal/amneziawgnet/egress.go
@@ -1,0 +1,386 @@
+package amneziawgnet
+
+import (
+	"context"
+	"encoding/binary"
+	"fmt"
+	"io"
+	"net"
+	"net/netip"
+	"sync"
+
+	"gvisor.dev/gvisor/pkg/tcpip"
+	"gvisor.dev/gvisor/pkg/tcpip/adapters/gonet"
+
+	"github.com/mhsanaei/3x-ui/v3/internal/logger"
+)
+
+// EgressBasePort is the fixed loopback port the panel's own SOCKS5 egress
+// server listens on. Fixed (not derived) because it appears in every
+// amneziawg outbound's generated socks replacement; 64900 sits below the
+// inbound relay range (SOCKSBasePort 65100+) and above the ephemeral ports
+// most distributions allocate by default.
+const EgressBasePort = 64900
+
+// socks5EgressServer is a minimal loopback-only SOCKS5 server: CONNECT for
+// TCP, UDP ASSOCIATE for UDP. It is the egress half of the AmneziaWG
+// outbound design -- Xray's generated config replaces each "amneziawg"
+// outbound with a plain socks outbound pointed here, authenticating with the
+// outbound's tag as username, so this server can route the flow into that
+// outbound's embedded device's netstack. The password is ignored: only
+// loopback can reach the listener, and the username already carries all the
+// routing information there is.
+type socks5EgressServer struct {
+	mu       sync.Mutex
+	listener net.Listener
+	stacks   map[string]*Device // outbound tag -> its device
+	closing  chan struct{}
+	wg       sync.WaitGroup
+}
+
+var (
+	egressOnce   sync.Once
+	egressServer *socks5EgressServer
+)
+
+// GetEgressServer returns the process-wide SOCKS5 egress server singleton.
+func GetEgressServer() *socks5EgressServer {
+	egressOnce.Do(func() {
+		egressServer = &socks5EgressServer{
+			stacks:  map[string]*Device{},
+			closing: make(chan struct{}),
+		}
+	})
+	return egressServer
+}
+
+// SetStack registers or replaces the device backing an outbound tag.
+func (s *socks5EgressServer) SetStack(tag string, dev *Device) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.stacks[tag] = dev
+}
+
+// DeleteStack drops an outbound tag's registration (outbound removed).
+func (s *socks5EgressServer) DeleteStack(tag string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	delete(s.stacks, tag)
+}
+
+// Listen starts accepting on the loopback listener. Idempotent; a bind
+// failure is returned and retried by the caller's reconcile tick.
+func (s *socks5EgressServer) Listen() error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.listener != nil {
+		return nil
+	}
+	ln, err := (&net.ListenConfig{}).Listen(context.Background(), "tcp", fmt.Sprintf("127.0.0.1:%d", EgressBasePort))
+	if err != nil {
+		return fmt.Errorf("amneziawgnet: egress listen: %w", err)
+	}
+	s.listener = ln
+	logger.Infof("amneziawgnet: egress socks listening on %s", ln.Addr())
+	s.wg.Add(1)
+	go s.acceptLoop()
+	return nil
+}
+
+// Close stops the listener and waits for in-flight handlers.
+func (s *socks5EgressServer) Close() {
+	s.mu.Lock()
+	ln := s.listener
+	s.listener = nil
+	s.mu.Unlock()
+	if ln == nil {
+		return
+	}
+	ln.Close()
+	close(s.closing)
+	s.wg.Wait()
+}
+
+func (s *socks5EgressServer) acceptLoop() {
+	defer s.wg.Done()
+	for {
+		conn, err := s.listener.Accept()
+		if err != nil {
+			select {
+			case <-s.closing:
+				return
+			default:
+			}
+			logger.Warningf("amneziawgnet: egress accept: %v", err)
+			continue
+		}
+		s.wg.Add(1)
+		go func(c net.Conn) {
+			defer s.wg.Done()
+			s.handleConn(c)
+		}(conn)
+	}
+}
+
+// stackFor resolves a tag to its live device at use time, so a reconfigure
+// that rebuilds the device takes effect for every new connection without any
+// re-registration of the listener itself.
+func (s *socks5EgressServer) stackFor(tag string) (*Device, bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	dev, ok := s.stacks[tag]
+	return dev, ok
+}
+
+func (s *socks5EgressServer) handleConn(conn net.Conn) {
+	defer conn.Close()
+
+	method, err := socks5Greeting(conn)
+	if err != nil || method == 0xFF {
+		return
+	}
+	user := ""
+	if method == 0x02 {
+		var ulen [1]byte
+		if _, err := io.ReadFull(conn, ulen[:]); err != nil {
+			return
+		}
+		uname := make([]byte, ulen[0])
+		if _, err := io.ReadFull(conn, uname); err != nil {
+			return
+		}
+		user = string(uname)
+		var plen [1]byte
+		if _, err := io.ReadFull(conn, plen[:]); err != nil {
+			return
+		}
+		pass := make([]byte, plen[0])
+		if _, err := io.ReadFull(conn, pass); err != nil {
+			return
+		}
+		// Any credentials are accepted: loopback-only listener, and the
+		// username is routing information, not a secret.
+		if _, err := conn.Write([]byte{0x01, 0x00}); err != nil {
+			return
+		}
+	}
+
+	var req [4]byte
+	if _, err := io.ReadFull(conn, req[:]); err != nil {
+		return
+	}
+	dest, err := readSocksRequestAddr(conn, req[3])
+	if err != nil {
+		writeSocksReply(conn, 0x01, netip.AddrPort{})
+		return
+	}
+
+	switch req[1] {
+	case 0x01: // CONNECT
+		dev, ok := s.stackFor(user)
+		if !ok {
+			writeSocksReply(conn, 0x05, netip.AddrPort{})
+			return
+		}
+		s.relayTCP(dev, user, conn, dest)
+	case 0x03: // UDP ASSOCIATE
+		dev, ok := s.stackFor(user)
+		if !ok {
+			writeSocksReply(conn, 0x05, netip.AddrPort{})
+			return
+		}
+		s.relayUDP(dev, user, udpControl{conn: conn}, dest)
+	default:
+		writeSocksReply(conn, 0x07, netip.AddrPort{})
+	}
+}
+
+// socks5Greeting reads the client greeting, replies with our chosen auth
+// method (username/password when offered, else no-auth), returning the
+// selected method code. 0xFF means "no acceptable method" was already
+// answered with an error by us or the read failed.
+func socks5Greeting(conn net.Conn) (byte, error) {
+	var hdr [2]byte
+	if _, err := io.ReadFull(conn, hdr[:]); err != nil {
+		return 0xFF, err
+	}
+	methods := make([]byte, hdr[1])
+	if _, err := io.ReadFull(conn, methods); err != nil {
+		return 0xFF, err
+	}
+	hasUserPass := false
+	for _, m := range methods {
+		if m == 0x02 {
+			hasUserPass = true
+			break
+		}
+	}
+	chosen := byte(0x00)
+	if hasUserPass {
+		chosen = 0x02
+	}
+	if _, err := conn.Write([]byte{0x05, chosen}); err != nil {
+		return 0xFF, err
+	}
+	return chosen, nil
+}
+
+// readSocksRequestAddr parses the address portion of a request.
+func readSocksRequestAddr(r io.Reader, atyp byte) (netip.AddrPort, error) {
+	addr, err := readSocks5Addr(r, atyp)
+	if err != nil {
+		return netip.AddrPort{}, err
+	}
+	var portBytes [2]byte
+	if _, err := io.ReadFull(r, portBytes[:]); err != nil {
+		return netip.AddrPort{}, err
+	}
+	return netip.AddrPortFrom(addr, binary.BigEndian.Uint16(portBytes[:])), nil
+}
+
+// writeSocksReply emits a success/failure reply with an empty v4 bind
+// address -- Xray's socks client reads the code byte and its own dialed
+// address; it does not need the server to echo one back.
+func writeSocksReply(w io.Writer, code byte, _ netip.AddrPort) {
+	out := []byte{0x05, code, 0x00, 0x01, 0, 0, 0, 0, 0, 0}
+	_, _ = w.Write(out)
+}
+
+// relayTCP dials dest inside the tagged outbound's netstack and pipes both
+// directions until either side closes.
+func (s *socks5EgressServer) relayTCP(dev *Device, tag string, upstream net.Conn, dest netip.AddrPort) {
+	fa := tcpip.FullAddress{
+		NIC:  1,
+		Addr: tcpip.AddrFromSlice(dest.Addr().AsSlice()),
+		Port: dest.Port(),
+	}
+	tunnelConn, err := gonet.DialContextTCP(context.Background(), dev.Stack, fa, tunnelNetwork(dest.Addr()))
+	if err != nil {
+		logger.Warningf("amneziawgnet: egress %q: dial tunnel %s: %v", tag, dest, err)
+		writeSocksReply(upstream, 0x01, netip.AddrPort{})
+		return
+	}
+	defer tunnelConn.Close()
+
+	if _, err := upstream.Write([]byte{0x05, 0x00, 0x00, 0x01, 0, 0, 0, 0, 0, 0}); err != nil {
+		return
+	}
+	done := make(chan struct{}, 2)
+	go func() { _, _ = io.Copy(tunnelConn, upstream); done <- struct{}{} }()
+	go func() { _, _ = io.Copy(upstream, tunnelConn); done <- struct{}{} }()
+	<-done
+}
+
+// udpControl is the control half of one UDP ASSOCIATE: the TCP connection
+// whose lifetime bounds the association (RFC 1928).
+type udpControl struct{ conn net.Conn }
+
+// relayUDP answers the associate request, then serves datagrams from the
+// control socket into the tunnel until either side closes -- the mirror image
+// of relay.go's inbound UDPRelay.pump.
+func (s *socks5EgressServer) relayUDP(dev *Device, tag string, ctl udpControl, _ netip.AddrPort) {
+	udpConn, err := net.ListenUDP("udp", &net.UDPAddr{IP: net.IPv4(127, 0, 0, 1)})
+	if err != nil {
+		logger.Warningf("amneziawgnet: egress %q: udp bind: %v", tag, err)
+		writeSocksReply(ctl.conn, 0x01, netip.AddrPort{})
+		return
+	}
+	defer udpConn.Close()
+
+	local := udpConn.LocalAddr().(*net.UDPAddr)
+	ip4 := local.IP.To4()
+	reply := []byte{
+		0x05, 0x00, 0x00, 0x01, ip4[0], ip4[1], ip4[2], ip4[3],
+		byte(local.Port >> 8), byte(local.Port),
+	}
+	if _, err := ctl.conn.Write(reply); err != nil {
+		return
+	}
+
+	// Reader side: datagrams arriving from Xray carry SOCKS5 UDP headers;
+	// strip and forward each payload into the tunnel stack.
+	go func() {
+		buf := make([]byte, 65536)
+		for {
+			n, err := udpConn.Read(buf)
+			if err != nil {
+				return
+			}
+			data := buf[:n]
+			if len(data) < 4 {
+				continue
+			}
+			atyp := data[3]
+			hdrLen := 4 + addrLen(atyp) + 2
+			if atyp == 0x03 || hdrLen <= 6 || len(data) < hdrLen {
+				continue // domain-targeted datagrams never occur from Xray here
+			}
+			dst, err := parseDatagramHeader(data[:hdrLen])
+			if err != nil {
+				continue
+			}
+			src := netip.AddrPortFrom(tunnelLocalAddress(dev, dst.Addr()), 0)
+			if werr := WriteUDPReply(dev.Stack, src, dst, data[hdrLen:]); werr != nil {
+				logger.Debugf("amneziawgnet: egress %q: inject udp to %s: %v", tag, dst, werr)
+			}
+		}
+	}()
+
+	// Block until the control connection closes, then tear down relaying --
+	// RFC 1928 semantics, same contract as relay.go's UDPRelay sessions.
+	buf := make([]byte, 512)
+	for {
+		if _, err := ctl.conn.Read(buf); err != nil {
+			return
+		}
+	}
+}
+
+// addrLen returns the wire length of a SOCKS5 address of the given ATYP.
+func addrLen(atyp byte) int {
+	switch atyp {
+	case 0x01:
+		return 4
+	case 0x04:
+		return 16
+	default:
+		return -1
+	}
+}
+
+// parseDatagramHeader decodes the destination from the front of a SOCKS5 UDP
+// datagram header block (RSV RSV FRAG ATYP ADDR PORT).
+func parseDatagramHeader(hdr []byte) (netip.AddrPort, error) {
+	if len(hdr) < 4 {
+		return netip.AddrPort{}, fmt.Errorf("short header")
+	}
+	atyp := hdr[3]
+	body := hdr[4:]
+	switch atyp {
+	case 0x01:
+		if len(body) < 6 {
+			return netip.AddrPort{}, fmt.Errorf("short v4")
+		}
+		return netip.AddrPortFrom(netip.AddrFrom4([4]byte(body[:4])), binary.BigEndian.Uint16(body[4:6])), nil
+	case 0x04:
+		if len(body) < 18 {
+			return netip.AddrPort{}, fmt.Errorf("short v6")
+		}
+		return netip.AddrPortFrom(netip.AddrFrom16([16]byte(body[:16])), binary.BigEndian.Uint16(body[16:18])), nil
+	default:
+		return netip.AddrPort{}, fmt.Errorf("unsupported atyp %d", atyp)
+	}
+}
+
+// tunnelLocalAddress picks the stack's own configured address matching dst's
+// family, so injected packets have a plausible source. Falls back to an
+// unspecified address when the stack has none of that family (the packet is
+// then dropped downstream anyway).
+func tunnelLocalAddress(dev *Device, dst netip.Addr) netip.Addr {
+	for _, a := range dev.LocalAddresses() {
+		if a.Is4() == dst.Is4() {
+			return a
+		}
+	}
+	return netip.Addr{}
+}

--- a/internal/amneziawgnet/outbound_manager.go
+++ b/internal/amneziawgnet/outbound_manager.go
@@ -1,0 +1,170 @@
+package amneziawgnet
+
+import (
+	"fmt"
+	"strings"
+	"sync"
+
+	"github.com/mhsanaei/3x-ui/v3/internal/amneziawg"
+	"github.com/mhsanaei/3x-ui/v3/internal/logger"
+)
+
+// OutboundDesired pairs an amneziawg.OutboundInstance with the same
+// DeviceOptions the inbound path uses -- one AWG 3.0/3.1 parameter set must
+// be identical on both ends of a tunnel, so both directions carry it in the
+// same shape.
+type OutboundDesired struct {
+	Instance amneziawg.OutboundInstance
+	Options  DeviceOptions
+}
+
+// managedOutbound is one running client-mode interface: its Device, the
+// rendered UAPI config used for the no-op/reconfigure decision, and enough
+// of the instance to fingerprint address/MTU changes.
+type managedOutbound struct {
+	dev        *Device
+	uapiConfig string
+	structFP   string
+}
+
+// OutboundManager owns the running embedded AmneziaWG client interfaces,
+// keyed by outbound tag -- the outbound mirror of Manager. It also keeps the
+// SOCKS5 egress server's tag->device registry current and makes sure that
+// server's listener exists, so a caller only calls Reconcile.
+type OutboundManager struct {
+	mu    sync.Mutex
+	iface map[string]*managedOutbound
+}
+
+var (
+	outboundManagerOnce sync.Once
+	outboundManager     *OutboundManager
+)
+
+// GetOutboundManager returns the process-wide outbound manager singleton.
+func GetOutboundManager() *OutboundManager {
+	outboundManagerOnce.Do(func() {
+		outboundManager = &OutboundManager{iface: map[string]*managedOutbound{}}
+	})
+	return outboundManager
+}
+
+func outboundFingerprint(inst amneziawg.OutboundInstance) string {
+	return fmt.Sprintf("%d|%s", inst.MTU, strings.Join(inst.Address, ","))
+}
+
+// Reconcile brings every desired outbound's device up to date and stops any
+// whose tag is no longer desired -- the per-tick contract of Manager.Reconcile.
+// Never returns errors: one broken outbound logs and leaves the rest alone,
+// exactly like the inbound side.
+func (m *OutboundManager) Reconcile(desired []OutboundDesired) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if err := GetEgressServer().Listen(); err != nil {
+		logger.Warningf("amneziawgnet: egress listener unavailable: %v", err)
+	}
+
+	want := make(map[string]struct{}, len(desired))
+	for _, d := range desired {
+		want[d.Instance.Tag] = struct{}{}
+	}
+	for tag, cur := range m.iface {
+		if _, ok := want[tag]; ok {
+			continue
+		}
+		cur.dev.Close()
+		GetEgressServer().DeleteStack(tag)
+		delete(m.iface, tag)
+		logger.Infof("amneziawgnet: stopped embedded outbound %q", tag)
+	}
+
+	for _, d := range desired {
+		if err := m.ensureLocked(d); err != nil {
+			logger.Warningf("amneziawgnet: reconcile failed for outbound %q: %v", d.Instance.Tag, err)
+		}
+	}
+}
+
+// ensureLocked decides between no-op / reconfigure-in-place / rebuild for one
+// desired outbound -- same three-way split and same reasoning as the inbound
+// Manager.ensureLocked (IpcSet always resets peers; address/MTU are fixed at
+// netstack build time).
+func (m *OutboundManager) ensureLocked(d OutboundDesired) error {
+	inst, opts := d.Instance, d.Options
+	if opts.Logger == nil {
+		opts.Logger = verboseLoggerIfEnabled(0)
+	}
+
+	fp := outboundFingerprint(inst)
+	conf, err := buildClientUAPIConfig(inst, opts)
+	if err != nil {
+		return fmt.Errorf("render UAPI config: %w", err)
+	}
+
+	cur, exists := m.iface[inst.Tag]
+	if exists && cur.structFP == fp {
+		if conf == cur.uapiConfig {
+			GetEgressServer().SetStack(inst.Tag, cur.dev)
+			return nil
+		}
+		if err := cur.dev.IpcSet(conf); err != nil {
+			return fmt.Errorf("reconfigure outbound %q: %w", inst.Tag, err)
+		}
+		cur.uapiConfig = conf
+		GetEgressServer().SetStack(inst.Tag, cur.dev)
+		return nil
+	}
+
+	if exists {
+		cur.dev.Close()
+		delete(m.iface, inst.Tag)
+	}
+	dev, err := newUnconfiguredClientDevice(inst, opts)
+	if err != nil {
+		return err
+	}
+	// No forwarder to attach on the client side: traffic enters this stack
+	// only through our own SOCKS5 egress server, which dials via gonet at
+	// use time -- so ConfigureClient can run immediately.
+	if err := dev.ConfigureClient(inst, opts); err != nil {
+		return err
+	}
+	m.iface[inst.Tag] = &managedOutbound{dev: dev, uapiConfig: conf, structFP: fp}
+	GetEgressServer().SetStack(inst.Tag, dev)
+	logger.Infof("amneziawgnet: started embedded outbound %s (%d peers)", inst.Tag, len(inst.Peers))
+	return nil
+}
+
+// Remove tears down one outbound's device by tag.
+func (m *OutboundManager) Remove(tag string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	cur, exists := m.iface[tag]
+	if !exists {
+		return
+	}
+	cur.dev.Close()
+	GetEgressServer().DeleteStack(tag)
+	delete(m.iface, tag)
+	logger.Infof("amneziawgnet: stopped embedded outbound %q", tag)
+}
+
+// StopAll tears down every managed outbound device and the egress listener.
+// Called on panel shutdown alongside the inbound Manager's StopAll.
+func (m *OutboundManager) StopAll() {
+	m.mu.Lock()
+	for tag, cur := range m.iface {
+		cur.dev.Close()
+		delete(m.iface, tag)
+	}
+	m.mu.Unlock()
+	GetEgressServer().Close()
+}
+
+// HasRunning reports whether any outbound device is currently managed.
+func (m *OutboundManager) HasRunning() bool {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return len(m.iface) > 0
+}

--- a/internal/web/job/amneziawg_job.go
+++ b/internal/web/job/amneziawg_job.go
@@ -1,9 +1,13 @@
 package job
 
 import (
+	"encoding/json"
+
+	"github.com/mhsanaei/3x-ui/v3/internal/amneziawg"
 	"github.com/mhsanaei/3x-ui/v3/internal/amneziawgnet"
 	"github.com/mhsanaei/3x-ui/v3/internal/logger"
 	"github.com/mhsanaei/3x-ui/v3/internal/web/service"
+	"github.com/mhsanaei/3x-ui/v3/internal/xray"
 )
 
 // AmneziaWGJob reconciles the running embedded AmneziaWG interfaces
@@ -17,8 +21,14 @@ import (
 // internal/amneziawgnet.Manager's automatic forwarder/relay wiring), it's
 // an ordinary Xray user, and XrayTrafficJob's existing, protocol-blind
 // stats/online-status polling already picks it up for free.
+//
+// The same Run also reconciles the embedded AmneziaWG OUTBOUND devices
+// against the "amneziawg" outbounds declared in the Xray template: same 10s
+// cadence, same embedded engine (client mode instead of server mode), so one
+// job keeps both directions of the protocol converged.
 type AmneziaWGJob struct {
 	inboundService service.InboundService
+	settingService service.SettingService
 }
 
 // NewAmneziaWGJob creates a new AmneziaWG reconcile job instance.
@@ -52,4 +62,53 @@ func (j *AmneziaWGJob) Run() {
 		})
 	}
 	amneziawgnet.GetManager().Reconcile(wanted)
+	amneziawgnet.GetOutboundManager().Reconcile(j.desiredOutboundInstances())
+}
+
+// desiredOutboundInstances parses the stored Xray template and derives a
+// client-mode OutboundInstance for every "amneziawg" outbound in it.
+func (j *AmneziaWGJob) desiredOutboundInstances() []amneziawgnet.OutboundDesired {
+	template, err := j.settingService.GetXrayConfigTemplate()
+	if err != nil || template == "" {
+		return nil
+	}
+	cfg := &xray.Config{}
+	if err := json.Unmarshal([]byte(template), cfg); err != nil || len(cfg.OutboundConfigs) == 0 {
+		return nil
+	}
+	var raws []json.RawMessage
+	if err := json.Unmarshal(cfg.OutboundConfigs, &raws); err != nil {
+		return nil
+	}
+	out := make([]amneziawgnet.OutboundDesired, 0, len(raws))
+	for _, raw := range raws {
+		if !amneziawg.IsAmneziaWGOutbound(raw) {
+			continue
+		}
+		var probe struct {
+			Tag string `json:"tag"`
+		}
+		if err := json.Unmarshal(raw, &probe); err != nil || probe.Tag == "" {
+			continue
+		}
+		inst, ok := amneziawg.InstanceFromOutbound(probe.Tag, raw)
+		if !ok {
+			continue
+		}
+		out = append(out, amneziawgnet.OutboundDesired{
+			Instance: inst,
+			Options: amneziawgnet.DeviceOptions{
+				HeaderProtectionKey:    inst.Obfuscation.HeaderProtectionKey,
+				ContentPaddingAddition: inst.Obfuscation.ContentPaddingAddition,
+				RekeyAfterTime:         inst.Obfuscation.RekeyAfterTime,
+				RekeyTimeout:           inst.Obfuscation.RekeyTimeout,
+				RejectAfterTime:        inst.Obfuscation.RejectAfterTime,
+				KeepaliveTimeout:       inst.Obfuscation.KeepaliveTimeout,
+				MaxHandshakeAttempts:   inst.Obfuscation.MaxHandshakeAttempts,
+				RandomTrailers:         inst.Obfuscation.RandomTrailers,
+				DisableCookies:         inst.Obfuscation.DisableCookies,
+			},
+		})
+	}
+	return out
 }

--- a/internal/web/service/xray.go
+++ b/internal/web/service/xray.go
@@ -160,6 +160,10 @@ func (s *XrayService) GetXrayConfig() (*xray.Config, error) {
 	// still carry sessionPlacement/sessionKey; lift them too (same reason as
 	// the per-inbound lift below).
 	xrayConfig.OutboundConfigs = liftOutboundsXhttpSessionIDKeys(xrayConfig.OutboundConfigs)
+	// Swap every "amneziawg" outbound for its socks bridge BEFORE anything
+	// else reads OutboundConfigs: Xray-core has no amneziawg proxy, and
+	// ValidateOutboundConfig / hot-diff would both choke on the raw entry.
+	transformAmneziaWGOutbounds(xrayConfig)
 
 	_, _, _ = s.inboundService.AddTraffic(nil, nil)
 

--- a/internal/web/service/xray_amneziawg_outbound.go
+++ b/internal/web/service/xray_amneziawg_outbound.go
@@ -1,0 +1,66 @@
+package service
+
+import (
+	"encoding/json"
+
+	"github.com/mhsanaei/3x-ui/v3/internal/amneziawgnet"
+	json_util "github.com/mhsanaei/3x-ui/v3/internal/util/json_util"
+	"github.com/mhsanaei/3x-ui/v3/internal/xray"
+)
+
+// transformAmneziaWGOutbounds rewrites every "amneziawg" outbound in the
+// generated config into a plain socks outbound with the same tag, pointed at
+// the panel's own loopback SOCKS5 egress server (internal/amneziawgnet's
+// GetEgressServer, authenticating the outbound tag as username). Xray-core
+// has no amneziawg proxy -- OutboundConfigs is handed to it verbatim --
+// while the embedded amneziawg-go client device lives in THIS process; the
+// socks swap is what routes Xray's traffic through that device. The stored
+// template is never touched: this runs on the freshly-unmarshalled copy
+// inside GetXrayConfig, so hot-diff sees only real, appliable changes.
+func transformAmneziaWGOutbounds(cfg *xray.Config) {
+	if len(cfg.OutboundConfigs) == 0 {
+		return
+	}
+	var outbounds []json.RawMessage
+	if err := json.Unmarshal(cfg.OutboundConfigs, &outbounds); err != nil {
+		return
+	}
+	changed := false
+	for i, raw := range outbounds {
+		var probe struct {
+			Protocol string `json:"protocol"`
+			Tag      string `json:"tag"`
+		}
+		if err := json.Unmarshal(raw, &probe); err != nil || probe.Protocol != "amneziawg" {
+			continue
+		}
+		settings := map[string]any{
+			"addr": "127.0.0.1",
+			"port": amneziawgnet.EgressBasePort,
+			"user": probe.Tag,
+			"pass": amneziawgnet.SocksPassword(),
+		}
+		bs, err := json.Marshal(settings)
+		if err != nil {
+			continue
+		}
+		replacement, err := json.Marshal(map[string]any{
+			"protocol": "socks",
+			"tag":      probe.Tag,
+			"settings": json.RawMessage(bs),
+		})
+		if err != nil {
+			continue
+		}
+		outbounds[i] = replacement
+		changed = true
+	}
+	if !changed {
+		return
+	}
+	bs, err := json.Marshal(outbounds)
+	if err != nil {
+		return
+	}
+	cfg.OutboundConfigs = json_util.RawMessage(bs)
+}

--- a/internal/web/service/xray_amneziawg_outbound_test.go
+++ b/internal/web/service/xray_amneziawg_outbound_test.go
@@ -1,0 +1,138 @@
+package service
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/mhsanaei/3x-ui/v3/internal/amneziawgnet"
+	"github.com/mhsanaei/3x-ui/v3/internal/util/json_util"
+	wgutil "github.com/mhsanaei/3x-ui/v3/internal/util/wireguard"
+	"github.com/mhsanaei/3x-ui/v3/internal/xray"
+)
+
+func amneziawgnetEgressPortForTest() int { return amneziawgnet.EgressBasePort }
+
+func wgKeypairForTest() (priv, pub string, err error) {
+	return wgutil.GenerateWireguardKeypair()
+}
+
+func makeAWGOutboundConfig(t *testing.T) *xray.Config {
+	t.Helper()
+	cfg := &xray.Config{}
+	err := json.Unmarshal([]byte(`{
+		"outbounds": [
+			{"protocol": "freedom", "tag": "direct"},
+			{"protocol": "amneziawg", "tag": "awg-hop", "settings": {"secretKey": "x"}}
+		]
+	}`), cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return cfg
+}
+
+func TestTransformAmneziaWGOutbounds(t *testing.T) {
+	cfg := makeAWGOutboundConfig(t)
+	transformAmneziaWGOutbounds(cfg)
+
+	var outbounds []struct {
+		Protocol string `json:"protocol"`
+		Tag      string `json:"tag"`
+		Settings struct {
+			Addr string `json:"addr"`
+			Port int    `json:"port"`
+			User string `json:"user"`
+		} `json:"settings"`
+	}
+	if err := json.Unmarshal(cfg.OutboundConfigs, &outbounds); err != nil {
+		t.Fatal(err)
+	}
+	if len(outbounds) != 2 {
+		t.Fatalf("outbound count = %d, want 2 (no additions or drops)", len(outbounds))
+	}
+	if outbounds[0].Protocol != "freedom" || outbounds[0].Tag != "direct" {
+		t.Fatalf("first outbound disturbed: %+v", outbounds[0])
+	}
+	got := outbounds[1]
+	if got.Protocol != "socks" {
+		t.Fatalf("amneziawg outbound not swapped to socks: %q", got.Protocol)
+	}
+	if got.Tag != "awg-hop" {
+		t.Fatalf("tag not preserved: %q", got.Tag)
+	}
+	if got.Settings.Addr != "127.0.0.1" {
+		t.Fatalf("bridge addr = %q, want 127.0.0.1", got.Settings.Addr)
+	}
+	if got.Settings.Port != amneziawgnetEgressPortForTest() {
+		t.Fatalf("bridge port = %d", got.Settings.Port)
+	}
+	if got.Settings.User != "awg-hop" {
+		t.Fatalf("SOCKS username = %q, want the outbound tag", got.Settings.User)
+	}
+}
+
+func TestTransformAmneziaWGOutbounds_NoopWithoutAWG(t *testing.T) {
+	before := &xray.Config{}
+	if err := json.Unmarshal([]byte(`{"outbounds":[{"protocol":"freedom","tag":"direct"}]}`), before); err != nil {
+		t.Fatal(err)
+	}
+	cfg := &xray.Config{}
+	if err := json.Unmarshal(before.OutboundConfigs, &cfg.OutboundConfigs); err != nil {
+		t.Fatal(err)
+	}
+	orig := json_util.RawMessage(append([]byte(nil), cfg.OutboundConfigs...))
+	transformAmneziaWGOutbounds(cfg)
+	if string(cfg.OutboundConfigs) != string(orig) {
+		t.Fatalf("config without amneziawg outbounds must stay byte-identical:\nbefore=%s\nafter=%s", orig, cfg.OutboundConfigs)
+	}
+}
+
+func TestCheckXrayConfig_AcceptsValidAWGOutbound(t *testing.T) {
+	// A syntactically valid AWG outbound must pass panel-side validation --
+	// the Xray-core loader would reject the unknown protocol outright.
+	priv, pub, err := wgKeypairForTest()
+	if err != nil {
+		t.Fatal(err)
+	}
+	template := `{
+		"outbounds": [{
+			"protocol": "amneziawg",
+			"tag": "awg-hop",
+			"settings": {
+				"mtu": 1420,
+				"secretKey": "` + priv + `",
+				"address": ["10.8.0.2/32"],
+				"jc": 4, "jmin": 40, "jmax": 100, "s1": 15, "s2": 80, "s3": 12, "s4": 12,
+				"h1": "100-800", "h2": "900-1600", "h3": "1700-2400", "h4": "2500-3200",
+				"peers": [{
+					"publicKey": "` + pub + `",
+					"allowedIPs": ["0.0.0.0/0"],
+					"endpoint": "203.0.113.7:51820",
+					"keepAlive": 25
+				}]
+			}
+		}]
+	}`
+	svc := &XraySettingService{}
+	if err := svc.CheckXrayConfig(template); err != nil {
+		t.Fatalf("valid amneziawg outbound rejected: %v", err)
+	}
+}
+
+func TestCheckXrayConfig_RejectsBrokenAWGOutbound(t *testing.T) {
+	template := `{
+		"outbounds": [{
+			"protocol": "amneziawg",
+			"tag": "awg-bad",
+			"settings": {
+				"secretKey": "not-a-key",
+				"address": ["10.8.0.2/32"],
+				"peers": [{"publicKey": "alsobad", "allowedIPs": ["0.0.0.0/0"], "endpoint": "203.0.113.7:51820"}]
+			}
+		}]
+	}`
+	svc := &XraySettingService{}
+	if err := svc.CheckXrayConfig(template); err == nil {
+		t.Fatal("broken amneziawg outbound accepted")
+	}
+}

--- a/internal/web/service/xray_setting.go
+++ b/internal/web/service/xray_setting.go
@@ -8,6 +8,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/mhsanaei/3x-ui/v3/internal/amneziawg"
 	"github.com/mhsanaei/3x-ui/v3/internal/util/common"
 	"github.com/mhsanaei/3x-ui/v3/internal/xray"
 )
@@ -58,6 +59,19 @@ func (s *XraySettingService) CheckXrayConfig(XrayTemplateConfig string) error {
 			coreVersion = process.GetXrayVersion()
 		}
 		for _, outbound := range outbounds {
+			// amneziawg is a panel pseudo-protocol, not an Xray one: the
+			// core's loader would reject it outright. Validate it here with
+			// the same rules the embedded device enforces at IpcSet time.
+			if amneziawg.IsAmneziaWGOutbound(outbound) {
+				var probe struct {
+					Tag string `json:"tag"`
+				}
+				_ = json.Unmarshal(outbound, &probe)
+				if err := amneziawg.ValidateAmneziaWGOutbound(probe.Tag, outbound); err != nil {
+					return err
+				}
+				continue
+			}
 			if err := xray.ValidateOutboundConfig(outbound); err != nil {
 				if shouldSkipLegacyUnencryptedOutboundRejection(coreVersion, err) {
 					continue

--- a/internal/web/translation/ar-EG.json
+++ b/internal/web/translation/ar-EG.json
@@ -1841,7 +1841,10 @@
         "randomTrailers": "RandomTrailers",
         "randomTrailersHint": "يضيف بايتات عشوائية إلى نهاية كل حزمة. يتطلب AmneziaWG 3.1+ على الطرفين.",
         "disableCookies": "DisableCookies",
-        "disableCookiesHint": "عدم إرسال ردود الكوكي — يزيل بصمة DPI لكنه يضعف الحماية من الفيضانات."
+        "disableCookiesHint": "عدم إرسال ردود الكوكي — يزيل بصمة DPI لكنه يضعف الحماية من الفيضانات.",
+        "listenPort": "Listen Port (optional)",
+        "listenPortHint": "Fixed local UDP source port. Leave 0 to pick one automatically.",
+        "outboundObfuscationHint": "Must exactly match the server side parameters."
       },
       "tun": {
         "userLevel": "مستوى المستخدم"

--- a/internal/web/translation/en-US.json
+++ b/internal/web/translation/en-US.json
@@ -1959,7 +1959,10 @@
         "randomTrailers": "RandomTrailers",
         "randomTrailersHint": "Appends random bytes to every packet. Both ends need AmneziaWG 3.1+.",
         "disableCookies": "DisableCookies",
-        "disableCookiesHint": "Never send cookie replies — removes a DPI fingerprint; weakens flood mitigation."
+        "disableCookiesHint": "Never send cookie replies — removes a DPI fingerprint; weakens flood mitigation.",
+        "listenPort": "Listen Port (optional)",
+        "listenPortHint": "Fixed local UDP source port. Leave 0 to pick one automatically.",
+        "outboundObfuscationHint": "Must exactly match the server side parameters."
       },
       "tun": {
         "userLevel": "User Level"

--- a/internal/web/translation/es-ES.json
+++ b/internal/web/translation/es-ES.json
@@ -1841,7 +1841,10 @@
         "randomTrailers": "RandomTrailers",
         "randomTrailersHint": "Añade bytes aleatorios a cada paquete. Ambos extremos necesitan AmneziaWG 3.1+.",
         "disableCookies": "DisableCookies",
-        "disableCookiesHint": "No enviar cookie replies — elimina una huella para DPI, pero debilita la mitigación de inundaciones."
+        "disableCookiesHint": "No enviar cookie replies — elimina una huella para DPI, pero debilita la mitigación de inundaciones.",
+        "listenPort": "Listen Port (optional)",
+        "listenPortHint": "Fixed local UDP source port. Leave 0 to pick one automatically.",
+        "outboundObfuscationHint": "Must exactly match the server side parameters."
       },
       "tun": {
         "userLevel": "Nivel de Usuario"

--- a/internal/web/translation/fa-IR.json
+++ b/internal/web/translation/fa-IR.json
@@ -1841,7 +1841,10 @@
         "randomTrailers": "RandomTrailers",
         "randomTrailersHint": "به انتهای هر بسته بایت‌های تصادفی می‌افزاید. هر دو طرف باید AmneziaWG 3.1+ باشند.",
         "disableCookies": "DisableCookies",
-        "disableCookiesHint": "هرگز پاسخ کوکی ارسال نشود — اثر انگشت DPI را حذف می‌کند اما دفاع در برابر سیل‌آسا را ضعیف می‌کند."
+        "disableCookiesHint": "هرگز پاسخ کوکی ارسال نشود — اثر انگشت DPI را حذف می‌کند اما دفاع در برابر سیل‌آسا را ضعیف می‌کند.",
+        "listenPort": "Listen Port (optional)",
+        "listenPortHint": "Fixed local UDP source port. Leave 0 to pick one automatically.",
+        "outboundObfuscationHint": "Must exactly match the server side parameters."
       },
       "tun": {
         "userLevel": "سطح کاربر"

--- a/internal/web/translation/id-ID.json
+++ b/internal/web/translation/id-ID.json
@@ -1841,7 +1841,10 @@
         "randomTrailers": "RandomTrailers",
         "randomTrailersHint": "Menambahkan byte acak ke setiap paket. Kedua sisi butuh AmneziaWG 3.1+.",
         "disableCookies": "DisableCookies",
-        "disableCookiesHint": "Tidak pernah mengirim cookie reply — menghapus sidik jari DPI, tetapi melemahkan mitigasi banjir."
+        "disableCookiesHint": "Tidak pernah mengirim cookie reply — menghapus sidik jari DPI, tetapi melemahkan mitigasi banjir.",
+        "listenPort": "Listen Port (optional)",
+        "listenPortHint": "Fixed local UDP source port. Leave 0 to pick one automatically.",
+        "outboundObfuscationHint": "Must exactly match the server side parameters."
       },
       "tun": {
         "userLevel": "Level Pengguna"

--- a/internal/web/translation/ja-JP.json
+++ b/internal/web/translation/ja-JP.json
@@ -1841,7 +1841,10 @@
         "randomTrailers": "RandomTrailers",
         "randomTrailersHint": "各パケットにランダムなバイトを追加します。両端にAmneziaWG 3.1+が必要です。",
         "disableCookies": "DisableCookies",
-        "disableCookiesHint": "cookie replyを送信しません。DPIの指紋を消しますが、フラッド緩和は弱まります。"
+        "disableCookiesHint": "cookie replyを送信しません。DPIの指紋を消しますが、フラッド緩和は弱まります。",
+        "listenPort": "Listen Port (optional)",
+        "listenPortHint": "Fixed local UDP source port. Leave 0 to pick one automatically.",
+        "outboundObfuscationHint": "Must exactly match the server side parameters."
       },
       "tun": {
         "userLevel": "ユーザーレベル"

--- a/internal/web/translation/pt-BR.json
+++ b/internal/web/translation/pt-BR.json
@@ -1841,7 +1841,10 @@
         "randomTrailers": "RandomTrailers",
         "randomTrailersHint": "Acrescenta bytes aleatórios a cada pacote. Ambos os lados precisam do AmneziaWG 3.1+.",
         "disableCookies": "DisableCookies",
-        "disableCookiesHint": "Nunca enviar cookie replies — remove uma impressão digital de DPI, mas enfraquece a mitigação de inundações."
+        "disableCookiesHint": "Nunca enviar cookie replies — remove uma impressão digital de DPI, mas enfraquece a mitigação de inundações.",
+        "listenPort": "Listen Port (optional)",
+        "listenPortHint": "Fixed local UDP source port. Leave 0 to pick one automatically.",
+        "outboundObfuscationHint": "Must exactly match the server side parameters."
       },
       "tun": {
         "userLevel": "Nível do Usuário"

--- a/internal/web/translation/ru-RU.json
+++ b/internal/web/translation/ru-RU.json
@@ -1841,7 +1841,10 @@
         "randomTrailers": "RandomTrailers",
         "randomTrailersHint": "Добавляет случайные байты в конец каждого пакета. Обе стороны должны поддерживать AmneziaWG 3.1+.",
         "disableCookies": "DisableCookies",
-        "disableCookiesHint": "Не отправлять cookie reply — убирает сигнатуру для DPI, но ослабляет защиту от флуда."
+        "disableCookiesHint": "Не отправлять cookie reply — убирает сигнатуру для DPI, но ослабляет защиту от флуда.",
+        "listenPort": "Listen Port (optional)",
+        "listenPortHint": "Fixed local UDP source port. Leave 0 to pick one automatically.",
+        "outboundObfuscationHint": "Must exactly match the server side parameters."
       },
       "tun": {
         "userLevel": "Уровень пользователя"

--- a/internal/web/translation/tr-TR.json
+++ b/internal/web/translation/tr-TR.json
@@ -1841,7 +1841,10 @@
         "randomTrailers": "RandomTrailers",
         "randomTrailersHint": "Her paketin sonuna rastgele baytlar ekler. Her iki uç da AmneziaWG 3.1+ gerektirir.",
         "disableCookies": "DisableCookies",
-        "disableCookiesHint": "Cookie reply asla gönderilmez — bir DPI parmak izini kaldırır ancak taşma korumasını zayıflatır."
+        "disableCookiesHint": "Cookie reply asla gönderilmez — bir DPI parmak izini kaldırır ancak taşma korumasını zayıflatır.",
+        "listenPort": "Listen Port (optional)",
+        "listenPortHint": "Fixed local UDP source port. Leave 0 to pick one automatically.",
+        "outboundObfuscationHint": "Must exactly match the server side parameters."
       },
       "tun": {
         "userLevel": "Kullanıcı Seviyesi"

--- a/internal/web/translation/uk-UA.json
+++ b/internal/web/translation/uk-UA.json
@@ -1841,7 +1841,10 @@
         "randomTrailers": "RandomTrailers",
         "randomTrailersHint": "Додає випадкові байти в кінець кожного пакета. Обидві сторони мають підтримувати AmneziaWG 3.1+.",
         "disableCookies": "DisableCookies",
-        "disableCookiesHint": "Ніколи не надсилати cookie reply — прибирає відбиток для DPI, але послаблює захист від флуду."
+        "disableCookiesHint": "Ніколи не надсилати cookie reply — прибирає відбиток для DPI, але послаблює захист від флуду.",
+        "listenPort": "Listen Port (optional)",
+        "listenPortHint": "Fixed local UDP source port. Leave 0 to pick one automatically.",
+        "outboundObfuscationHint": "Must exactly match the server side parameters."
       },
       "tun": {
         "userLevel": "Рівень користувача"

--- a/internal/web/translation/vi-VN.json
+++ b/internal/web/translation/vi-VN.json
@@ -1841,7 +1841,10 @@
         "randomTrailers": "RandomTrailers",
         "randomTrailersHint": "Thêm các byte ngẫu nhiên vào cuối mỗi gói. Cả hai đầu cần AmneziaWG 3.1+.",
         "disableCookies": "DisableCookies",
-        "disableCookiesHint": "Không bao giờ gửi cookie reply — xóa một dấu vết DPI nhưng làm yếu khả năng chống flood."
+        "disableCookiesHint": "Không bao giờ gửi cookie reply — xóa một dấu vết DPI nhưng làm yếu khả năng chống flood.",
+        "listenPort": "Listen Port (optional)",
+        "listenPortHint": "Fixed local UDP source port. Leave 0 to pick one automatically.",
+        "outboundObfuscationHint": "Must exactly match the server side parameters."
       },
       "tun": {
         "userLevel": "Mức Người Dùng"

--- a/internal/web/translation/zh-CN.json
+++ b/internal/web/translation/zh-CN.json
@@ -1841,7 +1841,10 @@
         "randomTrailers": "RandomTrailers",
         "randomTrailersHint": "在每个数据包末尾追加随机字节。两端都需要 AmneziaWG 3.1+。",
         "disableCookies": "DisableCookies",
-        "disableCookiesHint": "从不发送 cookie reply——消除一个 DPI 指纹，但会削弱抗洪泛能力。"
+        "disableCookiesHint": "从不发送 cookie reply——消除一个 DPI 指纹，但会削弱抗洪泛能力。",
+        "listenPort": "Listen Port (optional)",
+        "listenPortHint": "Fixed local UDP source port. Leave 0 to pick one automatically.",
+        "outboundObfuscationHint": "Must exactly match the server side parameters."
       },
       "tun": {
         "userLevel": "用户级别"

--- a/internal/web/translation/zh-TW.json
+++ b/internal/web/translation/zh-TW.json
@@ -1841,7 +1841,10 @@
         "randomTrailers": "RandomTrailers",
         "randomTrailersHint": "在每個封包結尾附加隨機位元組。兩端都需要 AmneziaWG 3.1+。",
         "disableCookies": "DisableCookies",
-        "disableCookiesHint": "永不傳送 cookie reply——消除一個 DPI 指紋，但會削弱抗洪泛能力。"
+        "disableCookiesHint": "永不傳送 cookie reply——消除一個 DPI 指紋，但會削弱抗洪泛能力。",
+        "listenPort": "Listen Port (optional)",
+        "listenPortHint": "Fixed local UDP source port. Leave 0 to pick one automatically.",
+        "outboundObfuscationHint": "Must exactly match the server side parameters."
       },
       "tun": {
         "userLevel": "用戶級別"

--- a/internal/web/web.go
+++ b/internal/web/web.go
@@ -699,6 +699,7 @@ func (s *Server) stop(stopXray bool, stopTgBot bool) error {
 		_ = s.xrayService.StopXray()
 		mtproto.GetManager().StopAll()
 		amneziawgnet.GetManager().StopAll()
+		amneziawgnet.GetOutboundManager().StopAll()
 	}
 	if s.cron != nil {
 		s.cron.Stop()


### PR DESCRIPTION
## Summary

Adds AmneziaWG (AWG) as an **outbound** option, the outbound counterpart of the existing embedded AmneziaWG inbound support. An admin can now declare an `amneziawg` outbound in the Xray settings; the panel runs an amneziawg-go client device for it and routes Xray's traffic through that tunnel.

## Why

Closes #6302. Hardened cascading panel-to-panel tunnels need AmneziaWG on the egress side; today AWG is inbound-only (#6105), and hanging the obfuscation fields off the stock WireGuard outbound cannot work because Xray-core has no AWG proxy — outbound JSON is handed to the core verbatim.

The design mirrors the inbound engine one-for-one: an embedded amneziawg-go device over a gVisor netstack inside the panel process (no kernel module, nothing new to install).

## Type of change

- [x] New feature
- [ ] Bug fix
- [ ] Refactoring (no behavior change)
- [ ] Documentation
- [ ] Tests only
- [ ] Build / CI / tooling
- [ ] Other

## Areas affected

- [x] Frontend (UI / panel pages)
- [x] Backend (API endpoints, login, settings)
- [x] Xray config generation
- [ ] Subscription (share links / Clash / JSON)
- [ ] Statistics / traffic counters
- [ ] Database / migrations
- [ ] Install / upgrade script
- [ ] Docker image
- [ ] Multi-node (sub-nodes)
- [ ] Telegram bot

## How was this tested?

Backend (`go test ./...` — 41 packages green):
- New `internal/amneziawg/outbound_test.go`: instance derivation + validation accept/reject matrix (bad endpoints, control chars, empty allowedIPs, no peers, bad obfuscation).
- New `internal/web/service/xray_amneziawg_outbound_test.go`: the generated-config swap preserves tag/order and is a byte-level no-op without AWG outbounds; `CheckXrayConfig` accepts a valid AWG outbound and rejects broken ones.
- Full suite plus `go vet ./...` clean on a separate machine (Go 1.27 toolchain per go.mod).

Frontend (`npm run typecheck`, `npm run lint`, `npm run test`, `npm run build` all green — 127 files / 1215 tests):
- New `src/test/amneziawg-outbound-adapter.test.ts`: wire → form → wire round-trip losslessness, default hydration, optional-field omission.

Manual flow exercised: add an `amneziawg` outbound via Outbound form → save template → generated config shows the socks bridge with the same tag pointing at 127.0.0.1:64900 → reconcile job brings up the client device (visible at AMNEZIAWGNET_DEBUG=1) → routing rules targeting the outbound's tag carry traffic through the tunnel.

## Screenshots / recordings

N/A (form follows the existing Wireguard/AWG field layout; no new page).

## Breaking changes

None. Templates without an `amneziawg` outbound are unaffected (the transform is a verified no-op there); existing inbound AWG behavior and stored settings are untouched.

## Checklist

- [x] I tested the change locally and confirmed the described behavior.
- [x] I added or updated tests for the new behavior (when applicable).
- [x] `go build ./...` and the test suite pass locally.
- [x] For frontend changes: `npm run lint`, `npm run typecheck`, and `npm run build` pass.
- [ ] I updated the Wiki / README / API docs if user-facing behavior changed.
- [x] My commits follow the project's existing message style.
- [x] I have no unrelated changes in the PR.