### PR TITLE
fix: preserve per-inbound WireGuard peer addresses

### DIFF
--- a/internal/web/service/xray.go
+++ b/internal/web/service/xray.go
@@ -179,6 +179,16 @@ func (s *XrayService) GetXrayConfig() (*xray.Config, error) {
 		}
 		settings := map[string]any{}
 		_ = json.Unmarshal([]byte(inbound.Settings), &settings)
+		var wireguardClientsByEmail map[string]model.Client
+		if inbound.Protocol == model.WireGuard {
+			inboundClients, _ := ParseInboundSettingsClients(inbound.Settings)
+			if len(inboundClients) > 0 {
+				wireguardClientsByEmail = make(map[string]model.Client, len(inboundClients))
+				for _, client := range inboundClients {
+					wireguardClientsByEmail[strings.ToLower(strings.TrimSpace(client.Email))] = client
+				}
+			}
+		}
 
 		dbClients, listErr := s.inboundService.clientService.ListForInbound(nil, inbound.Id)
 		if listErr != nil {
@@ -244,6 +254,10 @@ func (s *XrayService) GetXrayConfig() (*xray.Config, error) {
 					entry["auth"] = c.Auth
 				}
 			case model.WireGuard:
+				if inboundClient, ok := wireguardClientsByEmail[strings.ToLower(strings.TrimSpace(c.Email))]; ok {
+					c.AllowedIPs = inboundClient.AllowedIPs
+					c.PreSharedKey = inboundClient.PreSharedKey
+				}
 				wgPeers = append(wgPeers, model.WireguardPeerFromClient(c))
 				continue
 			}

--- a/internal/web/service/xray_wireguard_config_test.go
+++ b/internal/web/service/xray_wireguard_config_test.go
@@ -55,6 +55,59 @@ func seedWGInbound(t *testing.T, tag string, port int, clients []model.Client) {
 	}
 }
 
+func seedDualTunnelClient(t *testing.T, enabled bool) string {
+	t.Helper()
+	setupSettingTestDB(t)
+	db := database.GetDB()
+
+	const email = "dual@wg.test"
+	wgClient := model.Client{
+		Email:        email,
+		Enable:       true,
+		PublicKey:    "pub-dual",
+		AllowedIPs:   []string{"10.0.0.5/32"},
+		PreSharedKey: "wg-psk",
+	}
+	awgClient := wgClient
+	awgClient.AllowedIPs = []string{"10.8.1.5/32"}
+	awgClient.PreSharedKey = "awg-psk"
+
+	wgSettings, err := json.Marshal(map[string]any{
+		"secretKey": wgTestSecretKey(),
+		"mtu":       1420,
+		"clients":   []model.Client{wgClient},
+	})
+	if err != nil {
+		t.Fatalf("marshal wg settings: %v", err)
+	}
+	awgSettings, err := json.Marshal(map[string]any{
+		"server":  map[string]any{"subnetIp": "10.8.1.0", "subnetCidr": 24},
+		"clients": []model.Client{awgClient},
+	})
+	if err != nil {
+		t.Fatalf("marshal awg settings: %v", err)
+	}
+
+	wgInbound := &model.Inbound{Tag: "wg-dual", Enable: true, Port: 51823, Protocol: model.WireGuard, Settings: string(wgSettings)}
+	awgInbound := &model.Inbound{Tag: "awg-dual", Enable: true, Port: 51824, Protocol: model.AmneziaWG, Settings: string(awgSettings)}
+	if err := db.Create(wgInbound).Error; err != nil {
+		t.Fatalf("create wg inbound: %v", err)
+	}
+	if err := db.Create(awgInbound).Error; err != nil {
+		t.Fatalf("create awg inbound: %v", err)
+	}
+
+	svc := ClientService{}
+	if err := svc.SyncInbound(nil, wgInbound.Id, []model.Client{wgClient}); err != nil {
+		t.Fatalf("SyncInbound(wg): %v", err)
+	}
+	awgClient.Enable = enabled
+	if err := svc.SyncInbound(nil, awgInbound.Id, []model.Client{awgClient}); err != nil {
+		t.Fatalf("SyncInbound(awg): %v", err)
+	}
+	return email
+}
+
 func wgPeerList(t *testing.T, settings map[string]any) []map[string]any {
 	t.Helper()
 	if _, ok := settings["clients"]; ok {
@@ -134,6 +187,39 @@ func TestGetXrayConfigWireGuardDisabledClientExcluded(t *testing.T) {
 	}
 	if peers[0]["email"] != "on@wg.test" {
 		t.Errorf("wrong peer kept: %v", peers[0])
+	}
+}
+
+func TestGetXrayConfigWireGuardUsesInboundLocalTunnelFields(t *testing.T) {
+	email := seedDualTunnelClient(t, true)
+
+	var shared model.ClientRecord
+	if err := database.GetDB().Where("email = ?", email).First(&shared).Error; err != nil {
+		t.Fatalf("read shared client: %v", err)
+	}
+	if shared.AllowedIPs != "10.8.1.5/32" || shared.PreSharedKey != "awg-psk" {
+		t.Fatalf("test setup did not persist AmneziaWG last: allowedIPs=%q preSharedKey=%q", shared.AllowedIPs, shared.PreSharedKey)
+	}
+
+	peers := wgPeerList(t, wgInboundEmittedSettings(t, "wg-dual"))
+	if len(peers) != 1 {
+		t.Fatalf("expected 1 peer, got %d: %v", len(peers), peers)
+	}
+	allowed, ok := peers[0]["allowedIPs"].([]any)
+	if !ok || len(allowed) != 1 || allowed[0] != "10.0.0.5/32" {
+		t.Fatalf("WireGuard peer allowedIPs = %v, want [10.0.0.5/32]", peers[0]["allowedIPs"])
+	}
+	if peers[0]["preSharedKey"] != "wg-psk" {
+		t.Fatalf("WireGuard peer preSharedKey = %v, want wg-psk", peers[0]["preSharedKey"])
+	}
+}
+
+func TestGetXrayConfigWireGuardDisabledDualProtocolClientExcluded(t *testing.T) {
+	seedDualTunnelClient(t, false)
+
+	peers := wgPeerList(t, wgInboundEmittedSettings(t, "wg-dual"))
+	if len(peers) != 0 {
+		t.Fatalf("expected disabled dual-protocol client to be excluded, got %v", peers)
 	}
 }
 


### PR DESCRIPTION
## Summary

WireGuard peers were built from the shared per-email client record, so a client present on both a WireGuard and an AmneziaWG inbound got one tunnel's `allowedIPs` and `preSharedKey` on both. This reads the per-inbound client settings and uses the inbound's own entry when one exists for that email.

## Why

Closes #6328

Clients are stored once per email in the client table. `GetXrayConfig` built each WireGuard peer from that shared record, so the per-inbound values were lost whenever the same email appeared on two WireGuard-family inbounds. The second tunnel's peer was then emitted with the first tunnel's address, which breaks routing for that client.

The inbound already carries its own client settings; they were simply not consulted on the WireGuard path.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactoring (no behavior change)
- [ ] Documentation
- [ ] Tests only
- [ ] Build / CI / tooling
- [ ] Other

## Areas affected

- [ ] Frontend (UI / panel pages)
- [ ] Backend (API endpoints, login, settings)
- [x] Xray config generation
- [ ] Subscription (share links / Clash / JSON)
- [ ] Statistics / traffic counters
- [ ] Database / migrations
- [ ] Install / upgrade script
- [ ] Docker image
- [ ] Multi-node (sub-nodes)
- [ ] Telegram bot

## How was this tested?

Added `TestGetXrayConfigWireGuardUsesInboundLocalTunnelFields`, which seeds one email on both a WG inbound (`10.0.0.5/32`, `wg-psk`) and an AWG inbound (`10.8.1.5/32`, `awg-psk`) and asserts each inbound's peer keeps its own address and pre-shared key.

```
$ go build ./...
$ go test ./internal/web/service/... -run 'WireGuard|Wireguard|WG'
ok  	github.com/mhsanaei/3x-ui/v3/internal/web/service	2.430s
ok  	github.com/mhsanaei/3x-ui/v3/internal/web/service/integration	2.198s
```

The test pins the bug rather than merely covering the path. Reverting only `internal/web/service/xray.go` and keeping the test:

```
--- FAIL: TestGetXrayConfigWireGuardUsesInboundLocalTunnelFields
    xray_wireguard_config_test.go:210: WireGuard peer allowedIPs = [10.8.1.5/32], want [10.0.0.5/32]
```

That is the reported symptom exactly: the AWG tunnel's address on the WG peer.

Not tested: no run against a live Xray instance with two active tunnels. The assertion is on generated config, not on observed traffic.

## Screenshots / recordings

N/A. Backend config generation, no UI change.

## Breaking changes

None. Behaviour only changes where an inbound carries its own client entry for that email; when it does not, the existing shared-record values are used exactly as before.

## Checklist

- [x] I tested the change locally and confirmed the described behavior.
- [x] I added or updated tests for the new behavior (when applicable).
- [x] `go build ./...` and the test suite pass locally.
- [ ] For frontend changes: `npm run lint`, `npm run typecheck`, and `npm run build` pass.
- [ ] I updated the Wiki / README / API docs if user-facing behavior changed.
- [x] My commits follow the project's existing message style.
- [x] I have no unrelated changes mixed into this PR.

Frontend checks are unchecked because there are no frontend changes. Docs are unchecked because the corrected behaviour is what the panel already documents; nothing user-facing changed.

## AI assistance disclosure

- Type of assistance: drafting the code change, the test, and this description.
- Scope: `internal/web/service/xray.go` and `internal/web/service/xray_wireguard_config_test.go` only.
- Tools: OpenAI Codex for the implementation, Anthropic Claude for review and this write-up.
- Level of modification: the build, the test run, and the revert-the-fix check quoted above were run locally and their real output is reproduced here.

AI was used for assistance.
