### PR TITLE
docs: improve Quick Start section

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,25 +68,39 @@ Built as an enhanced fork of the original X-UI project, 3X-UI adds broader proto
 
 ## Quick Start
 
-```bash
-bash <(curl -Ls https://raw.githubusercontent.com/mhsanaei/3x-ui/master/install.sh)
-```
-
-To install a specific version, append its tag (e.g. `v3.4.0`):
+### One-line installation (recommended)
 
 ```bash
-bash <(curl -Ls https://raw.githubusercontent.com/mhsanaei/3x-ui/master/install.sh) v3.4.0
+curl -Ls https://raw.githubusercontent.com/mhsanaei/3x-ui/master/install.sh | sudo bash
 ```
 
-To install the rolling **dev** build (latest per-commit pre-release from `main`, not a stable release), pass `dev-latest`:
+Alternative method
+```bash
+<(curl -Ls https://raw.githubusercontent.com/mhsanaei/3x-ui/master/install.sh)
+```
+
+Install a specific version
 
 ```bash
-bash <(curl -Ls https://raw.githubusercontent.com/mhsanaei/3x-ui/master/install.sh) dev-latest
+<(curl -Ls https://raw.githubusercontent.com/mhsanaei/3x-ui/master/install.sh) v3.4.0
 ```
 
-During installation a random username, password, and access path are generated. After installation, run `x-ui` to open the management menu, where you can start/stop the service, view or reset your login credentials, manage SSL certificates, and more.
+Install the latest development build
+```bash
+<(curl -Ls https://raw.githubusercontent.com/mhsanaei/3x-ui/master/install.sh) dev-latest
+```
 
-For full documentation, please visit the [project Wiki](https://github.com/MHSanaei/3x-ui/wiki).
+After installation:
+
+Run the command x-ui
+The management menu will open
+From there you can view/reset credentials, change port, path, manage SSL certificates, and more
+
+Important: A random username, password, and access path are generated during installation.
+
+Make sure to save them immediately.
+Full documentation is available in the project Wiki.
+
 
 ### Unattended install
 


### PR DESCRIPTION
## Description

Improved the Quick Start section in the README to make it clearer and more user-friendly.

### Changes:
- Moved the recommended installation method (`curl ... | sudo bash`) to the top
- Improved structure and readability
- Added clearer steps after installation
- Added a note about saving the generated credentials
- Minor formatting improvements

### Why
The previous version had two installation methods without clearly indicating which one is preferred.  
Also, new users often forget to save the randomly generated credentials.

This change should reduce confusion for first-time users.