### PR TITLE
feat(ui): add global command palette (Ctrl+K) for fast navigation and search

### DIFF
--- a/frontend/src/components/command-palette/CommandPalette.css
+++ b/frontend/src/components/command-palette/CommandPalette.css
@@ -1,0 +1,573 @@
+/* ==========================================================================
+   Command Palette Backdrop & Modal
+   ========================================================================== */
+
+.command-palette-backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 2000;
+  display: flex;
+  align-items: flex-start;
+  justify-content: center;
+  padding-top: 12vh;
+  background: rgba(0, 0, 0, 0.45);
+  backdrop-filter: blur(8px);
+  -webkit-backdrop-filter: blur(8px);
+  animation: cp-fade-in 0.15s ease-out;
+}
+
+.command-palette-backdrop.light {
+  background: rgba(0, 0, 0, 0.25);
+}
+
+.command-palette-backdrop.ultra {
+  background: rgba(0, 0, 0, 0.75);
+}
+
+@keyframes cp-fade-in {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+
+.command-palette-modal {
+  position: relative;
+  width: 680px;
+  max-width: 92vw;
+  max-height: 72vh;
+  display: flex;
+  flex-direction: column;
+  border-radius: 14px;
+  overflow: hidden;
+  animation: cp-scale-in 0.18s cubic-bezier(0.16, 1, 0.3, 1);
+  transition:
+    background 0.2s ease,
+    border-color 0.2s ease,
+    color 0.2s ease,
+    box-shadow 0.2s ease;
+}
+
+@keyframes cp-scale-in {
+  from {
+    opacity: 0;
+    transform: scale(0.96) translateY(-10px);
+  }
+  to {
+    opacity: 1;
+    transform: scale(1) translateY(0);
+  }
+}
+
+/* --------------------------------------------------------------------------
+   Theme-Specific Container Styles
+   -------------------------------------------------------------------------- */
+
+/* Light Theme */
+.command-palette-modal.light,
+body.light .command-palette-modal {
+  background: rgba(255, 255, 255, 0.96);
+  color: #1f1f1f;
+  border: 1px solid rgba(0, 0, 0, 0.12);
+  box-shadow:
+    0 20px 50px rgba(0, 0, 0, 0.16),
+    0 2px 8px rgba(0, 0, 0, 0.08);
+}
+
+/* Dark Theme */
+.command-palette-modal.dark,
+body.dark .command-palette-modal {
+  background: rgba(35, 37, 43, 0.95);
+  color: #ffffff;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  box-shadow:
+    0 25px 60px rgba(0, 0, 0, 0.65),
+    0 4px 16px rgba(0, 0, 0, 0.4);
+}
+
+/* Ultra Dark Theme */
+.command-palette-modal.ultra,
+html[data-theme='ultra-dark'] .command-palette-modal {
+  background: rgba(16, 16, 19, 0.98);
+  color: #ffffff;
+  border: 1px solid rgba(255, 255, 255, 0.18);
+  box-shadow: 0 30px 70px rgba(0, 0, 0, 0.9);
+}
+
+/* --------------------------------------------------------------------------
+   Header & Search Input
+   -------------------------------------------------------------------------- */
+
+.command-palette-header {
+  display: flex;
+  align-items: center;
+  padding: 16px 20px;
+  gap: 14px;
+  border-bottom: 1px solid;
+}
+
+.command-palette-modal.light .command-palette-header {
+  border-bottom-color: rgba(0, 0, 0, 0.08);
+}
+
+.command-palette-modal.dark .command-palette-header {
+  border-bottom-color: rgba(255, 255, 255, 0.08);
+}
+
+.command-palette-modal.ultra .command-palette-header {
+  border-bottom-color: rgba(255, 255, 255, 0.12);
+}
+
+.command-palette-search-icon {
+  font-size: 24px;
+  width: 28px;
+  height: 28px;
+  color: #1677ff;
+  flex-shrink: 0;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  transition: transform 0.2s ease;
+}
+
+.command-palette-search-icon.spinning {
+  color: #1677ff;
+  animation: cp-spin 0.8s linear infinite;
+}
+
+@keyframes cp-spin {
+  100% {
+    transform: rotate(360deg);
+  }
+}
+
+.command-palette-input {
+  flex: 1;
+  background: transparent;
+  border: none;
+  outline: none;
+  font-size: 16.5px;
+  font-weight: 400;
+  font-family: inherit;
+  letter-spacing: -0.2px;
+}
+
+.command-palette-modal.light .command-palette-input {
+  color: #1f1f1f;
+}
+
+.command-palette-modal.light .command-palette-input::placeholder {
+  color: #8c8c8c;
+}
+
+.command-palette-modal.dark .command-palette-input,
+.command-palette-modal.ultra .command-palette-input {
+  color: #ffffff;
+}
+
+.command-palette-modal.dark .command-palette-input::placeholder,
+.command-palette-modal.ultra .command-palette-input::placeholder {
+  color: #737373;
+}
+
+/* --------------------------------------------------------------------------
+   Body & Scrollbar
+   -------------------------------------------------------------------------- */
+
+.command-palette-body {
+  flex: 1;
+  overflow-y: auto;
+  padding: 10px;
+  max-height: calc(72vh - 116px);
+  scrollbar-width: thin;
+}
+
+/* Scrollbar Harmonization */
+.command-palette-modal.light .command-palette-body {
+  scrollbar-color: rgba(0, 0, 0, 0.2) transparent;
+}
+
+.command-palette-modal.dark .command-palette-body,
+.command-palette-modal.ultra .command-palette-body {
+  scrollbar-color: rgba(255, 255, 255, 0.2) transparent;
+}
+
+.command-palette-body::-webkit-scrollbar {
+  width: 6px;
+}
+
+.command-palette-body::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+.command-palette-modal.light .command-palette-body::-webkit-scrollbar-thumb {
+  background: rgba(0, 0, 0, 0.2);
+  border-radius: 3px;
+}
+
+.command-palette-modal.light .command-palette-body::-webkit-scrollbar-thumb:hover {
+  background: rgba(0, 0, 0, 0.35);
+}
+
+.command-palette-modal.dark .command-palette-body::-webkit-scrollbar-thumb,
+.command-palette-modal.ultra .command-palette-body::-webkit-scrollbar-thumb {
+  background: rgba(255, 255, 255, 0.2);
+  border-radius: 3px;
+}
+
+.command-palette-modal.dark .command-palette-body::-webkit-scrollbar-thumb:hover,
+.command-palette-modal.ultra .command-palette-body::-webkit-scrollbar-thumb:hover {
+  background: rgba(255, 255, 255, 0.35);
+}
+
+/* --------------------------------------------------------------------------
+   Groups & Items
+   -------------------------------------------------------------------------- */
+
+.command-palette-group {
+  margin-bottom: 8px;
+}
+
+.command-palette-group-title {
+  padding: 6px 12px 4px;
+  font-size: 11px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.6px;
+}
+
+.command-palette-modal.light .command-palette-group-title {
+  color: #8c8c8c;
+}
+
+.command-palette-modal.dark .command-palette-group-title,
+.command-palette-modal.ultra .command-palette-group-title {
+  color: #8c8c8c;
+}
+
+.command-palette-item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  width: 100%;
+  padding: 9px 14px;
+  background: transparent;
+  border: none;
+  border-radius: 9px;
+  cursor: pointer;
+  text-align: start;
+  font-family: inherit;
+  color: inherit;
+  transition:
+    background 0.12s ease,
+    color 0.12s ease;
+  user-select: none;
+}
+
+/* Item Active & Hover States */
+.command-palette-modal.light .command-palette-item.active {
+  background: #e6f4ff;
+  color: #0958d9;
+}
+
+.command-palette-modal.dark .command-palette-item.active {
+  background: rgba(22, 119, 255, 0.2);
+  color: #4096ff;
+}
+
+.command-palette-modal.ultra .command-palette-item.active {
+  background: rgba(22, 119, 255, 0.28);
+  color: #69b1ff;
+}
+
+.command-palette-item-main {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  min-width: 0;
+  flex: 1;
+}
+
+.command-palette-item-icon {
+  font-size: 20px;
+  width: 26px;
+  height: 26px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+}
+
+.command-palette-item-content {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+  overflow: hidden;
+}
+
+.command-palette-item-title {
+  font-size: 14px;
+  font-weight: 500;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.command-palette-item-subtitle {
+  font-size: 12px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.command-palette-modal.light .command-palette-item-subtitle {
+  color: #8c8c8c;
+}
+
+.command-palette-modal.dark .command-palette-item-subtitle,
+.command-palette-modal.ultra .command-palette-item-subtitle {
+  color: #8c8c8c;
+}
+
+.command-palette-item-actions {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-inline-start: 12px;
+  flex-shrink: 0;
+}
+
+/* Secondary Action Button (e.g. Copy Subscription) */
+.command-palette-action-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  padding: 0;
+  border: none;
+  border-radius: 6px;
+  background: transparent;
+  cursor: pointer;
+  font-size: 15px;
+  transition: all 0.15s ease;
+}
+
+.command-palette-modal.light .command-palette-action-btn {
+  color: rgba(0, 0, 0, 0.4);
+}
+
+.command-palette-modal.light .command-palette-action-btn:hover {
+  color: #0958d9;
+  background: rgba(0, 0, 0, 0.06);
+}
+
+.command-palette-modal.dark .command-palette-action-btn {
+  color: rgba(255, 255, 255, 0.45);
+}
+
+.command-palette-modal.dark .command-palette-action-btn:hover {
+  color: #4096ff;
+  background: rgba(255, 255, 255, 0.1);
+}
+
+.command-palette-modal.ultra .command-palette-action-btn {
+  color: rgba(255, 255, 255, 0.5);
+}
+
+.command-palette-modal.ultra .command-palette-action-btn:hover {
+  color: #69b1ff;
+  background: rgba(255, 255, 255, 0.15);
+}
+
+.command-palette-item.active .command-palette-action-btn {
+  color: inherit;
+  opacity: 0.8;
+}
+
+.command-palette-item.active .command-palette-action-btn:hover {
+  opacity: 1;
+}
+
+.command-palette-tooltip {
+  z-index: 2500 !important;
+}
+
+.command-palette-empty {
+  padding: 36px 16px;
+  text-align: center;
+  font-size: 14px;
+}
+
+.command-palette-modal.light .command-palette-empty {
+  color: #8c8c8c;
+}
+
+.command-palette-modal.dark .command-palette-empty,
+.command-palette-modal.ultra .command-palette-empty {
+  color: #8c8c8c;
+}
+
+/* --------------------------------------------------------------------------
+   Footer & Keyboard Badges
+   -------------------------------------------------------------------------- */
+
+.command-palette-footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 10px 18px;
+  font-size: 11.5px;
+  border-top: 1px solid;
+}
+
+.command-palette-modal.light .command-palette-footer {
+  background: #fafafa;
+  border-top-color: rgba(0, 0, 0, 0.08);
+  color: #8c8c8c;
+}
+
+.command-palette-modal.dark .command-palette-footer {
+  background: rgba(21, 22, 26, 0.95);
+  border-top-color: rgba(255, 255, 255, 0.08);
+  color: #8c8c8c;
+}
+
+.command-palette-modal.ultra .command-palette-footer {
+  background: #050507;
+  border-top-color: rgba(255, 255, 255, 0.12);
+  color: #8c8c8c;
+}
+
+.command-palette-kbd-group {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+}
+
+.command-palette-kbd {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 22px;
+  height: 22px;
+  padding: 0 5px;
+  font-family: inherit;
+  font-size: 11.5px;
+  font-weight: 600;
+  line-height: 1;
+  border-radius: 4px;
+  margin-inline-end: 4px;
+}
+
+.command-palette-modal.light .command-palette-kbd {
+  background: #ffffff;
+  border: 1px solid #d9d9d9;
+  color: #595959;
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.06);
+}
+
+.command-palette-modal.dark .command-palette-kbd {
+  background: rgba(255, 255, 255, 0.1);
+  border: 1px solid rgba(255, 255, 255, 0.15);
+  color: #d9d9d9;
+}
+
+.command-palette-modal.ultra .command-palette-kbd {
+  background: rgba(255, 255, 255, 0.15);
+  border: 1px solid rgba(255, 255, 255, 0.25);
+  color: #ffffff;
+}
+
+/* --------------------------------------------------------------------------
+   Sidebar Trigger Button
+   -------------------------------------------------------------------------- */
+
+.sidebar-command-trigger {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  width: calc(100% - 16px);
+  margin: 8px 8px 4px;
+  padding: 7px 12px;
+  border-radius: 7px;
+  font-size: 13px;
+  cursor: pointer;
+  transition: all 0.15s ease;
+}
+
+body.light .sidebar-command-trigger {
+  background: rgba(0, 0, 0, 0.04);
+  border: 1px solid rgba(0, 0, 0, 0.08);
+  color: #595959;
+}
+
+body.light .sidebar-command-trigger:hover {
+  background: rgba(0, 0, 0, 0.08);
+  border-color: rgba(0, 0, 0, 0.15);
+  color: #1f1f1f;
+}
+
+body.dark .sidebar-command-trigger {
+  background: rgba(255, 255, 255, 0.05);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  color: #8c8c8c;
+}
+
+body.dark .sidebar-command-trigger:hover {
+  background: rgba(255, 255, 255, 0.09);
+  border-color: rgba(255, 255, 255, 0.18);
+  color: #ffffff;
+}
+
+.sidebar-command-trigger .sidebar-command-icon {
+  font-size: 15px;
+}
+
+.sidebar-command-trigger .sidebar-command-kbd {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 2.5px;
+  height: 20px;
+  padding: 0 5px;
+  border-radius: 4px;
+  user-select: none;
+}
+
+.sidebar-command-trigger .sidebar-command-kbd .kbd-cmd {
+  font-family:
+    -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
+  font-size: 10px;
+  line-height: 1;
+  display: inline-block;
+  opacity: 0.9;
+}
+
+.sidebar-command-trigger .sidebar-command-kbd .kbd-key {
+  font-family:
+    -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
+  font-size: 11px;
+  font-weight: 700;
+  line-height: 1;
+  display: inline-block;
+}
+
+body.light .sidebar-command-trigger .sidebar-command-kbd {
+  background: rgba(0, 0, 0, 0.06);
+  border: 1px solid rgba(0, 0, 0, 0.12);
+  color: #595959;
+}
+
+body.dark .sidebar-command-trigger .sidebar-command-kbd {
+  background: rgba(255, 255, 255, 0.1);
+  border: 1px solid rgba(255, 255, 255, 0.15);
+  color: #d9d9d9;
+}
+
+body.dark .sidebar-command-trigger:hover .sidebar-command-kbd {
+  border-color: rgba(255, 255, 255, 0.25);
+  color: #ffffff;
+}

--- a/frontend/src/components/command-palette/CommandPalette.tsx
+++ b/frontend/src/components/command-palette/CommandPalette.tsx
@@ -1,0 +1,847 @@
+import { useCallback, useDeferredValue, useEffect, useMemo, useRef, useState } from 'react';
+import type { ReactNode } from 'react';
+import { useNavigate } from 'react-router';
+import { useTranslation } from 'react-i18next';
+import { Tag, Tooltip, message } from 'antd';
+import {
+  ApiOutlined,
+  ApartmentOutlined,
+  CheckCircleFilled,
+  ClockCircleOutlined,
+  CloseCircleFilled,
+  CloudServerOutlined,
+  ClusterOutlined,
+  CodeOutlined,
+  CopyOutlined,
+  DashboardOutlined,
+  DatabaseOutlined,
+  ExportOutlined,
+  FileTextOutlined,
+  GlobalOutlined,
+  ImportOutlined,
+  LoadingOutlined,
+  MailOutlined,
+  MessageOutlined,
+  MoonOutlined,
+  PlusOutlined,
+  ReloadOutlined,
+  SafetyOutlined,
+  SearchOutlined,
+  SettingOutlined,
+  SunOutlined,
+  SwapOutlined,
+  TagsOutlined,
+  TeamOutlined,
+  ToolOutlined,
+} from '@ant-design/icons';
+
+import { ClipboardManager, HttpUtil, SizeFormatter } from '@/utils';
+import { useInboundOptions } from '@/api/queries/useInboundOptions';
+import { useAllSettings } from '@/api/queries/useAllSettings';
+import { useTheme } from '@/hooks/useTheme';
+import type { ClientRecord, InboundOption } from '@/schemas/client';
+import { useCommandPalette } from './useCommandPalette';
+import './CommandPalette.css';
+
+interface PaletteItem {
+  id: string;
+  category: 'clients' | 'inbounds' | 'navigation' | 'settings' | 'actions';
+  title: string;
+  subtitle?: string;
+  keywords?: string[];
+  icon: ReactNode;
+  tag?: ReactNode;
+  action: () => void | Promise<void>;
+  secondaryAction?: {
+    label: string;
+    icon: ReactNode;
+    execute: (e: React.MouseEvent) => void;
+  };
+}
+
+export default function CommandPalette() {
+  const { t } = useTranslation();
+  const navigate = useNavigate();
+  const { isDark, isUltra, toggleTheme, toggleUltra } = useTheme();
+  const { isOpen, close } = useCommandPalette();
+  const { allSetting } = useAllSettings();
+  const { data: inbounds = [] } = useInboundOptions();
+
+  const [query, setQuery] = useState('');
+  const debouncedQuery = useDeferredValue(query.trim());
+  const [clients, setClients] = useState<ClientRecord[]>([]);
+  const [loadingClients, setLoadingClients] = useState(false);
+  const [activeIndex, setActiveIndex] = useState(0);
+
+  const inputRef = useRef<HTMLInputElement>(null);
+  const listRef = useRef<HTMLDivElement>(null);
+
+  // Focus input when opened
+  useEffect(() => {
+    if (isOpen) {
+      setTimeout(() => inputRef.current?.focus(), 50);
+    }
+  }, [isOpen]);
+
+  // Query matching clients from API when searching
+  useEffect(() => {
+    if (!isOpen || debouncedQuery.length < 1) {
+      return;
+    }
+
+    let isCurrent = true;
+
+    HttpUtil.get(
+      `/panel/api/clients/list/paged?search=${encodeURIComponent(debouncedQuery)}&pageSize=8`,
+      undefined,
+      { silent: true },
+    )
+      .then((msg) => {
+        if (!isCurrent) return;
+        if (
+          msg?.success &&
+          msg?.obj &&
+          Array.isArray((msg.obj as { items?: ClientRecord[] }).items)
+        ) {
+          setClients((msg.obj as { items: ClientRecord[] }).items);
+        } else {
+          setClients([]);
+        }
+      })
+      .catch(() => {
+        if (isCurrent) setClients([]);
+      })
+      .finally(() => {
+        if (isCurrent) setLoadingClients(false);
+      });
+
+    return () => {
+      isCurrent = false;
+    };
+  }, [isOpen, debouncedQuery]);
+
+  const copySubscription = useCallback(
+    async (client: ClientRecord) => {
+      if (!client.subId || !allSetting.subURI) {
+        message.warning(t('pages.clients.noSubId'));
+        return;
+      }
+      const link = `${allSetting.subURI}${client.subId}`;
+      const ok = await ClipboardManager.copyText(link);
+      if (ok) message.success(t('copied'));
+    },
+    [allSetting.subURI, t],
+  );
+
+  const restartXray = useCallback(async () => {
+    close();
+    const msg = await HttpUtil.post('/panel/api/server/restartXrayService');
+    if (msg?.success) {
+      message.success(t('pages.index.toasts.restartedXray') || 'Xray restarted');
+    }
+  }, [close, t]);
+
+  const cycleTheme = useCallback(() => {
+    if (!isDark) {
+      toggleTheme();
+      if (isUltra) toggleUltra();
+    } else if (!isUltra) {
+      toggleUltra();
+    } else {
+      toggleUltra();
+      toggleTheme();
+    }
+    close();
+  }, [isDark, isUltra, toggleTheme, toggleUltra, close]);
+
+  const isClientSearching = isOpen && debouncedQuery.length >= 1 && loadingClients;
+
+  // Build items grouped by category
+  const items = useMemo<PaletteItem[]>(() => {
+    const list: PaletteItem[] = [];
+    const q = debouncedQuery.toLowerCase();
+
+    const matches = (title: string, subtitle?: string, keywords: string[] = []) => {
+      if (!q) return true;
+      if (title.toLowerCase().includes(q)) return true;
+      if (subtitle && subtitle.toLowerCase().includes(q)) return true;
+      return keywords.some((k) => k.toLowerCase().includes(q));
+    };
+
+    // 1. Clients
+    if (debouncedQuery.length > 0 && clients.length > 0) {
+      clients.forEach((c) => {
+        const up = Number(c.traffic?.up || 0);
+        const down = Number(c.traffic?.down || 0);
+        const total = Number(c.traffic?.total || (c.totalGB ? c.totalGB * 1024 * 1024 * 1024 : 0));
+        const trafficUsed = SizeFormatter.sizeFormat(up + down);
+        const trafficTotal = total > 0 ? SizeFormatter.sizeFormat(total) : '∞';
+        const isOnline = c.enable !== false;
+
+        list.push({
+          id: `client-${c.id ?? c.email}`,
+          category: 'clients',
+          title: c.email,
+          subtitle: `${trafficUsed} / ${trafficTotal}${c.comment ? ` · ${c.comment}` : ''}`,
+          icon: isOnline ? (
+            <CheckCircleFilled style={{ color: '#52c41a' }} />
+          ) : (
+            <CloseCircleFilled style={{ color: '#ff4d4f' }} />
+          ),
+          action: () => {
+            close();
+            navigate(`/clients?search=${encodeURIComponent(c.email)}`);
+          },
+          secondaryAction:
+            c.subId && allSetting.subURI
+              ? {
+                  label: t('commandPalette.copySubscription') || 'Copy subscription',
+                  icon: <CopyOutlined />,
+                  execute: (e) => {
+                    e.stopPropagation();
+                    copySubscription(c);
+                  },
+                }
+              : undefined,
+        });
+      });
+    }
+
+    // 2. Inbounds
+    const matchedInbounds = inbounds.filter((ib: InboundOption) => {
+      if (!q) return false;
+      return (
+        (ib.tag && ib.tag.toLowerCase().includes(q)) ||
+        (ib.remark && ib.remark.toLowerCase().includes(q)) ||
+        (ib.protocol && ib.protocol.toLowerCase().includes(q)) ||
+        (ib.port && String(ib.port).includes(q))
+      );
+    });
+
+    matchedInbounds.slice(0, 8).forEach((ib) => {
+      list.push({
+        id: `inbound-${ib.id}`,
+        category: 'inbounds',
+        title: ib.remark || ib.tag || `Inbound #${ib.id}`,
+        subtitle: `Port ${ib.port || ''} · ${ib.protocol || ''}`,
+        icon: <ImportOutlined style={{ color: '#1677ff' }} />,
+        tag: ib.protocol ? <Tag color="blue">{ib.protocol.toUpperCase()}</Tag> : undefined,
+        action: () => {
+          close();
+          navigate(
+            `/inbounds?search=${encodeURIComponent(ib.tag || ib.remark || String(ib.port || ''))}`,
+          );
+        },
+      });
+    });
+
+    // 3. Navigation Pages
+    const pages = [
+      {
+        path: '/',
+        title: t('menu.dashboard'),
+        subtitle: 'Overview & system telemetry',
+        keywords: [
+          'overview',
+          'dashboard',
+          'داشبورد',
+          'نمای کلی',
+          'cpu',
+          'ram',
+          'memory',
+          'traffic',
+          'speed',
+        ],
+        icon: <DashboardOutlined />,
+      },
+      {
+        path: '/inbounds',
+        title: t('menu.inbounds'),
+        subtitle: 'Manage protocols & ports',
+        keywords: [
+          'inbounds',
+          'ورودی',
+          'پورت',
+          'اینباند',
+          'vless',
+          'vmess',
+          'reality',
+          'trojan',
+          'shadowsocks',
+          'wireguard',
+          'hysteria',
+        ],
+        icon: <ImportOutlined />,
+      },
+      {
+        path: '/clients',
+        title: t('menu.clients'),
+        subtitle: 'Manage client accounts & limits',
+        keywords: ['clients', 'مشتریان', 'کاربران', 'کلاینت', 'users', 'sub', 'traffic'],
+        icon: <TeamOutlined />,
+      },
+      {
+        path: '/groups',
+        title: t('menu.groups'),
+        subtitle: 'Client grouping & batch assignments',
+        keywords: ['groups', 'گروه‌ها', 'دسته بندی', 'تگ'],
+        icon: <TagsOutlined />,
+      },
+      {
+        path: '/nodes',
+        title: t('menu.nodes'),
+        subtitle: 'Multi-node cluster management',
+        keywords: ['nodes', 'نودها', 'سرورها', 'سرور', 'cluster', 'remote nodes'],
+        icon: <ClusterOutlined />,
+      },
+      {
+        path: '/hosts',
+        title: t('menu.hosts'),
+        subtitle: 'Custom SNI & domain routing hosts',
+        keywords: ['hosts', 'هاست‌ها', 'دامنه', 'sni', 'domains'],
+        icon: <GlobalOutlined />,
+      },
+      {
+        path: '/outbound',
+        title: t('menu.outbounds'),
+        subtitle: 'Exit proxies & warp gateways',
+        keywords: [
+          'outbounds',
+          'خروجی',
+          'آتباند',
+          'freedom',
+          'blackhole',
+          'socks',
+          'http',
+          'warp',
+          'nord',
+          'pia',
+        ],
+        icon: <ExportOutlined />,
+      },
+      {
+        path: '/routing',
+        title: t('menu.routing'),
+        subtitle: 'Traffic routing & rule balancer',
+        keywords: [
+          'routing',
+          'روتینگ',
+          'مسیریابی',
+          'قوانین',
+          'rules',
+          'geoip',
+          'geosite',
+          'direct',
+          'block',
+        ],
+        icon: <SwapOutlined />,
+      },
+      {
+        path: '/settings',
+        title: t('menu.settings'),
+        subtitle: 'Panel configuration & security',
+        keywords: ['settings', 'تنظیمات', 'پنل', 'port', 'password', 'ssl', 'telegram'],
+        icon: <SettingOutlined />,
+      },
+      {
+        path: '/xray',
+        title: t('menu.xray'),
+        subtitle: 'Xray core templates & balancer configs',
+        keywords: ['xray', 'کانفیگ', 'تنظیمات xray', 'template', 'balancer', 'dns'],
+        icon: <ToolOutlined />,
+      },
+      {
+        path: '/api-docs',
+        title: t('menu.apiDocs'),
+        subtitle: 'OpenAPI documentation & Swagger explorer',
+        keywords: ['api', 'api docs', 'مستندات', 'swagger', 'rest api', 'endpoints'],
+        icon: <ApiOutlined />,
+      },
+    ];
+
+    pages
+      .filter((p) => matches(p.title, p.subtitle, p.keywords))
+      .forEach((p) => {
+        list.push({
+          id: `nav-${p.path}`,
+          category: 'navigation',
+          title: p.title,
+          subtitle: p.subtitle,
+          keywords: p.keywords,
+          icon: p.icon,
+          action: () => {
+            close();
+            navigate(p.path);
+          },
+        });
+      });
+
+    // 4. Detailed Settings & Subpages
+    const settingsSubSections = [
+      // Settings Page Tabs
+      {
+        path: '/settings#general',
+        title: `${t('menu.settings')} · ${t('pages.settings.panelSettings')}`,
+        subtitle: 'Web port, base path, listen IP, SSL certificates',
+        keywords: [
+          'general',
+          'عمومی',
+          'پورت پنل',
+          'آدرس پنل',
+          'ssl',
+          'certificate',
+          'webPort',
+          'webBasePath',
+          'listenIP',
+          'گواهی',
+        ],
+        icon: <SettingOutlined />,
+      },
+      {
+        path: '/settings#security',
+        title: `${t('menu.settings')} · ${t('pages.settings.securitySettings')}`,
+        subtitle: 'Admin credentials, password, Two-Factor 2FA, session limits',
+        keywords: [
+          'security',
+          'امنیت',
+          'رمز عبور',
+          'نام کاربری',
+          'دو مرحله‌ای',
+          '2fa',
+          'two factor',
+          'password',
+          'username',
+          'login limit',
+        ],
+        icon: <SafetyOutlined />,
+      },
+      {
+        path: '/settings#telegram',
+        title: `${t('menu.settings')} · ${t('pages.settings.TGBotSettings')}`,
+        subtitle: 'Telegram bot alerts, token, chat ID, backup scheduler',
+        keywords: [
+          'telegram',
+          'تلگرام',
+          'ربات تلگرام',
+          'توکن',
+          'tgbot',
+          'bot token',
+          'chat id',
+          'notifications',
+          'هشدار',
+        ],
+        icon: <MessageOutlined />,
+      },
+      {
+        path: '/settings#email',
+        title: `${t('menu.settings')} · ${t('pages.settings.emailSettings')}`,
+        subtitle: 'SMTP mail service, server status and crash alerts',
+        keywords: ['email', 'ایمیل', 'هشدار ایمیل', 'smtp', 'mail', 'crash alerts'],
+        icon: <MailOutlined />,
+      },
+      {
+        path: '/settings#subscription',
+        title: `${t('menu.settings')} · ${t('pages.settings.subSettings')}`,
+        subtitle: 'Subscription service port, domain, reverse proxy URI',
+        keywords: [
+          'subscription',
+          'سابسکریپشن',
+          'لینک اشتراک',
+          'پورت ساب',
+          'subPort',
+          'subURI',
+          'subDomain',
+          'reverse proxy',
+        ],
+        icon: <CloudServerOutlined />,
+      },
+      {
+        path: '/settings#subscription-formats',
+        title: `${t('menu.settings')} · ${t('menu.subFormats')}`,
+        subtitle: 'Clash, Sing-box, V2Ray JSON subscription endpoints',
+        keywords: ['formats', 'فرمت ساب', 'clash', 'sing-box', 'v2ray', 'json', 'sub formats'],
+        icon: <CodeOutlined />,
+      },
+      {
+        path: '/settings#subscription-balancers',
+        title: `${t('menu.settings')} · ${t('pages.settings.subBalancers.menu')}`,
+        subtitle: 'Automated subscription node balancing',
+        keywords: ['balancers', 'لود بالانسر ساب', 'sub balancers', 'balancer nodes'],
+        icon: <ApartmentOutlined />,
+      },
+
+      // Xray Configs Sub-sections
+      {
+        path: '/xray#basic',
+        title: `${t('menu.xray')} · ${t('pages.xray.basicTemplate')}`,
+        subtitle: 'Freedom strategies, happy eyeballs, connection & log policies',
+        keywords: [
+          'xray basics',
+          'پایه',
+          'عمومی',
+          'freedom strategy',
+          'happy eyeballs',
+          'torrent',
+          'connection',
+        ],
+        icon: <ToolOutlined />,
+      },
+      {
+        path: '/xray#basic',
+        title: `${t('menu.xray')} · ${t('pages.xray.metricsListen') || 'Metrics Endpoint'}`,
+        subtitle: 'Prometheus metrics endpoint, inbound/outbound uplink & downlink stats',
+        keywords: [
+          'metrics',
+          'متریک',
+          'آمار',
+          'prometheus',
+          'statistics',
+          'listen',
+          'statsInbound',
+          'statsOutbound',
+          'metrics_out',
+        ],
+        icon: <DashboardOutlined />,
+      },
+      {
+        path: '/xray#basic',
+        title: `${t('menu.xray')} · ${t('pages.xray.connectionLimits') || 'Connection Limits'}`,
+        subtitle: 'Idle timeout (connIdle) and handshake buffer size',
+        keywords: [
+          'limits',
+          'محدودیت اتصال',
+          'بافر',
+          'idle timeout',
+          'bufferSize',
+          'connIdle',
+          'timeout',
+        ],
+        icon: <ClockCircleOutlined />,
+      },
+      {
+        path: '/xray#basic',
+        title: `${t('menu.xray')} · ${t('pages.xray.logConfigs') || 'Log Configs'}`,
+        subtitle: 'Log level (debug/info/warning/error), access log, error log, DNS log',
+        keywords: [
+          'logs',
+          'لاگ xray',
+          'سطح لاگ',
+          'access log',
+          'error log',
+          'dns log',
+          'mask address',
+          'loglevel',
+        ],
+        icon: <FileTextOutlined />,
+      },
+      {
+        path: '/xray#balancer',
+        title: `${t('menu.xray')} · ${t('pages.xray.Balancers')}`,
+        subtitle: 'Traffic load balancers, leastPing, roundRobin, fallback strategies',
+        keywords: [
+          'balancers',
+          'بالانسر',
+          'لود بالانسر',
+          'balancer',
+          'fallback',
+          'leastPing',
+          'roundRobin',
+          'strategy',
+        ],
+        icon: <ClusterOutlined />,
+      },
+      {
+        path: '/xray#dns',
+        title: `${t('menu.xray')} · DNS Configs`,
+        subtitle: 'Custom DNS upstream servers, hosts map, DoH, DoT, DoU',
+        keywords: ['dns', 'دی ان اس', 'dns servers', 'hosts', 'doh', 'dot', 'cloudflare dns'],
+        icon: <DatabaseOutlined />,
+      },
+      {
+        path: '/xray#outbound',
+        title: `${t('menu.xray')} · ${t('pages.xray.Outbounds')}`,
+        subtitle: 'Freedom direct, blackhole, shadowsocks, socks outbounds',
+        keywords: ['outbound', 'خروجی', 'آتباند', 'freedom', 'direct', 'proxy outbounds'],
+        icon: <ExportOutlined />,
+      },
+      {
+        path: '/xray#routing',
+        title: `${t('menu.xray')} · ${t('pages.xray.basicRouting') || 'Routing Rules'}`,
+        subtitle: 'Traffic routing rules, geoip/geosite domain & IP rules',
+        keywords: [
+          'routing',
+          'قوانین مسیریابی',
+          'routing rules',
+          'geoip',
+          'geosite',
+          'block',
+          'direct',
+        ],
+        icon: <SwapOutlined />,
+      },
+      {
+        path: '/xray#advanced',
+        title: `${t('menu.xray')} · ${t('pages.xray.advancedTemplate')}`,
+        subtitle: 'Raw JSON configuration template for Xray Core',
+        keywords: ['advanced', 'قالب پیشرفته', 'json template', 'advanced config', 'custom json'],
+        icon: <CodeOutlined />,
+      },
+    ];
+
+    settingsSubSections
+      .filter((s) => matches(s.title, s.subtitle, s.keywords))
+      .forEach((s) => {
+        list.push({
+          id: `setting-${s.path}-${s.title}`,
+          category: 'settings',
+          title: s.title,
+          subtitle: s.subtitle,
+          keywords: s.keywords,
+          icon: s.icon,
+          action: () => {
+            close();
+            navigate(s.path);
+          },
+        });
+      });
+
+    // 5. Quick Actions
+    const actions: PaletteItem[] = [
+      {
+        id: 'act-restart-xray',
+        category: 'actions',
+        title: t('pages.index.toasts.restartedXray') || 'Restart Xray Service',
+        subtitle: 'Hot-restart Xray Core backend',
+        keywords: ['restart', 'ری‌استارت', 'راه‌اندازی مجدد', 'xray restart', 'reboot xray'],
+        icon: <ReloadOutlined style={{ color: '#faad14' }} />,
+        action: restartXray,
+      },
+      {
+        id: 'act-cycle-theme',
+        category: 'actions',
+        title: 'Cycle Theme (Light → Dark → Ultra)',
+        subtitle: `Currently: ${isUltra ? 'Ultra Dark' : isDark ? 'Dark' : 'Light'}`,
+        keywords: ['theme', 'تم', 'تغییر تم', 'light', 'dark', 'ultra', 'روشن', 'تاریک'],
+        icon: isDark ? <SunOutlined /> : <MoonOutlined />,
+        action: cycleTheme,
+      },
+      {
+        id: 'act-toggle-theme',
+        category: 'actions',
+        title: isDark ? 'Switch to Light Theme' : 'Switch to Dark Theme',
+        subtitle: isDark ? 'Light mode (white)' : 'Dark mode',
+        keywords: ['light', 'dark', 'روشن', 'تاریک', 'تم'],
+        icon: isDark ? (
+          <SunOutlined style={{ color: '#faad14' }} />
+        ) : (
+          <MoonOutlined style={{ color: '#1677ff' }} />
+        ),
+        action: () => {
+          toggleTheme();
+          close();
+        },
+      },
+      {
+        id: 'act-add-inbound',
+        category: 'actions',
+        title: 'New Inbound',
+        subtitle: 'Create a new proxy port/protocol',
+        keywords: ['add inbound', 'اینباند جدید', 'پورت جدید', 'create inbound', 'new port'],
+        icon: <PlusOutlined style={{ color: '#52c41a' }} />,
+        action: () => {
+          close();
+          navigate('/inbounds');
+        },
+      },
+      {
+        id: 'act-add-client',
+        category: 'actions',
+        title: 'New Client',
+        subtitle: 'Create a new user account',
+        keywords: ['add client', 'کلاینت جدید', 'کاربر جدید', 'create user', 'new client'],
+        icon: <PlusOutlined style={{ color: '#52c41a' }} />,
+        action: () => {
+          close();
+          navigate('/clients');
+        },
+      },
+    ];
+
+    actions.filter((a) => matches(a.title, a.subtitle, a.keywords)).forEach((a) => list.push(a));
+
+    return list;
+  }, [
+    debouncedQuery,
+    clients,
+    inbounds,
+    isDark,
+    isUltra,
+    allSetting.subURI,
+    t,
+    close,
+    navigate,
+    copySubscription,
+    restartXray,
+    cycleTheme,
+    toggleTheme,
+  ]);
+
+  const clampedActiveIndex = Math.min(activeIndex, Math.max(0, items.length - 1));
+
+  // Auto-scroll selected item into view
+  useEffect(() => {
+    if (!listRef.current) return;
+    const activeEl = listRef.current.querySelector(
+      `.command-palette-item[data-index="${clampedActiveIndex}"]`,
+    ) as HTMLElement | null;
+    if (activeEl) {
+      activeEl.scrollIntoView({ block: 'nearest' });
+    }
+  }, [clampedActiveIndex]);
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'ArrowDown') {
+      e.preventDefault();
+      setActiveIndex((prev) => (items.length ? (prev + 1) % items.length : 0));
+    } else if (e.key === 'ArrowUp') {
+      e.preventDefault();
+      setActiveIndex((prev) => (items.length ? (prev - 1 + items.length) % items.length : 0));
+    } else if (e.key === 'Enter') {
+      e.preventDefault();
+      const current = items[clampedActiveIndex];
+      if (current) current.action();
+    }
+  };
+
+  if (!isOpen) return null;
+
+  let lastCategory = '';
+  const themeModeClass = isUltra ? 'ultra' : isDark ? 'dark' : 'light';
+
+  return (
+    <div
+      className={`command-palette-backdrop ${themeModeClass}`}
+      role="presentation"
+      onClick={(e) => {
+        if (e.target === e.currentTarget) close();
+      }}
+    >
+      <div
+        className={`command-palette-modal ${themeModeClass}`}
+        role="dialog"
+        aria-modal="true"
+        aria-label={t('commandPalette.title') || 'Command Palette'}
+      >
+        <div className="command-palette-header">
+          {isClientSearching ? (
+            <LoadingOutlined className="command-palette-search-icon spinning" />
+          ) : (
+            <SearchOutlined className="command-palette-search-icon" />
+          )}
+          <input
+            ref={inputRef}
+            className="command-palette-input"
+            type="text"
+            placeholder={
+              t('commandPalette.placeholder') ||
+              'Type a command or search clients, inbounds, pages...'
+            }
+            value={query}
+            onChange={(e) => {
+              setQuery(e.target.value);
+              setLoadingClients(e.target.value.trim().length > 0);
+            }}
+            onKeyDown={handleKeyDown}
+          />
+        </div>
+
+        <div className="command-palette-body" ref={listRef}>
+          {!isClientSearching && items.length === 0 && (
+            <div className="command-palette-empty">{t('noData')}</div>
+          )}
+
+          {items.map((item, index) => {
+            const isFirstOfCategory = item.category !== lastCategory;
+            lastCategory = item.category;
+
+            const categoryLabel =
+              item.category === 'clients'
+                ? t('menu.clients')
+                : item.category === 'inbounds'
+                  ? t('menu.inbounds')
+                  : item.category === 'navigation'
+                    ? t('commandPalette.navigation') || 'Navigation'
+                    : item.category === 'settings'
+                      ? t('menu.settings') || 'Settings & Sections'
+                      : t('commandPalette.actions') || 'Actions';
+
+            return (
+              <div key={item.id} className="command-palette-group">
+                {isFirstOfCategory && (
+                  <div className="command-palette-group-title">{categoryLabel}</div>
+                )}
+                <button
+                  type="button"
+                  className={`command-palette-item ${index === clampedActiveIndex ? 'active' : ''}`}
+                  data-index={index}
+                  onClick={() => item.action()}
+                  onMouseEnter={() => setActiveIndex(index)}
+                >
+                  <div className="command-palette-item-main">
+                    <span className="command-palette-item-icon">{item.icon}</span>
+                    <div className="command-palette-item-content">
+                      <span className="command-palette-item-title">{item.title}</span>
+                      {item.subtitle && (
+                        <span className="command-palette-item-subtitle">{item.subtitle}</span>
+                      )}
+                    </div>
+                  </div>
+
+                  <div className="command-palette-item-actions">
+                    {item.tag}
+                    {item.secondaryAction && (
+                      <Tooltip
+                        title={item.secondaryAction.label}
+                        placement="top"
+                        zIndex={2500}
+                        rootClassName="command-palette-tooltip"
+                      >
+                        <button
+                          type="button"
+                          className="command-palette-action-btn"
+                          onClick={item.secondaryAction.execute}
+                          aria-label={item.secondaryAction.label}
+                        >
+                          {item.secondaryAction.icon}
+                        </button>
+                      </Tooltip>
+                    )}
+                  </div>
+                </button>
+              </div>
+            );
+          })}
+        </div>
+
+        <div className="command-palette-footer">
+          <div className="command-palette-kbd-group">
+            <span>
+              <kbd className="command-palette-kbd">↑</kbd>
+              <kbd className="command-palette-kbd">↓</kbd>
+              {t('commandPalette.navigate') || 'Navigate'}
+            </span>
+            <span>
+              <kbd className="command-palette-kbd">↵</kbd>
+              {t('commandPalette.select') || 'Select'}
+            </span>
+            <span>
+              <kbd className="command-palette-kbd">Esc</kbd>
+              {t('close')}
+            </span>
+          </div>
+          <span>3x-ui Command Palette</span>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/command-palette/useCommandPalette.ts
+++ b/frontend/src/components/command-palette/useCommandPalette.ts
@@ -1,0 +1,66 @@
+import { useCallback, useEffect, useSyncExternalStore } from 'react';
+
+let isOpen = false;
+const listeners = new Set<() => void>();
+
+function notify() {
+  listeners.forEach((listener) => listener());
+}
+
+export const commandPaletteStore = {
+  getSnapshot: () => isOpen,
+  subscribe: (listener: () => void) => {
+    listeners.add(listener);
+    return () => {
+      listeners.delete(listener);
+    };
+  },
+  open: () => {
+    if (!isOpen) {
+      isOpen = true;
+      notify();
+    }
+  },
+  close: () => {
+    if (isOpen) {
+      isOpen = false;
+      notify();
+    }
+  },
+  toggle: () => {
+    isOpen = !isOpen;
+    notify();
+  },
+};
+
+export function useCommandPalette() {
+  const open = useSyncExternalStore(commandPaletteStore.subscribe, commandPaletteStore.getSnapshot);
+
+  const openPalette = useCallback(() => commandPaletteStore.open(), []);
+  const closePalette = useCallback(() => commandPaletteStore.close(), []);
+  const togglePalette = useCallback(() => commandPaletteStore.toggle(), []);
+
+  useEffect(() => {
+    function handleKeyDown(e: KeyboardEvent) {
+      if ((e.metaKey || e.ctrlKey) && (e.key === 'k' || e.key === 'K')) {
+        e.preventDefault();
+        commandPaletteStore.toggle();
+      } else if (e.key === 'Escape' && isOpen) {
+        e.preventDefault();
+        commandPaletteStore.close();
+      }
+    }
+
+    window.addEventListener('keydown', handleKeyDown, { capture: true });
+    return () => {
+      window.removeEventListener('keydown', handleKeyDown, { capture: true });
+    };
+  }, []);
+
+  return {
+    isOpen: open,
+    open: openPalette,
+    close: closePalette,
+    toggle: togglePalette,
+  };
+}

--- a/frontend/src/layouts/AppSidebar.tsx
+++ b/frontend/src/layouts/AppSidebar.tsx
@@ -28,6 +28,7 @@ import {
   PushpinOutlined,
   ReadOutlined,
   SafetyOutlined,
+  SearchOutlined,
   SettingOutlined,
   SunOutlined,
   SwapOutlined,
@@ -40,6 +41,7 @@ import { HttpUtil } from '@/utils';
 import { formatPanelVersion } from '@/lib/panel-version';
 import { pauseAnimationsUntilLeave, useTheme } from '@/hooks/useTheme';
 import { useAllSettings } from '@/api/queries/useAllSettings';
+import { useCommandPalette } from '@/components/command-palette/useCommandPalette';
 import './AppSidebar.css';
 
 const DONATE_URL = 'https://donate.sanaei.dev/';
@@ -174,6 +176,7 @@ function saveSidebarPinned(pinned: boolean) {
 export default function AppSidebar() {
   const { t } = useTranslation();
   const { isDark, isUltra, toggleTheme, toggleUltra } = useTheme();
+  const { open: openCommandPalette } = useCommandPalette();
   const navigate = useNavigate();
   const { pathname, hash } = useLocation();
   const { allSetting } = useAllSettings();
@@ -392,6 +395,23 @@ export default function AppSidebar() {
             </div>
           )}
         </div>
+        {!railCollapsed && (
+          <button
+            type="button"
+            className="sidebar-command-trigger"
+            onClick={openCommandPalette}
+            aria-label={t('commandPalette.title') || 'Command Palette (Ctrl + K)'}
+          >
+            <span style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+              <SearchOutlined className="sidebar-command-icon" />
+              <span>{t('commandPalette.search') || 'Search...'}</span>
+            </span>
+            <span className="sidebar-command-kbd">
+              <span className="kbd-cmd">⌘</span>
+              <span className="kbd-key">K</span>
+            </span>
+          </button>
+        )}
         <Menu
           theme={currentTheme}
           mode="inline"
@@ -452,6 +472,25 @@ export default function AppSidebar() {
             </button>
           </div>
         </div>
+        <button
+          type="button"
+          className="sidebar-command-trigger"
+          onClick={() => {
+            setDrawerOpen(false);
+            openCommandPalette();
+          }}
+          aria-label={t('commandPalette.title') || 'Command Palette (Ctrl + K)'}
+          style={{ margin: '8px 12px 4px', width: 'calc(100% - 24px)' }}
+        >
+          <span style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+            <SearchOutlined className="sidebar-command-icon" />
+            <span>{t('commandPalette.search') || 'Search...'}</span>
+          </span>
+          <span className="sidebar-command-kbd">
+            <span className="kbd-cmd">⌘</span>
+            <span className="kbd-key">K</span>
+          </span>
+        </button>
         <Menu
           theme={currentTheme}
           mode="inline"

--- a/frontend/src/layouts/PanelLayout.tsx
+++ b/frontend/src/layouts/PanelLayout.tsx
@@ -2,9 +2,15 @@ import { Outlet } from 'react-router';
 
 import { useWebSocketBridge } from '@/api/websocketBridge';
 import { usePageTitle } from '@/hooks/usePageTitle';
+import CommandPalette from '@/components/command-palette/CommandPalette';
 
 export default function PanelLayout() {
   useWebSocketBridge();
   usePageTitle();
-  return <Outlet />;
+  return (
+    <>
+      <Outlet />
+      <CommandPalette />
+    </>
+  );
 }

--- a/frontend/src/test/command-palette.test.tsx
+++ b/frontend/src/test/command-palette.test.tsx
@@ -1,0 +1,106 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { act, fireEvent, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router';
+
+import CommandPalette from '@/components/command-palette/CommandPalette';
+import { commandPaletteStore } from '@/components/command-palette/useCommandPalette';
+import { renderWithProviders } from './test-utils';
+
+function renderPalette() {
+  return renderWithProviders(
+    <MemoryRouter>
+      <CommandPalette />
+    </MemoryRouter>,
+  );
+}
+
+describe('CommandPalette component', () => {
+  beforeEach(() => {
+    window.HTMLElement.prototype.scrollIntoView = vi.fn();
+    act(() => {
+      commandPaletteStore.close();
+    });
+    vi.clearAllMocks();
+  });
+
+  it('does not render when closed', () => {
+    renderPalette();
+    expect(screen.queryByRole('dialog')).toBeNull();
+  });
+
+  it('renders and focuses input when opened via store', () => {
+    renderPalette();
+
+    act(() => {
+      commandPaletteStore.open();
+    });
+
+    expect(screen.getByRole('dialog')).toBeTruthy();
+    expect(screen.getByPlaceholderText(/Type a command or search/i)).toBeTruthy();
+  });
+
+  it('toggles open and closed with Ctrl+K and Escape keyboard shortcuts', () => {
+    renderPalette();
+
+    // Trigger Ctrl+K
+    act(() => {
+      window.dispatchEvent(new KeyboardEvent('keydown', { key: 'k', ctrlKey: true }));
+    });
+    expect(commandPaletteStore.getSnapshot()).toBe(true);
+
+    // Trigger Escape
+    act(() => {
+      window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }));
+    });
+    expect(commandPaletteStore.getSnapshot()).toBe(false);
+  });
+
+  it('closes when clicking backdrop', () => {
+    renderPalette();
+    act(() => {
+      commandPaletteStore.open();
+    });
+
+    const backdrop = screen.getByRole('presentation');
+    fireEvent.click(backdrop);
+
+    expect(commandPaletteStore.getSnapshot()).toBe(false);
+  });
+
+  it('navigates items with ArrowDown and ArrowUp', () => {
+    renderPalette();
+    act(() => {
+      commandPaletteStore.open();
+    });
+
+    const input = screen.getByPlaceholderText(/Type a command or search/i);
+    const items = document.querySelectorAll('.command-palette-item');
+    expect(items.length).toBeGreaterThan(0);
+
+    // Initial active index 0
+    expect(items[0]?.classList.contains('active')).toBe(true);
+
+    // Press ArrowDown -> active index 1
+    fireEvent.keyDown(input, { key: 'ArrowDown' });
+    const updatedItems = document.querySelectorAll('.command-palette-item');
+    expect(updatedItems[1]?.classList.contains('active')).toBe(true);
+
+    // Press ArrowUp -> active index 0
+    fireEvent.keyDown(input, { key: 'ArrowUp' });
+    const reupdatedItems = document.querySelectorAll('.command-palette-item');
+    expect(reupdatedItems[0]?.classList.contains('active')).toBe(true);
+  });
+
+  it('filters items when typing a search query', async () => {
+    renderPalette();
+    act(() => {
+      commandPaletteStore.open();
+    });
+
+    const input = screen.getByPlaceholderText(/Type a command or search/i);
+    fireEvent.change(input, { target: { value: 'settings' } });
+
+    // Should filter items
+    expect(screen.getAllByText(/Panel Settings/i).length).toBeGreaterThan(0);
+  });
+});

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -5,7 +5,7 @@ import path from 'node:path';
 import { DatabaseSync } from 'node:sqlite';
 
 const outDir = path.resolve(import.meta.dirname, '../internal/web/dist');
-const BACKEND_TARGET = 'http://localhost:2053';
+const BACKEND_TARGET = process.env.BACKEND_TARGET || 'http://localhost:2053';
 
 function resolveDBPath() {
   const envFolder = process.env.XUI_DB_FOLDER;
@@ -92,9 +92,28 @@ function rocketLoaderOptOutPlugin() {
 function bypassMigratedRoute(req) {
   if (req.method !== 'GET') return undefined;
   const url = req.url.split('?')[0];
+
+  if (
+    url.startsWith('/src/') ||
+    url.startsWith('/@') ||
+    url.startsWith('/node_modules/') ||
+    url.startsWith('/assets/') ||
+    url === '/favicon.ico' ||
+    url.endsWith('.tsx') ||
+    url.endsWith('.ts') ||
+    url.endsWith('.js') ||
+    url.endsWith('.mjs') ||
+    url.endsWith('.css') ||
+    url.endsWith('.svg') ||
+    url.endsWith('.png') ||
+    url.endsWith('.woff2')
+  ) {
+    return req.url;
+  }
+
   const basePath = refreshBasePath();
 
-  if (url === basePath) return '/login.html';
+  if (url === basePath || url === basePath.slice(0, -1)) return '/login.html';
 
   if (url.startsWith(basePath)) {
     const stripped = url.slice(basePath.length);
@@ -121,6 +140,7 @@ function makeBackendProxy(target) {
   return {
     target,
     changeOrigin: true,
+    secure: false,
     rewrite: rewriteToBackend,
     bypass: bypassMigratedRoute,
     configure(proxy) {

--- a/internal/web/translation/en-US.json
+++ b/internal/web/translation/en-US.json
@@ -2248,5 +2248,15 @@
     "statusFailed": "FAILED",
     "statusDown": "DOWN",
     "statusUp": "UP"
+  },
+  "commandPalette": {
+    "title": "Command Palette",
+    "placeholder": "Type a command or search clients, inbounds, pages...",
+    "search": "Search...",
+    "navigation": "Navigation",
+    "actions": "Actions",
+    "navigate": "Navigate",
+    "select": "Select",
+    "copySubscription": "Copy subscription"
   }
 }

--- a/internal/web/translation/fa-IR.json
+++ b/internal/web/translation/fa-IR.json
@@ -2248,5 +2248,15 @@
     "statusFailed": "ناموفق",
     "statusDown": "قطع",
     "statusUp": "وصل"
+  },
+  "commandPalette": {
+    "title": "پالت دستورات",
+    "placeholder": "جستجوی کلاینت‌ها، اینباندها، صفحات یا تایپ دستور...",
+    "search": "جستجو...",
+    "navigation": "ناوبری و صفحات",
+    "actions": "دستورات سیستمی",
+    "navigate": "پیمایش",
+    "select": "انتخاب",
+    "copySubscription": "کپی لینک اشتراک"
   }
 }


### PR DESCRIPTION
## Summary

Adds a global Command Palette (`Ctrl+K` / `⌘K` or sidebar search button) providing instant keyboard-driven search and navigation across clients, inbounds, panel routes, settings subpages, and system actions.

## Why

Navigating large panels with dozens of clients, inbounds, and nested configuration tabs requires multiple clicks. This command palette enables instant search, quick client subscription link copying, theme cycling, and deep-linking into nested settings.

## Type of change

- [x] New feature

## Areas affected

- [x] Frontend (UI / panel pages)

## How was this tested?

- **Hotkeys & Trigger:** Verified `Ctrl+K` / `⌘K` and sidebar trigger button open/close modal across desktop and mobile drawer.
- **Search & Deep Navigation:** Tested live client API queries, inbound matching, settings tab navigation, and theme switcher action.
