### PR TITLE
fix(outbound): test VLESS vnext endpoints

### DIFF
--- a/internal/web/service/outbound/outbound.go
+++ b/internal/web/service/outbound/outbound.go
@@ -257,7 +257,16 @@ func extractOutboundEndpoints(ob map[string]any) []string {
 			}
 		}
 	case "vless":
-		addServer(settings["address"], settings["port"])
+		if vnext, ok := settings["vnext"].([]any); ok {
+			for _, v := range vnext {
+				if vm, ok := v.(map[string]any); ok {
+					addServer(vm["address"], vm["port"])
+				}
+			}
+		}
+		if len(out) == 0 {
+			addServer(settings["address"], settings["port"])
+		}
 	case "hysteria":
 		addServer(settings["address"], settings["port"])
 	case "trojan", "shadowsocks", "http", "socks":

--- a/internal/web/service/outbound/outbound_endpoints_test.go
+++ b/internal/web/service/outbound/outbound_endpoints_test.go
@@ -1,0 +1,54 @@
+package outbound
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestExtractOutboundEndpointsVLESS(t *testing.T) {
+	tests := []struct {
+		name     string
+		settings map[string]any
+		want     []string
+	}{
+		{
+			name: "vnext endpoints",
+			settings: map[string]any{
+				"vnext": []any{
+					map[string]any{"address": "first.example.com", "port": float64(443)},
+					map[string]any{"address": "second.example.com", "port": float64(8443)},
+				},
+			},
+			want: []string{"first.example.com:443", "second.example.com:8443"},
+		},
+		{
+			name: "flat endpoint",
+			settings: map[string]any{
+				"address": "legacy.example.com",
+				"port":    float64(443),
+			},
+			want: []string{"legacy.example.com:443"},
+		},
+		{
+			name: "invalid vnext falls back to flat endpoint",
+			settings: map[string]any{
+				"vnext":   []any{map[string]any{"address": "missing-port.example.com"}},
+				"address": "fallback.example.com",
+				"port":    float64(2053),
+			},
+			want: []string{"fallback.example.com:2053"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := extractOutboundEndpoints(map[string]any{
+				"protocol": "vless",
+				"settings": tt.settings,
+			})
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Fatalf("extractOutboundEndpoints() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- Read VLESS TCP probe endpoints from the `vnext` form.
- Keep the existing flat `address` and `port` form as a fallback.
- Add regression coverage for both forms and invalid `vnext` entries.

## Why

VLESS outbounds stored in the `vnext` form currently produce no TCP probe endpoints even though the panel accepts that form.

Closes #6312

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactoring (no behavior change)
- [ ] Documentation
- [ ] Tests only
- [ ] Build / CI / tooling
- [ ] Other

## Areas affected

- [ ] Frontend (UI / panel pages)
- [x] Backend (API endpoints, login, settings)
- [ ] Xray config generation
- [ ] Subscription (share links / Clash / JSON)
- [ ] Statistics / traffic counters
- [ ] Database / migrations
- [ ] Install / upgrade script
- [ ] Docker image
- [ ] Multi-node (sub-nodes)

## How was this tested?

- `go test ./internal/web/service/outbound -run '^TestExtractOutboundEndpointsVLESS$' -count=1`
- `make gen-check lint format-check typecheck msw-worker-check test-go build build-storybook`
- `npm test -- --maxWorkers=1 --fileParallelism=false`

## Breaking changes

None.

## Checklist

- [x] I tested the change locally and confirmed the described behavior.
- [x] I added or updated tests for the new behavior.
- [x] `go build ./...` and the test suite pass locally.
- [x] My commits follow the project's existing message style.
- [x] I have no unrelated changes mixed into this PR.
