### PR TITLE
feat(routing): add panel-only comment field to routing rules

### DIFF
--- a/frontend/src/pages/xray/routing/RoutingTab.css
+++ b/frontend/src/pages/xray/routing/RoutingTab.css
@@ -14,6 +14,36 @@
   transition: opacity 0.15s;
 }
 
+.rule-comment-cell {
+  display: block;
+  max-width: 140px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: 12px;
+  color: var(--ant-color-text-tertiary);
+}
+
+.rule-comment {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  margin-top: 6px;
+  padding: 2px 6px;
+  font-size: 12px;
+  color: var(--ant-color-text-tertiary);
+  border-radius: 4px;
+  background: var(--ant-color-fill-tertiary);
+  max-width: 100%;
+  overflow: hidden;
+}
+
+.rule-comment-text {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
 .drag-handle:hover {
   opacity: 0.8;
 }

--- a/frontend/src/pages/xray/routing/RoutingTab.tsx
+++ b/frontend/src/pages/xray/routing/RoutingTab.tsx
@@ -89,6 +89,7 @@ export default function RoutingTab({
           if (rule.attrs && typeof rule.attrs === 'object' && !Array.isArray(rule.attrs)) {
             r.attrs = JSON.stringify(rule.attrs, null, 2);
           }
+          r.comment = rule.comment || undefined;
           r.outboundTag = rule.outboundTag;
           r.balancerTag = rule.balancerTag;
           return r;

--- a/frontend/src/pages/xray/routing/RuleCardList.tsx
+++ b/frontend/src/pages/xray/routing/RuleCardList.tsx
@@ -181,6 +181,13 @@ export default function RuleCardList({
                 ))}
               </div>
             )}
+            {rule.comment && (
+              <Tooltip title={rule.comment}>
+                <div className="rule-comment">
+                  <span className="rule-comment-text">{rule.comment}</span>
+                </div>
+              </Tooltip>
+            )}
           </div>
         ))
       )}

--- a/frontend/src/pages/xray/routing/RuleFormModal.tsx
+++ b/frontend/src/pages/xray/routing/RuleFormModal.tsx
@@ -13,6 +13,7 @@ import { buildRemarkByTag, formatInboundTag, isApiRule } from './helpers';
 
 export interface RoutingRule {
   enabled?: boolean;
+  comment?: string;
   type?: string;
   domain?: string | string[];
   ip?: string | string[];
@@ -42,6 +43,7 @@ interface RuleFormModalProps {
 
 const initialForm = (): RuleFormValues => ({
   enabled: true,
+  comment: '',
   domain: '',
   ip: '',
   port: '',
@@ -104,6 +106,7 @@ export default function RuleFormModal({
     if (rule) {
       methods.reset({
         enabled: rule.enabled !== false,
+        comment: rule.comment || '',
         domain: Array.isArray(rule.domain) ? rule.domain.join(',') : rule.domain || '',
         ip: Array.isArray(rule.ip) ? rule.ip.join(',') : rule.ip || '',
         port: rule.port || '',
@@ -132,6 +135,7 @@ export default function RuleFormModal({
     const built: Record<string, unknown> = {
       type: 'field',
       enabled: v.enabled,
+      comment: v.comment,
       domain: csv(v.domain),
       ip: csv(v.ip),
       port: v.port,
@@ -183,6 +187,10 @@ export default function RuleFormModal({
         <Form colon={false} labelCol={{ md: { span: 8 } }} wrapperCol={{ md: { span: 14 } }}>
           <FormField name="enabled" label={t('enable')} valueProp="checked">
             <Switch disabled={isApiRule(rule ?? {})} />
+          </FormField>
+
+          <FormField name="comment" label={t('comment')}>
+            <Input maxLength={200} showCount placeholder={t('comment')} />
           </FormField>
 
           <FormField

--- a/frontend/src/pages/xray/routing/types.ts
+++ b/frontend/src/pages/xray/routing/types.ts
@@ -1,6 +1,7 @@
 export interface RuleRow {
   key: number;
   enabled?: boolean;
+  comment?: string;
   domain?: string;
   ip?: string;
   port?: string;

--- a/frontend/src/pages/xray/routing/useRoutingColumns.tsx
+++ b/frontend/src/pages/xray/routing/useRoutingColumns.tsx
@@ -1,6 +1,6 @@
 import { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
-import { Button, Dropdown, Switch, Tag } from 'antd';
+import { Button, Dropdown, Switch, Tag, Tooltip } from 'antd';
 import {
   MoreOutlined,
   EditOutlined,
@@ -192,6 +192,20 @@ export function useRoutingColumns({
             )}
           </div>
         ),
+      },
+      {
+        title: t('comment'),
+        align: 'left',
+        width: 150,
+        key: 'comment',
+        render: (_v, record) =>
+          record.comment ? (
+            <Tooltip title={record.comment}>
+              <span className="rule-comment-cell">{record.comment}</span>
+            </Tooltip>
+          ) : (
+            <span className="criterion-empty">—</span>
+          ),
       },
       {
         title: t('pages.inbounds.network'),

--- a/frontend/src/schemas/routing.ts
+++ b/frontend/src/schemas/routing.ts
@@ -15,6 +15,7 @@ export type RuleWebhook = z.infer<typeof RuleWebhookSchema>;
 export const RuleObjectSchema = z.object({
   type: z.literal('field').default('field'),
   enabled: z.boolean().optional(),
+  comment: z.string().optional(),
   domain: z.array(z.string()).optional(),
   ip: z.array(z.string()).optional(),
   port: PortValueSchema.optional(),

--- a/frontend/src/schemas/xray.ts
+++ b/frontend/src/schemas/xray.ts
@@ -110,6 +110,7 @@ export const OutboundTestResultListSchema = z.array(OutboundTestResultSchema);
 
 export const RuleFormSchema = z.object({
   enabled: z.boolean(),
+  comment: z.string(),
   domain: z.string(),
   ip: z.string(),
   port: z.string(),

--- a/internal/web/service/xray.go
+++ b/internal/web/service/xray.go
@@ -1060,9 +1060,9 @@ func resolveXrayLogPaths(logCfg json_util.RawMessage) json_util.RawMessage {
 }
 
 // stripDisabledRules removes routing rules marked `enabled: false` from the
-// generated runtime config and strips the panel-only `enabled` key from the
-// rest, since xray-core has no such field. The internal api rule is always
-// kept (see isApiRule) so traffic stats can't be toggled off. The stored
+// generated runtime config and strips panel-only keys (`enabled`, `comment`)
+// from the rest, since xray-core has no such fields. The internal api rule is
+// always kept (see isApiRule) so traffic stats can't be toggled off. The stored
 // template is untouched — only the generated config is filtered.
 func stripDisabledRules(routerCfg json_util.RawMessage) json_util.RawMessage {
 	if len(routerCfg) == 0 {
@@ -1095,6 +1095,10 @@ func stripDisabledRules(routerCfg json_util.RawMessage) json_util.RawMessage {
 				continue
 			}
 			delete(rule, "enabled")
+			changed = true
+		}
+		if _, exists := rule["comment"]; exists {
+			delete(rule, "comment")
 			changed = true
 		}
 		activeRules = append(activeRules, rule)


### PR DESCRIPTION
## Summary

- Add a panel-only `comment` field to routing rules for human-readable annotations.
- Strip `comment` from the generated xray-core config (same pattern as the existing `enabled` flag).
- Display the comment as a column in the desktop table (with Ant Design Tooltip on hover) and as a chip in the mobile card list.

## Why

When adding routing rules manually — specific IPs, domains — it's easy to forget what each rule is for after a few weeks. A rule pointing at `91.108.4.0/22` or `10.0.0.0/8` means nothing a month later without context. A panel-only comment field lets admins label rules (e.g. "1С server subnet", "Office VPN range", "Temp bypass for client X") so they remain readable over time, without affecting the xray-core config.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactoring (no behavior change)
- [ ] Documentation
- [ ] Tests only
- [ ] Build / CI / tooling
- [ ] Other

## Areas affected

- [x] Frontend (UI / panel pages)
- [x] Backend (API endpoints, login, settings)
- [ ] Xray config generation
- [ ] Subscription (share links / Clash / JSON)
- [ ] Statistics / traffic counters
- [ ] Database / migrations
- [ ] Install / upgrade script
- [ ] Docker image
- [ ] Multi-node (sub-nodes)

## How was this tested?

- `npm run typecheck` passes.
- `go build ./internal/web/service/` passes.
- Manually verified: create/edit routing rule with comment, confirm comment persists in template JSON, confirm comment is absent from generated xray config, confirm tooltip shows full text on hover.

## Breaking changes

None. The `comment` field is optional and silently ignored by xray-core if it ever leaks through (unknown keys are tolerated by xray's JSON parser).

## Checklist

- [x] I tested the change locally and confirmed the described behavior.
- [ ] I added or updated tests for the new behavior.
- [x] `go build ./...` and the test suite pass locally.
- [x] My commits follow the project's existing message style.
- [x] I have no unrelated changes mixed into this PR.


- [x] I tested the change locally and confirmed the described behavior.
- [ ] I added or updated tests for the new behavior.
- [x] `go build ./...` and the test suite pass locally.
- [x] My commits follow the project's existing message style.
- [x] I have no unrelated changes mixed into this PR.
