### PR TITLE
fix(log): do not log successfull login twice

### DIFF
--- a/internal/web/controller/index.go
+++ b/internal/web/controller/index.go
@@ -126,7 +126,6 @@ func (a *IndexController) login(c *gin.Context) {
 		return
 	}
 
-	logger.Infof("%s logged in successfully", safeUser)
 	jsonMsg(c, I18nWeb(c, "pages.login.toasts.successLogin"), nil)
 }
 


### PR DESCRIPTION
## Summary

<!-- What does this PR do? One or two sentences. -->
Remove one line to not print almost the same line into the log twice
## Why
To save space, make it more readable etc
<!--
What problem does this solve, or what use case does it enable?
Link related issues here: "Closes #123", "Refs #456".
-->

## Type of change

- [x] Bug fix
- [ ] New feature
- [x] Refactoring (no behavior change)
- [ ] Documentation
- [ ] Tests only
- [ ] Build / CI / tooling
- [ ] Other

## Areas affected

- [ ] Frontend (UI / panel pages)
- [x] Backend (API endpoints, login, settings)
- [ ] Xray config generation
- [ ] Subscription (share links / Clash / JSON)
- [ ] Statistics / traffic counters
- [ ] Database / migrations
- [ ] Install / upgrade script
- [ ] Docker image
- [ ] Multi-node (sub-nodes)
- [ ] Telegram bot

## How was this tested?
`docker compose up -d`
login into the panel
check log
screenshot below
<!--
Concrete steps the reviewer can repeat. For UI changes: which page,
which actions, which browser. For backend: which endpoint, which payload,
which response. Mention any new unit/integration tests added.
-->

## Screenshots / recordings
<img width="1138" height="433" alt="image" src="https://github.com/user-attachments/assets/9f0a795f-008d-4077-b03d-e6b82dc00539" />

<!-- Required for UI changes. Drag images or GIFs here. Remove if N/A. -->

## Breaking changes
None
<!--
Does this change require existing users to update their config, run a
migration, or change their API calls? If yes, describe the migration path.
Write "None" if there are no breaking changes.
-->

## Checklist

- [x] I tested the change locally and confirmed the described behavior.
- [ ] I added or updated tests for the new behavior (when applicable).
- [x] `go build ./...` and the test suite pass locally.
- [ ] For frontend changes: `npm run lint`, `npm run typecheck`, and `npm run build` pass.
- [ ] I updated the Wiki / README / API docs if user-facing behavior changed.
- [x] My commits follow the project's existing message style.
- [x] I have no unrelated changes mixed into this PR.
