### PR TITLE
fix: Prevent node snapshots from resurrecting bulk-deleted clients

### DIFF
--- a/internal/web/service/client_bulk.go
+++ b/internal/web/service/client_bulk.go
@@ -908,8 +908,9 @@ func (s *ClientService) bulkDelInboundClients(
 		return res
 	}
 
-	// Match by email — the client's stable identity (see Delete). Removes every
-	// entry carrying a wanted email, independent of credential drift.
+	// Match by email — the client's stable identity (see Delete). The link-derived
+	// set is deletion intent: an email already absent from settings is successful,
+	// while foundEmails tracks entries that still need settings-specific cleanup.
 	wantedEmails := make(map[string]struct{}, len(emails))
 	for _, email := range emails {
 		if records[email] == nil {
@@ -939,12 +940,6 @@ func (s *ClientService) bulkDelInboundClients(
 		newClients = append(newClients, client)
 	}
 
-	for email := range wantedEmails {
-		if !foundEmails[email] {
-			res.perEmailSkipped[email] = "Client Not Found In Inbound"
-		}
-	}
-
 	db := database.GetDB()
 	newClients = compactOrphans(db, newClients)
 	if newClients == nil {
@@ -953,7 +948,7 @@ func (s *ClientService) bulkDelInboundClients(
 	settings["clients"] = newClients
 	newSettings, err := json.MarshalIndent(settings, "", "  ")
 	if err != nil {
-		for email := range foundEmails {
+		for email := range wantedEmails {
 			if _, skip := res.perEmailSkipped[email]; !skip {
 				res.perEmailSkipped[email] = err.Error()
 			}
@@ -991,9 +986,8 @@ func (s *ClientService) bulkDelInboundClients(
 		var sharedErr error
 		sharedSet, sharedErr = inboundSvc.emailsUsedByOtherInbounds(foundList, inboundId)
 		if sharedErr != nil {
-			for email := range foundEmails {
+			for email := range wantedEmails {
 				res.perEmailSkipped[email] = sharedErr.Error()
-				delete(foundEmails, email)
 			}
 			return res
 		}
@@ -1046,7 +1040,7 @@ func (s *ClientService) bulkDelInboundClients(
 		return nil
 	})
 	if txErr != nil {
-		for email := range foundEmails {
+		for email := range wantedEmails {
 			if _, skip := res.perEmailSkipped[email]; !skip {
 				res.perEmailSkipped[email] = txErr.Error()
 			}
@@ -1071,12 +1065,21 @@ func (s *ClientService) bulkDelInboundClients(
 				}
 			}
 		}
-	} else if len(foundEmails) <= nodeBulkPushThreshold {
+	} else {
+		dispatchEmails := make([]string, 0, len(wantedEmails))
+		for email := range wantedEmails {
+			if _, skip := res.perEmailSkipped[email]; !skip {
+				dispatchEmails = append(dispatchEmails, email)
+			}
+		}
+		if len(dispatchEmails) > nodeBulkPushThreshold {
+			return res
+		}
 		rt, push, _, perr := inboundSvc.nodePushPlan(oldInbound)
 		if perr != nil {
 			logger.Warning("BulkDelete: node runtime lookup after commit failed:", perr)
 		} else if push {
-			for email := range foundEmails {
+			for _, email := range dispatchEmails {
 				if err1 := rt.DeleteClient(context.Background(), email); err1 != nil {
 					logger.Warning("Error in deleting client on", rt.Name(), ":", err1)
 				}

--- a/internal/web/service/node_bulk_dispatch_test.go
+++ b/internal/web/service/node_bulk_dispatch_test.go
@@ -234,6 +234,9 @@ func TestNodeBulkDeleteDoesNotPushBeforeFailedCommit(t *testing.T) {
 	if got := fake.deleteClient.Load() + fake.deleteUser.Load(); got != 0 {
 		t.Fatalf("failed transaction pushed %d delete call(s) to the node, want 0", got)
 	}
+	if isClientEmailTombstoned(client.Email) {
+		t.Fatal("failed bulk delete left a live tombstone")
+	}
 }
 
 func TestNodeBulkSmallDeleteRemovesWholeRemoteClient(t *testing.T) {
@@ -241,6 +244,10 @@ func TestNodeBulkSmallDeleteRemovesWholeRemoteClient(t *testing.T) {
 	nodeID, fake := setupNodeRuntime(t)
 	client := model.Client{ID: uuid.NewString(), Email: "full-delete@x", Enable: true}
 	nodeInbound(t, nodeID, 30024, []model.Client{client})
+	var record model.ClientRecord
+	if err := database.GetDB().Where("email = ?", client.Email).First(&record).Error; err != nil {
+		t.Fatalf("load client record: %v", err)
+	}
 
 	result, _, err := (&ClientService{}).BulkDelete(&InboundService{}, []string{client.Email}, true)
 	if err != nil {
@@ -254,6 +261,104 @@ func TestNodeBulkSmallDeleteRemovesWholeRemoteClient(t *testing.T) {
 	}
 	if got := fake.deleteUser.Load(); got != 0 {
 		t.Fatalf("remote DeleteUser detach calls = %d, want 0 for full deletion", got)
+	}
+	var records, links int64
+	if err := database.GetDB().Model(&model.ClientRecord{}).Where("email = ?", client.Email).Count(&records).Error; err != nil {
+		t.Fatalf("count client records: %v", err)
+	}
+	if err := database.GetDB().Model(&model.ClientInbound{}).Where("client_id = ?", record.Id).Count(&links).Error; err != nil {
+		t.Fatalf("count client links: %v", err)
+	}
+	if records != 0 || links != 0 {
+		t.Fatalf("bulk delete left records=%d links=%d, want 0/0", records, links)
+	}
+}
+
+func TestNodeBulkDeleteTreatsMissingSettingsClientAsAlreadyDeleted(t *testing.T) {
+	setupBulkDB(t)
+	nodeID, fake := setupNodeRuntime(t)
+	client := model.Client{ID: uuid.NewString(), Email: "drifted-delete@x", Enable: true}
+	ib := nodeInbound(t, nodeID, 30025, []model.Client{client})
+
+	// Simulate a stale normalized link after the client has already disappeared
+	// from the inbound settings JSON.
+	if err := database.GetDB().Model(&model.Inbound{}).Where("id = ?", ib.Id).
+		Update("settings", clientsSettings(t, nil)).Error; err != nil {
+		t.Fatalf("drift inbound settings: %v", err)
+	}
+
+	result, _, err := (&ClientService{}).BulkDelete(&InboundService{}, []string{client.Email}, true)
+	if err != nil {
+		t.Fatalf("BulkDelete: %v", err)
+	}
+	if result.Deleted != 1 || len(result.Skipped) != 0 {
+		t.Fatalf("BulkDelete result = %+v, want one deleted client", result)
+	}
+	if got := fake.deleteClient.Load(); got != 1 {
+		t.Fatalf("remote DeleteClient calls = %d, want 1", got)
+	}
+	var records, links int64
+	if err := database.GetDB().Model(&model.ClientRecord{}).Where("email = ?", client.Email).Count(&records).Error; err != nil {
+		t.Fatalf("count client records: %v", err)
+	}
+	if err := database.GetDB().Model(&model.ClientInbound{}).Where("inbound_id = ?", ib.Id).Count(&links).Error; err != nil {
+		t.Fatalf("count client links: %v", err)
+	}
+	if records != 0 || links != 0 {
+		t.Fatalf("bulk delete left records=%d links=%d, want 0/0", records, links)
+	}
+	if !isClientEmailTombstoned(client.Email) {
+		t.Fatal("successful bulk delete withdrew the client tombstone")
+	}
+	t.Cleanup(func() { withdrawClientTombstones(client.Email) })
+}
+
+func TestNodeBulkDeleteCompletesAcrossPresentAndMissingSettings(t *testing.T) {
+	setupBulkDB(t)
+	nodeID, fake := setupNodeRuntime(t)
+	client := model.Client{ID: uuid.NewString(), Email: "mixed-delete@x", Enable: true}
+	drifted := nodeInbound(t, nodeID, 30026, []model.Client{client})
+	nodeInbound(t, nodeID, 30027, []model.Client{client})
+
+	if err := database.GetDB().Model(&model.Inbound{}).Where("id = ?", drifted.Id).
+		Update("settings", clientsSettings(t, nil)).Error; err != nil {
+		t.Fatalf("drift inbound settings: %v", err)
+	}
+
+	result, _, err := (&ClientService{}).BulkDelete(&InboundService{}, []string{client.Email}, true)
+	if err != nil {
+		t.Fatalf("BulkDelete: %v", err)
+	}
+	if result.Deleted != 1 || len(result.Skipped) != 0 {
+		t.Fatalf("BulkDelete result = %+v, want one deleted client", result)
+	}
+	if got := fake.deleteClient.Load(); got != 2 {
+		t.Fatalf("remote DeleteClient calls = %d, want one per node inbound", got)
+	}
+}
+
+func TestNodeBulkDeleteMalformedSettingsWithdrawsTombstone(t *testing.T) {
+	setupBulkDB(t)
+	nodeID, fake := setupNodeRuntime(t)
+	client := model.Client{ID: uuid.NewString(), Email: "malformed-delete@x", Enable: true}
+	ib := nodeInbound(t, nodeID, 30028, []model.Client{client})
+	if err := database.GetDB().Model(&model.Inbound{}).Where("id = ?", ib.Id).
+		Update("settings", `{"clients":[`).Error; err != nil {
+		t.Fatalf("break inbound settings: %v", err)
+	}
+
+	result, _, err := (&ClientService{}).BulkDelete(&InboundService{}, []string{client.Email}, true)
+	if err != nil {
+		t.Fatalf("BulkDelete: %v", err)
+	}
+	if result.Deleted != 0 || len(result.Skipped) != 1 {
+		t.Fatalf("BulkDelete result = %+v, want one skipped client", result)
+	}
+	if got := fake.deleteClient.Load() + fake.deleteUser.Load(); got != 0 {
+		t.Fatalf("malformed settings pushed %d delete call(s) to the node, want 0", got)
+	}
+	if isClientEmailTombstoned(client.Email) {
+		t.Fatal("failed bulk delete left a live tombstone")
 	}
 }
 
@@ -351,8 +456,8 @@ func TestNodeBulk_LargeDeleteFoldsToDirty(t *testing.T) {
 		t.Fatalf("BulkDelete: %v", err)
 	}
 
-	if got := fake.deleteUser.Load(); got != 0 {
-		t.Fatalf("large delete streamed %d DeleteUser RPCs, want 0 (should fold to dirty)", got)
+	if got := fake.deleteClient.Load() + fake.deleteUser.Load(); got != 0 {
+		t.Fatalf("large delete streamed %d delete RPCs, want 0 (should fold to dirty)", got)
 	}
 	if _, _, dirty, _, err := (&NodeService{}).NodeSyncState(nodeID); err != nil {
 		t.Fatalf("NodeSyncState: %v", err)


### PR DESCRIPTION
## Summary

Treat the link-derived email set passed to `bulkDelInboundClients` as deletion intent and make an absent settings entry an idempotent success, matching the existing single-client `Delete` behavior. Keep the settings-present set only for operations that require an entry removed from the JSON, while tracking genuine parse, persistence, or cleanup failures separately so failed transactions remain skipped and never trigger premature RPCs. After a successful node-inbound transaction, dispatch `DeleteClient` for every intended email that has not encountered a real processing failure, including clients already absent from the settings JSON; preserve the existing threshold behavior for large batches.

Bulk deletion can remove a client from a master-side inbound while a later node snapshot recreates the client record and `client_inbounds` link from stale node state. On the next attempt, the link still selects that inbound for deletion, but the email is already absent from the inbound settings JSON, so `bulkDelInboundClients` reports `Client Not Found In Inbound`. That failure also excludes the email from the node-side `DeleteClient` dispatch and causes `BulkDelete` to withdraw the tombstone that would have filtered the stale snapshot. The reporter reproduced this cycle on PostgreSQL with online nodes and confirmed that single-row deletion succeeds while bulk deletion repeatedly leaves one attachment behind.

Closes #6356

## Why

Treat the link-derived email set passed to `bulkDelInboundClients` as deletion intent and make an absent settings entry an idempotent success, matching the existing single-client `Delete` behavior. Keep the settings-present set only for operations that require an entry removed from the JSON, while tracking genuine parse, persistence, or cleanup failures separately so failed transactions remain skipped and never trigger premature RPCs. After a successful node-inbound transaction, dispatch `DeleteClient` for every intended email that has not encountered a real processing failure, including clients already absent from the settings JSON; preserve the existing threshold behavior for large batches.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactoring (no behavior change)
- [ ] Documentation
- [ ] Tests only
- [ ] Build / CI / tooling
- [ ] Other

## Areas affected

- [ ] Frontend (UI / panel pages)
- [ ] Backend (API endpoints, login, settings)
- [ ] Xray config generation
- [ ] Subscription (share links / Clash / JSON)
- [ ] Statistics / traffic counters
- [ ] Database / migrations
- [ ] Install / upgrade script
- [ ] Docker image
- [ ] Multi-node (sub-nodes)
- [ ] Telegram bot

## How was this tested?

A normal small bulk delete where the client exists in both the link table and inbound settings still reports one deletion, removes the local record, and sends one full `DeleteClient` RPC rather than a detach call.
A drifted node inbound with a surviving `client_inbounds` row but no matching settings entry is treated as already removed from that inbound: bulk deletion reports success, deletes the client record and link, sends `DeleteClient` to the node, and leaves the deletion tombstone live so a stale snapshot cannot resurrect it.
A client spanning multiple inbounds, with the settings entry already absent from one inbound and present in another, completes as one successful bulk deletion instead of returning a partial failure or withdrawing the tombstone.
Malformed settings or an injected transaction failure remains a real skipped result, does not send a node delete before commit, and preserves the existing retry-safe tombstone withdrawal behavior.
A delete larger than `nodeBulkPushThreshold` continues to fold into the dirty-node reconcile path without streaming per-client RPCs.

## Screenshots / recordings

No user-visible surface changes in this PR, so there is nothing to show.

## Breaking changes

Covered in the summary above.

## Checklist

- [x] I tested the change locally and confirmed the described behavior.
- [x] I added or updated tests for the new behavior (when applicable).
- [x] `go build ./...` and the test suite pass locally.
- [x] For frontend changes: `npm run lint`, `npm run typecheck`, and `npm run build` pass.
- [x] I updated the Wiki / README / API docs if user-facing behavior changed.
- [x] My commits follow the project's existing message style.
- [ ] I have no unrelated changes mixed into this PR.

**AI disclosure**

AI was used for assistance.

- Tools: an AI coding assistant.
