### PR TITLE
fix(database): keep the SQLite store owner-only

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -155,7 +155,7 @@ write_install_result() {
     local u="$1" p="$2" port="$3" wbp="$4" scheme="$5" host="$6" token="$7" dbtype="$8"
     local result_file="/etc/x-ui/install-result.env"
     local url_host="${host:-SERVER_IP_UNKNOWN}"
-    install -d -m 755 /etc/x-ui 2> /dev/null
+    install -d -m 700 /etc/x-ui 2> /dev/null
     local prev_umask
     prev_umask=$(umask)
     umask 077

--- a/internal/database/db.go
+++ b/internal/database/db.go
@@ -2092,8 +2092,8 @@ func InitDB(dbPath string) error {
 		if err != nil {
 			return err
 		}
-		if err = restrictSQLiteFilePerms(dbPath); err != nil {
-			return err
+		if err := restrictSQLiteFilePerms(dbPath); err != nil {
+			log.Printf("restrict SQLite file permissions: %v", err)
 		}
 		sqlDB, err := db.DB()
 		if err != nil {
@@ -2195,8 +2195,8 @@ func openPostgresWithRetry(dsn string, c *gorm.Config) (*gorm.DB, error) {
 	return nil, fmt.Errorf("postgres unreachable after %d attempts: %w", len(delays), lastErr)
 }
 
-// The store holds client UUIDs, Reality private keys and the admin password
-// hash, so it and its WAL/SHM side files must stay owner-only.
+// The store holds client secrets, so it and its WAL/SHM side files stay
+// owner-only. Best effort: a store the panel cannot chmod still opens.
 func restrictSQLiteFilePerms(dbPath string) error {
 	for _, name := range []string{dbPath, dbPath + "-wal", dbPath + "-shm"} {
 		if err := os.Chmod(name, 0o600); err != nil && !errors.Is(err, os.ErrNotExist) {

--- a/internal/database/db.go
+++ b/internal/database/db.go
@@ -2078,7 +2078,7 @@ func InitDB(dbPath string) error {
 		}
 	default:
 		dir := path.Dir(dbPath)
-		if err = os.MkdirAll(dir, 0o755); err != nil {
+		if err = os.MkdirAll(dir, 0o700); err != nil {
 			return err
 		}
 		if err = cleanupSQLiteBackupDirs(filepath.Dir(dbPath)); err != nil {
@@ -2090,6 +2090,9 @@ func InitDB(dbPath string) error {
 		dsn := dbPath + "?_journal_mode=" + journal + "&_busy_timeout=10000&_synchronous=" + sync + "&_txlock=immediate"
 		db, err = gorm.Open(sqlite.Open(dsn), c)
 		if err != nil {
+			return err
+		}
+		if err = restrictSQLiteFilePerms(dbPath); err != nil {
 			return err
 		}
 		sqlDB, err := db.DB()
@@ -2190,6 +2193,17 @@ func openPostgresWithRetry(dsn string, c *gorm.Config) (*gorm.DB, error) {
 		log.Printf("postgres connection attempt %d/%d failed: %v", i+1, len(delays), err)
 	}
 	return nil, fmt.Errorf("postgres unreachable after %d attempts: %w", len(delays), lastErr)
+}
+
+// The store holds client UUIDs, Reality private keys and the admin password
+// hash, so it and its WAL/SHM side files must stay owner-only.
+func restrictSQLiteFilePerms(dbPath string) error {
+	for _, name := range []string{dbPath, dbPath + "-wal", dbPath + "-shm"} {
+		if err := os.Chmod(name, 0o600); err != nil && !errors.Is(err, os.ErrNotExist) {
+			return err
+		}
+	}
+	return nil
 }
 
 func sqliteJournalMode() string {

--- a/internal/database/db_permissions_test.go
+++ b/internal/database/db_permissions_test.go
@@ -1,0 +1,79 @@
+package database
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+func TestInitDBRestrictsSQLiteFilePermissions(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("POSIX permission bits are not meaningful on Windows")
+	}
+	t.Setenv("XUI_DB_JOURNAL_MODE", "")
+	dbDir := filepath.Join(t.TempDir(), "x-ui")
+	dbPath := filepath.Join(dbDir, "x-ui.db")
+
+	if err := InitDB(dbPath); err != nil {
+		t.Fatalf("InitDB: %v", err)
+	}
+	t.Cleanup(func() { _ = CloseDB() })
+
+	if info, err := os.Stat(dbDir); err != nil {
+		t.Fatalf("stat db dir: %v", err)
+	} else if perm := info.Mode().Perm(); perm != 0o700 {
+		t.Fatalf("db dir perm = %o, want 700", perm)
+	}
+	for _, name := range []string{dbPath, dbPath + "-wal", dbPath + "-shm"} {
+		info, err := os.Stat(name)
+		if errors.Is(err, os.ErrNotExist) && name != dbPath {
+			continue
+		}
+		if err != nil {
+			t.Fatalf("stat %s: %v", name, err)
+		}
+		if perm := info.Mode().Perm(); perm != 0o600 {
+			t.Fatalf("%s perm = %o, want 600", filepath.Base(name), perm)
+		}
+	}
+}
+
+func TestInitDBTightensExistingSQLiteFilePermissions(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("POSIX permission bits are not meaningful on Windows")
+	}
+	t.Setenv("XUI_DB_JOURNAL_MODE", "")
+	dbPath := filepath.Join(t.TempDir(), "x-ui.db")
+	if err := InitDB(dbPath); err != nil {
+		t.Fatalf("seed InitDB: %v", err)
+	}
+	if err := CloseDB(); err != nil {
+		t.Fatalf("seed CloseDB: %v", err)
+	}
+	// Simulate a store created by an older release under the default umask.
+	for _, name := range []string{dbPath, dbPath + "-wal", dbPath + "-shm"} {
+		if err := os.Chmod(name, 0o644); err != nil && !errors.Is(err, os.ErrNotExist) {
+			t.Fatalf("chmod %s: %v", name, err)
+		}
+	}
+
+	if err := InitDB(dbPath); err != nil {
+		t.Fatalf("InitDB: %v", err)
+	}
+	t.Cleanup(func() { _ = CloseDB() })
+
+	for _, name := range []string{dbPath, dbPath + "-wal", dbPath + "-shm"} {
+		info, err := os.Stat(name)
+		if errors.Is(err, os.ErrNotExist) && name != dbPath {
+			continue
+		}
+		if err != nil {
+			t.Fatalf("stat %s: %v", name, err)
+		}
+		if perm := info.Mode().Perm(); perm != 0o600 {
+			t.Fatalf("%s perm = %o, want 600", filepath.Base(name), perm)
+		}
+	}
+}

--- a/internal/database/dump_sqlite.go
+++ b/internal/database/dump_sqlite.go
@@ -24,7 +24,7 @@ func DumpSQLite(srcPath, outPath string) error {
 	if err != nil {
 		return err
 	}
-	return os.WriteFile(outPath, data, 0o644)
+	return os.WriteFile(outPath, data, 0o600)
 }
 
 // DumpSQLiteToBytes builds the same `sqlite3 .dump`-style SQL text as DumpSQLite


### PR DESCRIPTION
## Summary

Create the SQLite data directory with mode 0700 and chmod `x-ui.db` plus its `-wal`/`-shm` side files to 0600 on every start, so the store is readable by the panel's user (root) only.

## Why

`InitDB` creates the folder with `os.MkdirAll(dir, 0o755)` and lets SQLite create the files under the default umask, so on a stock install `/etc/x-ui/x-ui.db`, `x-ui.db-wal` and `x-ui.db-shm` end up 0644 (checked in the v3.7.0 container). The database holds client UUIDs and subscription ids, Reality private keys and the admin password hash, so any unprivileged local account can read everything needed to impersonate clients or attack the panel login offline. The panel already writes the generated Xray config with 0600 for the same reason (`writeFileAtomic` in `internal/xray/process.go`); this brings the store in line with that.

Fresh installs get a 0700 directory: the binary creates it that way and `install.sh` now creates it with `install -d -m 700` as well (it used to reset it to 0755). Docker bind mounts keep the host's directory mode; the files inside are still tightened. Existing installs keep their directory mode but get the files tightened on the next start. SQLite creates `-wal`/`-shm` with the mode of the main database file, so the chmod right after `gorm.Open` also covers side files created later. `XUI_DB_FOLDER` outside `/etc` is handled the same way. PostgreSQL deployments are untouched.

The chmod is best effort: if the panel cannot change the mode (a `root_squash` NFS mount, a foreign uid in a container) it logs and starts anyway, the same way the backup-directory cleanup above it does. On Windows `os.Chmod` only toggles the read-only attribute, so the change is a no-op there. The `migrate-db` dump written next to the store is a plaintext copy of the same secrets and is now 0600 too.

## Type of change

- [x] Bug fix

## Areas affected

- [x] Database / migrations

## How was this tested?

- New tests `TestInitDBRestrictsSQLiteFilePermissions` and `TestInitDBTightensExistingSQLiteFilePermissions` in `internal/database/db_permissions_test.go`. Both fail on `main` (`db dir perm = 755, want 700` and `x-ui.db perm = 644, want 600`) and pass with this change.
- `go test -shuffle=on -count=1 ./internal/database/`, `go vet`, `gofmt`, `golangci-lint run ./internal/database/...` (0 issues) and `go build ./...` on Linux with Go 1.27.0.
- Not run on Windows; the tests skip there.

## Screenshots / recordings

N/A

## Breaking changes

None for the panel itself. If something reads `x-ui.db` from a separate unprivileged account (an external backup job, for example), that account now needs root or an explicit ACL.

## Checklist

- [x] I tested the change locally and confirmed the described behavior.
- [x] I added or updated tests for the new behavior (when applicable).
- [x] `go build ./...` and the test suite pass locally.
- [ ] For frontend changes: N/A
- [ ] I updated the Wiki / README / API docs if user-facing behavior changed. (no user-facing docs affected)
- [x] My commits follow the project's existing message style.
- [x] I have no unrelated changes mixed into this PR.
