### PR TITLE
fix(x-ui.sh): put the fail2ban backend override in jail.d, not jail.conf

### DIFF
--- a/x-ui.sh
+++ b/x-ui.sh
@@ -2389,7 +2389,6 @@ remove_iplimit() {
             rm -f /etc/fail2ban/filter.d/3x-ipl.conf
             rm -f /etc/fail2ban/action.d/3x-ipl.conf
             rm -f /etc/fail2ban/jail.d/3x-ipl.conf
-            rm -f /etc/fail2ban/jail.d/3x-ipl-backend.conf
             if [[ $release == "alpine" ]]; then
                 rc-service fail2ban restart
             else
@@ -2493,9 +2492,10 @@ create_iplimit_jails() {
     # Uncomment 'allowipv6 = auto' in fail2ban.conf
     sed -i 's/#allowipv6 = auto/allowipv6 = auto/g' /etc/fail2ban/fail2ban.conf
 
-    # Debian 12+ and Ubuntu 22.04+ log sshd to the journal only. A jail.d
-    # override survives package upgrades; editing jail.conf in place does not.
-    if [[ ( "${release}" == "debian" && ${os_version} -ge 12 ) || ( "${release}" == "ubuntu" && ${os_version} -ge 2200 ) ]]; then
+    # Debian 12+ / Ubuntu 22.04+ log sshd to the journal only; a jail.d override
+    # survives package upgrades. Only the stock 'backend = auto' is overridden.
+    if [[ ( "${release}" == "debian" && ${os_version} -ge 12 ) || ( "${release}" == "ubuntu" && ${os_version} -ge 2200 ) ]] &&
+        sed -n '0,/action =/p' /etc/fail2ban/jail.conf | grep -q '^backend = auto'; then
         cat << EOF > /etc/fail2ban/jail.d/3x-ipl-backend.conf
 [DEFAULT]
 backend = systemd

--- a/x-ui.sh
+++ b/x-ui.sh
@@ -2389,6 +2389,7 @@ remove_iplimit() {
             rm -f /etc/fail2ban/filter.d/3x-ipl.conf
             rm -f /etc/fail2ban/action.d/3x-ipl.conf
             rm -f /etc/fail2ban/jail.d/3x-ipl.conf
+            rm -f /etc/fail2ban/jail.d/3x-ipl-backend.conf
             if [[ $release == "alpine" ]]; then
                 rc-service fail2ban restart
             else
@@ -2492,9 +2493,13 @@ create_iplimit_jails() {
     # Uncomment 'allowipv6 = auto' in fail2ban.conf
     sed -i 's/#allowipv6 = auto/allowipv6 = auto/g' /etc/fail2ban/fail2ban.conf
 
-    # On Debian 12+ and Ubuntu 22.04+ fail2ban's default backend should be changed to systemd
+    # Debian 12+ and Ubuntu 22.04+ log sshd to the journal only. A jail.d
+    # override survives package upgrades; editing jail.conf in place does not.
     if [[ ( "${release}" == "debian" && ${os_version} -ge 12 ) || ( "${release}" == "ubuntu" && ${os_version} -ge 2200 ) ]]; then
-        sed -i '0,/action =/s/backend = auto/backend = systemd/' /etc/fail2ban/jail.conf
+        cat << EOF > /etc/fail2ban/jail.d/3x-ipl-backend.conf
+[DEFAULT]
+backend = systemd
+EOF
     fi
 
     cat << EOF > /etc/fail2ban/jail.d/3x-ipl.conf


### PR DESCRIPTION
## Summary

Write the fail2ban `backend = systemd` override for Debian 12+ / Ubuntu 22.04+ to `/etc/fail2ban/jail.d/3x-ipl-backend.conf` instead of editing `/etc/fail2ban/jail.conf` in place with `sed`.

## Why

`create_iplimit_jails()` ran `sed -i '0,/action =/s/backend = auto/backend = systemd/' /etc/fail2ban/jail.conf`. `jail.conf` is the fail2ban package's conffile: on the next package upgrade dpkg either replaces the modified file (dropping the edit) or keeps the stale copy (dropping the package's updated jail defaults), depending on the conffile prompt. fail2ban documents that overrides belong in `jail.local` or `jail.d/*.conf`, which are read after `jail.conf` and left alone by upgrades; the script already owns `jail.d/3x-ipl.conf`.

The override is load-bearing on Debian 12: bookworm ships fail2ban 1.0.2-2 whose `paths-debian.conf` sets no `sshd_backend`, so the stock `[sshd]` jail inherits `[DEFAULT] backend` and, with no syslog files on a minimal install, fail2ban fails to start without it. Ubuntu 24.04 already ships `backend = systemd` in `jail.d/defaults-debian.conf`, so there the file is a harmless duplicate.

Two things kept from the old behaviour on purpose: the file is written only when `jail.conf` still carries the stock `backend = auto` in `[DEFAULT]` (the `sed` matched only that literal, so an operator's own value survived it and still does), and it is not removed by the "only remove IP Limit configurations" option (the `sed` edit was never reverted either, and deleting a `[DEFAULT]` override there would flip every inheriting jail back to `auto` on the restart in the same branch). The full `/etc/fail2ban` removal option deletes it with everything else.

The `[3x-ipl]` jail keeps its explicit `backend=auto`, so its own behaviour does not change. Existing installs that already have the `sed`-edited `jail.conf` are unaffected; the override file just makes the setting survive the next fail2ban upgrade.

## Type of change

- [x] Bug fix

## Areas affected

- [x] Install / upgrade script

## How was this tested?

- `bash -n x-ui.sh`; `shellcheck -S warning` warning count unchanged against `main` (42).
- Reviewed against fail2ban's config read order (`jail.conf`, `jail.d/*.conf`, `jail.local`, `jail.d/*.local`); a `[DEFAULT]` section in `jail.d/3x-ipl-backend.conf` overrides the `backend = auto` default from `jail.conf` exactly as the `sed` did.
- The guard was run against upstream's stock `jail.conf` (writes the override) and a copy with `backend = polling` in `[DEFAULT]` (skips it).
- Not run end to end on a fresh server.

## Screenshots / recordings

N/A

## Breaking changes

None.

## Checklist

- [x] I tested the change locally and confirmed the described behavior.
- [ ] I added or updated tests for the new behavior (when applicable). (no shell test harness in the repo)
- [x] `go build ./...` and the test suite pass locally. (no Go changes)
- [ ] For frontend changes: N/A
- [ ] I updated the Wiki / README / API docs if user-facing behavior changed. (none needed)
- [x] My commits follow the project's existing message style.
- [x] I have no unrelated changes mixed into this PR.
