### PR TITLE
fix(frontend): improve dense QR readability

### DIFF
--- a/frontend/src/pages/inbounds/qr/QrPanel.tsx
+++ b/frontend/src/pages/inbounds/qr/QrPanel.tsx
@@ -140,6 +140,8 @@ export default function QrPanel({
               className="qr-code"
               value={value}
               size={size}
+              errorLevel="L"
+              marginSize={4}
               type="svg"
               bordered={false}
               color="#000000"

--- a/frontend/src/test/qr-panel-readable.test.tsx
+++ b/frontend/src/test/qr-panel-readable.test.tsx
@@ -1,0 +1,89 @@
+import { render } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import { genAmneziaWGConfig } from '@/lib/xray/inbound-link';
+import QrPanel from '@/pages/inbounds/qr/QrPanel';
+import { AmneziawgInboundSettingsSchema } from '@/schemas/protocols/inbound/amneziawg';
+
+const KEY = `${'A'.repeat(43)}=`;
+
+function awgConfig(disableCookies: boolean): string {
+  const settings = AmneziawgInboundSettingsSchema.parse({
+    server: {
+      publicKey: KEY,
+      mtu: 1420,
+      primaryDns: '8.8.8.8',
+      secondaryDns: '8.8.4.4',
+      jc: 4,
+      jmin: 65,
+      jmax: 220,
+      s1: 87,
+      s2: 44,
+      s3: 21,
+      s4: 19,
+      h1: '462980921-463150218',
+      h2: '1177681572-1177787900',
+      h3: '1907413509-1907903969',
+      h4: '2029908558-2030313135',
+      i1: '<r 148>',
+      headerProtectionKey: KEY,
+      contentPaddingAddition: '17-49',
+      rekeyAfterTime: '111-139',
+      rekeyTimeout: '4-7',
+      rejectAfterTime: '187-251',
+      keepaliveTimeout: '9-14',
+      maxHandshakeAttempts: '19-36',
+      randomTrailers: true,
+      disableCookies,
+    },
+    clients: [
+      {
+        email: 'my-client',
+        privateKey: KEY,
+        preSharedKey: KEY,
+        allowedIPs: ['10.8.1.2/32'],
+        keepAlive: 25,
+      },
+    ],
+  });
+
+  return genAmneziaWGConfig({
+    settings,
+    address: 'your-server.example.com',
+    port: 443,
+    remark: 'my-client',
+    peerIndex: 0,
+  });
+}
+
+function qrGeometry(value: string): { viewBox: string; foreground: string } {
+  const { container } = render(<QrPanel value={value} />);
+  const svg = container.querySelector('.qr-code svg');
+  const paths = svg?.querySelectorAll('path');
+
+  expect(svg).not.toBeNull();
+  expect(paths).toHaveLength(2);
+
+  return {
+    viewBox: svg?.getAttribute('viewBox') ?? '',
+    foreground: paths?.item(1).getAttribute('d') ?? '',
+  };
+}
+
+describe('QrPanel dense AmneziaWG config', () => {
+  it('keeps the complete 3.1 config readable across the DisableCookies QR boundary', () => {
+    const complete = awgConfig(true);
+    const withoutDisableCookies = awgConfig(false);
+
+    expect(complete).toContain('DisableCookies = on\n');
+    expect(complete.length - withoutDisableCookies.length).toBe(20);
+
+    const completeQr = qrGeometry(complete);
+    const shorterQr = qrGeometry(withoutDisableCookies);
+
+    expect(completeQr.viewBox).toBe('0 0 105 105');
+    expect(shorterQr.viewBox).toBe('0 0 101 101');
+    expect(completeQr.foreground).toMatch(/^M4 4h7/);
+    expect(shorterQr.foreground).toMatch(/^M4 4h7/);
+  });
+});


### PR DESCRIPTION
## Summary

- Render shared config QR codes with low error correction and a standard four-module quiet zone, reducing module density without changing the encoded value.
- Add a regression test that renders a production-generated AmneziaWG 3.1 config across the reporter's 20-byte `DisableCookies` boundary and verifies the resulting SVG geometry.

## Why

The reporter confirmed that the downloaded `.conf` imports successfully, while the QR fails to scan, and that removing only `DisableCookies = on` makes it scannable. The setting itself is valid; removing that line only shortens the payload by 20 bytes.

At the current Ant Design defaults, the complete representative config renders as a 109-module QR with no quiet zone. Using the lower correction level already used by the project's 2FA QR, together with a four-module margin, produces a 105-cell total grid for the complete config while preserving every config byte. The same margin is retained when the SVG is rasterized for image copy/download.

Closes #6388

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactoring (no behavior change)
- [ ] Documentation
- [ ] Tests only
- [ ] Build / CI / tooling
- [ ] Other

## Areas affected

- [x] Frontend (UI / panel pages)
- [ ] Backend (API endpoints, login, settings)
- [ ] Xray config generation
- [ ] Subscription (share links / Clash / JSON)
- [ ] Statistics / traffic counters
- [ ] Database / migrations
- [ ] Install / upgrade script
- [ ] Docker image
- [ ] Multi-node (sub-nodes)
- [ ] Telegram bot

## How was this tested?

- Red-before-fix: the new component test received `viewBox="0 0 109 109"` with foreground modules starting at `(0,0)` instead of the expected margin-aware geometry.
- `npm run test -- --project components src/test/qr-panel-readable.test.tsx`
- Unit and component suites: 102 files, 1,137 tests passed.
- `npm run typecheck`
- `npm run lint`
- `npm run format:check`
- `npm run build`
- `npm run build-storybook`
- `git diff --check`

The automated test uses `genAmneziaWGConfig` and the real `QrPanel`, and checks both the full configuration and the version without the 20-byte line. I did not perform an Android/WG Tunnel camera scan locally; the device-level evidence is the reporter's A/B test in the issue.

## Screenshots / recordings

N/A — the affected QR normally contains private tunnel credentials, and a screenshot cannot demonstrate decoder reliability. The regression test verifies the generated SVG's module grid and quiet zone directly; there is no layout or styling change.

## Breaking changes

None. The encoded configuration, copy action, and `.conf` download are unchanged.

## Checklist

- [x] I tested the change locally and confirmed the described behavior.
- [x] I added a regression test that fails without the fix.
- [x] Go checks are not applicable; no Go files changed.
- [x] `npm run lint`, `npm run typecheck`, `npm run test`, `npm run build`, and `npm run build-storybook` pass.
- [x] Documentation updates are not applicable; no instructions or API behavior changed.
- [x] My commit follows the project's existing message style.
- [x] I have no unrelated changes mixed into this PR.
