### PR TITLE
fix(amneziawg): avoid manager lock inversion

### DIFF
--- a/internal/amneziawgnet/manager.go
+++ b/internal/amneziawgnet/manager.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"strings"
 	"sync"
+	"sync/atomic"
 
 	"github.com/amnezia-vpn/amneziawg-go/v3/device"
 	"gvisor.dev/gvisor/pkg/tcpip/adapters/gonet"
@@ -47,10 +48,34 @@ type managed struct {
 	dev          *Device
 	udpRelay     *UDPRelay
 	portForwards *PortForwardSet
-	peers        *PeerIndex
+	peers        atomic.Pointer[PeerIndex]
 	inst         amneziawg.Instance
 	structFP     string
 	uapiConfig   string
+}
+
+func (m *managed) lookupPeer(addr netip.Addr) (amneziawg.Peer, bool) {
+	peers := m.peers.Load()
+	if peers == nil {
+		return amneziawg.Peer{}, false
+	}
+	return peers.Lookup(addr)
+}
+
+func (m *managed) handleUDP(src, dst netip.AddrPort, payload []byte) {
+	peer, ok := m.lookupPeer(src.Addr())
+	if !ok {
+		return
+	}
+	m.udpRelay.Handle(src, dst, peer.Email, payload)
+}
+
+func (m *managed) close() {
+	m.portForwards.Close()
+	// Stop packet delivery before closing the relay so an in-flight handler
+	// cannot publish a new session after the relay has already been swept.
+	m.dev.Close()
+	m.udpRelay.Close()
 }
 
 // Manager owns the set of running embedded AmneziaWG interfaces, keyed by
@@ -135,7 +160,7 @@ func (m *Manager) ensureLocked(d Desired) error {
 		// buildUAPIConfig actually reads, the way a hand-maintained field
 		// list could.
 		if conf == cur.uapiConfig {
-			cur.peers = NewPeerIndex(inst.Peers)
+			cur.peers.Store(NewPeerIndex(inst.Peers))
 			cur.inst = inst
 			applyV6Aliases(diffV6Aliases(oldInst, inst))
 			// buildUAPIConfig never reads ForwardedPorts (it's a panel-level
@@ -151,7 +176,7 @@ func (m *Manager) ensureLocked(d Desired) error {
 		if err := cur.dev.IpcSet(conf); err != nil {
 			return fmt.Errorf("amneziawgnet: reconfigure inbound %d: %w", inst.Id, err)
 		}
-		cur.peers = NewPeerIndex(inst.Peers)
+		cur.peers.Store(NewPeerIndex(inst.Peers))
 		cur.inst = inst
 		cur.uapiConfig = conf
 		applyV6Aliases(diffV6Aliases(oldInst, inst))
@@ -160,9 +185,7 @@ func (m *Manager) ensureLocked(d Desired) error {
 	}
 
 	if exists {
-		cur.udpRelay.Close()
-		cur.portForwards.Close()
-		cur.dev.Close()
+		cur.close()
 		delete(m.ifaces, inst.Id)
 	}
 	dev, err := newUnconfiguredDevice(inst, opts)
@@ -173,40 +196,30 @@ func (m *Manager) ensureLocked(d Desired) error {
 	relay := socksRelayForInstance(inst)
 	udpRelay := NewUDPRelay(relay, dev.Stack)
 	portForwards := NewPortForwardSet(dev.Stack, inst.Id)
-	inboundID := inst.Id // captured for the closures below, which outlive this call
+	next := &managed{
+		dev:          dev,
+		udpRelay:     udpRelay,
+		portForwards: portForwards,
+		inst:         inst,
+		structFP:     structFP,
+	}
+	next.peers.Store(NewPeerIndex(inst.Peers))
 	AttachTCPForwarder(dev.Stack, func(conn *gonet.TCPConn, dest netip.AddrPort) {
 		srcAddrPort, err := netip.ParseAddrPort(conn.RemoteAddr().String())
 		if err != nil {
 			conn.Close()
 			return
 		}
-		// Re-fetched on every connection, not captured once at attach time:
-		// a reconfigure-in-place (peers added/removed, no rebuild) replaces
-		// cur.peers without ever re-attaching the forwarder, so a stale
-		// captured index would silently miss newly-added peers.
-		_, peers, ok := m.Lookup(inboundID)
-		if !ok {
-			conn.Close()
-			return
-		}
-		peer, ok := peers.Lookup(srcAddrPort.Addr().Unmap())
+		// Load the latest immutable peer snapshot without entering the
+		// lifecycle lock held while a device reconfigures or closes.
+		peer, ok := next.lookupPeer(srcAddrPort.Addr().Unmap())
 		if !ok {
 			conn.Close()
 			return
 		}
 		relay.RelayTCP(conn, peer.Email, dest)
 	})
-	AttachUDPHandler(dev.Stack, func(src, dst netip.AddrPort, payload []byte) {
-		_, peers, ok := m.Lookup(inboundID)
-		if !ok {
-			return
-		}
-		peer, ok := peers.Lookup(src.Addr())
-		if !ok {
-			return
-		}
-		udpRelay.Handle(src, dst, peer.Email, payload)
-	})
+	AttachUDPHandler(dev.Stack, next.handleUDP)
 
 	// Handlers are registered on dev.Stack above, BEFORE Configure's IpcSet
 	// can start any peer's receive goroutine -- see newUnconfiguredDevice's
@@ -224,16 +237,8 @@ func (m *Manager) ensureLocked(d Desired) error {
 	// the no-op check above a correct baseline to compare the next tick
 	// against instead of an empty string.
 	conf, _ := buildUAPIConfig(inst, opts)
-
-	m.ifaces[inst.Id] = &managed{
-		dev:          dev,
-		udpRelay:     udpRelay,
-		portForwards: portForwards,
-		peers:        NewPeerIndex(inst.Peers),
-		inst:         inst,
-		structFP:     structFP,
-		uapiConfig:   conf,
-	}
+	next.uapiConfig = conf
+	m.ifaces[inst.Id] = next
 	applyV6Aliases(diffV6Aliases(oldInst, inst))
 	portForwards.Reconcile(inst)
 	logger.Infof("amneziawgnet: started embedded interface %s for inbound %d", inst.InterfaceName, inst.Id)
@@ -275,9 +280,7 @@ func (m *Manager) Reconcile(desired []Desired) {
 			continue
 		}
 		applyV6Aliases(diffV6Aliases(cur.inst, amneziawg.Instance{}))
-		cur.udpRelay.Close()
-		cur.portForwards.Close()
-		cur.dev.Close()
+		cur.close()
 		delete(m.ifaces, id)
 		logger.Infof("amneziawgnet: stopped embedded interface for removed inbound %d", id)
 	}
@@ -300,9 +303,7 @@ func (m *Manager) Remove(id int) {
 		return
 	}
 	applyV6Aliases(diffV6Aliases(cur.inst, amneziawg.Instance{}))
-	cur.udpRelay.Close()
-	cur.portForwards.Close()
-	cur.dev.Close()
+	cur.close()
 	delete(m.ifaces, id)
 	logger.Infof("amneziawgnet: stopped embedded interface for removed inbound %d", id)
 }
@@ -313,9 +314,7 @@ func (m *Manager) StopAll() {
 	defer m.mu.Unlock()
 	for id, cur := range m.ifaces {
 		applyV6Aliases(diffV6Aliases(cur.inst, amneziawg.Instance{}))
-		cur.udpRelay.Close()
-		cur.portForwards.Close()
-		cur.dev.Close()
+		cur.close()
 		delete(m.ifaces, id)
 	}
 }
@@ -327,11 +326,8 @@ func (m *Manager) HasRunning() bool {
 	return len(m.ifaces) > 0
 }
 
-// Lookup returns the running Device and PeerIndex for inbound id, if any --
-// the forwarder/UDP-handler closures ensureLocked attaches use this to
-// re-fetch the current peer index on every connection (see ensureLocked's
-// comment on why), and it's equally available to a test harness or any
-// other caller that wants read access to a managed interface's state.
+// Lookup returns the running device and current peer snapshot for diagnostics,
+// tests, and other callers outside the packet-delivery path.
 func (m *Manager) Lookup(id int) (dev *Device, peers *PeerIndex, ok bool) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
@@ -339,5 +335,5 @@ func (m *Manager) Lookup(id int) (dev *Device, peers *PeerIndex, ok bool) {
 	if !exists {
 		return nil, nil, false
 	}
-	return cur.dev, cur.peers, true
+	return cur.dev, cur.peers.Load(), true
 }

--- a/internal/amneziawgnet/manager.go
+++ b/internal/amneziawgnet/manager.go
@@ -210,8 +210,8 @@ func (m *Manager) ensureLocked(d Desired) error {
 			conn.Close()
 			return
 		}
-		// Load the latest immutable peer snapshot without entering the
-		// lifecycle lock held while a device reconfigures or closes.
+		// Reload for every connection: in-place reconfiguration swaps the peer
+		// index without reattaching handlers and may hold the lifecycle lock.
 		peer, ok := next.lookupPeer(srcAddrPort.Addr().Unmap())
 		if !ok {
 			conn.Close()

--- a/internal/amneziawgnet/manager_test.go
+++ b/internal/amneziawgnet/manager_test.go
@@ -91,9 +91,12 @@ func TestManagerLifecycle(t *testing.T) {
 }
 
 func TestManagedUDPHandlerDoesNotWaitForManagerLock(t *testing.T) {
-	cur := &managed{}
-	cur.peers.Store(NewPeerIndex(nil))
-	m := &Manager{ifaces: map[int]*managed{10: cur}}
+	cur := &managed{udpRelay: NewUDPRelay(SocksRelay{Addr: "invalid"}, nil)}
+	cur.peers.Store(NewPeerIndex([]amneziawg.Peer{{
+		Email:      "peer@test",
+		AllowedIPs: []string{"10.210.0.2/32"},
+	}}))
+	m := &Manager{}
 
 	done := make(chan struct{})
 	m.mu.Lock()
@@ -101,7 +104,7 @@ func TestManagedUDPHandlerDoesNotWaitForManagerLock(t *testing.T) {
 		cur.handleUDP(
 			netip.MustParseAddrPort("10.210.0.2:1234"),
 			netip.MustParseAddrPort("10.210.0.3:53"),
-			nil,
+			[]byte("query"),
 		)
 		close(done)
 	}()

--- a/internal/amneziawgnet/manager_test.go
+++ b/internal/amneziawgnet/manager_test.go
@@ -3,6 +3,7 @@ package amneziawgnet
 import (
 	"fmt"
 	"net"
+	"net/netip"
 	"testing"
 	"time"
 
@@ -86,6 +87,31 @@ func TestManagerLifecycle(t *testing.T) {
 	}
 	if _, _, ok := m.Lookup(inst.Id); ok {
 		t.Error("Lookup succeeded after Reconcile([]) removed the interface")
+	}
+}
+
+func TestManagedUDPHandlerDoesNotWaitForManagerLock(t *testing.T) {
+	cur := &managed{}
+	cur.peers.Store(NewPeerIndex(nil))
+	m := &Manager{ifaces: map[int]*managed{10: cur}}
+
+	done := make(chan struct{})
+	m.mu.Lock()
+	go func() {
+		cur.handleUDP(
+			netip.MustParseAddrPort("10.210.0.2:1234"),
+			netip.MustParseAddrPort("10.210.0.3:53"),
+			nil,
+		)
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		m.mu.Unlock()
+	case <-time.After(time.Second):
+		m.mu.Unlock()
+		t.Fatal("UDP handler blocked on the manager lifecycle lock")
 	}
 }
 


### PR DESCRIPTION
## Summary

Prevent embedded AmneziaWG updates from deadlocking with active UDP traffic by keeping packet-path peer lookup independent from the manager lifecycle lock.

## Why

`Manager.Ensure`, `Reconcile`, `Remove`, and `StopAll` serialize device mutations with `Manager.mu`. The UDP receive handler previously called `Manager.Lookup`, which tried to acquire that same mutex while `IpcSet` or `Device.Close` could be waiting for the receive goroutine to exit.

This change publishes immutable peer indexes through an atomic pointer owned by each managed device. TCP and UDP handlers read that snapshot directly, while lifecycle operations remain serialized. Teardown now stops packet delivery before closing UDP relay sessions so an in-flight handler cannot recreate a session after cleanup.

Closes #6368

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactoring (no behavior change)
- [ ] Documentation
- [ ] Tests only
- [ ] Build / CI / tooling
- [ ] Other

## Areas affected

- [ ] Frontend (UI / panel pages)
- [x] Backend (API endpoints, login, settings)
- [ ] Xray config generation
- [ ] Subscription (share links / Clash / JSON)
- [ ] Statistics / traffic counters
- [ ] Database / migrations
- [ ] Install / upgrade script
- [ ] Docker image
- [ ] Multi-node (sub-nodes)
- [ ] Telegram bot

## How was this tested?

- Added a regression test that calls the production UDP handler while the manager lifecycle lock is held.
- `go test ./internal/amneziawgnet -run TestManagedUDPHandlerDoesNotWaitForManagerLock -count=50`
- `go test -shuffle=on -count=1 ./internal/amneziawgnet`
- `go test -race -shuffle=on -count=1 ./internal/amneziawgnet`
- `make test-go`
- `go vet ./internal/amneziawgnet`
- `go build ./...`

## Screenshots / recordings

N/A

## Breaking changes

None.

## Checklist

- [x] I tested the change locally and confirmed the described behavior.
- [x] I added or updated tests for the new behavior (when applicable).
- [x] `go build ./...` and the test suite pass locally.
- [x] For frontend changes: not applicable; this PR does not touch the frontend.
- [x] I updated the Wiki / README / API docs if user-facing behavior changed (not applicable).
- [x] My commits follow the project's existing message style.
- [x] I have no unrelated changes mixed into this PR.
