### PR TITLE
fix(geofile): verify downloaded geo databases against published digests

### DIFF
--- a/internal/web/service/server.go
+++ b/internal/web/service/server.go
@@ -21,6 +21,7 @@ import (
 	"net/url"
 	"os"
 	"os/exec"
+	"path"
 	"path/filepath"
 	"regexp"
 	"runtime"
@@ -2167,20 +2168,28 @@ func (s *ServerService) IsValidGeofileName(filename string) bool {
 	return matched
 }
 
-func (s *ServerService) UpdateGeofile(fileName string) error {
-	type geofileEntry struct {
-		URL      string
-		FileName string
-	}
-	geofileAllowlist := map[string]geofileEntry{
-		"geoip.dat":      {"https://github.com/Loyalsoldier/v2ray-rules-dat/releases/latest/download/geoip.dat", "geoip.dat"},
-		"geosite.dat":    {"https://github.com/Loyalsoldier/v2ray-rules-dat/releases/latest/download/geosite.dat", "geosite.dat"},
-		"geoip_IR.dat":   {"https://github.com/chocolate4u/Iran-v2ray-rules/releases/latest/download/geoip.dat", "geoip_IR.dat"},
-		"geosite_IR.dat": {"https://github.com/chocolate4u/Iran-v2ray-rules/releases/latest/download/geosite.dat", "geosite_IR.dat"},
-		"geoip_RU.dat":   {"https://github.com/runetfreedom/russia-v2ray-rules-dat/releases/latest/download/geoip.dat", "geoip_RU.dat"},
-		"geosite_RU.dat": {"https://github.com/runetfreedom/russia-v2ray-rules-dat/releases/latest/download/geosite.dat", "geosite_RU.dat"},
-	}
+type geofileEntry struct {
+	URL      string
+	FileName string
+}
 
+// geofileAllowlist maps the local database name to its upstream release asset.
+// Three upstreams all publish "geoip.dat"/"geosite.dat", so only the local name
+// tells them apart.
+var geofileAllowlist = map[string]geofileEntry{
+	"geoip.dat":      {"https://github.com/Loyalsoldier/v2ray-rules-dat/releases/latest/download/geoip.dat", "geoip.dat"},
+	"geosite.dat":    {"https://github.com/Loyalsoldier/v2ray-rules-dat/releases/latest/download/geosite.dat", "geosite.dat"},
+	"geoip_IR.dat":   {"https://github.com/chocolate4u/Iran-v2ray-rules/releases/latest/download/geoip.dat", "geoip_IR.dat"},
+	"geosite_IR.dat": {"https://github.com/chocolate4u/Iran-v2ray-rules/releases/latest/download/geosite.dat", "geosite_IR.dat"},
+	"geoip_RU.dat":   {"https://github.com/runetfreedom/russia-v2ray-rules-dat/releases/latest/download/geoip.dat", "geoip_RU.dat"},
+	"geosite_RU.dat": {"https://github.com/runetfreedom/russia-v2ray-rules-dat/releases/latest/download/geosite.dat", "geosite_RU.dat"},
+}
+
+// restartXrayAfterGeofileUpdate is a seam: tests assert that an update which
+// installed nothing also restarted nothing.
+var restartXrayAfterGeofileUpdate = (*ServerService).RestartXrayService
+
+func (s *ServerService) UpdateGeofile(fileName string) error {
 	// Strict allowlist check to avoid writing uncontrolled files
 	if fileName != "" {
 		if _, ok := geofileAllowlist[fileName]; !ok {
@@ -2188,103 +2197,173 @@ func (s *ServerService) UpdateGeofile(fileName string) error {
 		}
 	}
 
+	wanted := geofileAllowlist
+	if fileName != "" {
+		wanted = map[string]geofileEntry{fileName: geofileAllowlist[fileName]}
+	}
+
+	binFolder := config.GetBinFolderPath()
+	stageDir, err := os.MkdirTemp(binFolder, "geofile-")
+	if err != nil {
+		return common.NewErrorf("Failed to create staging folder for Geofiles: %v", err)
+	}
+	defer os.RemoveAll(stageDir)
+
 	client := s.settingService.NewProxiedHTTPClient(0)
 
-	downloadFile := func(url, destPath string) error {
-		var req *http.Request
-		req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, url, nil)
+	// Verify every database before installing any of them: a half-applied update
+	// leaves the core running databases from two different releases.
+	staged := make(map[string]string, len(wanted))
+	for _, entry := range wanted {
+		destPath := filepath.Join(binFolder, entry.FileName)
+		stagePath := filepath.Join(stageDir, entry.FileName)
+		changed, err := s.stageGeofile(client, entry, destPath, stagePath)
 		if err != nil {
-			return common.NewErrorf("Failed to create HTTP request for %s: %v", url, err)
+			return common.NewErrorf("Error downloading Geofile '%s': %v", entry.FileName, err)
 		}
-
-		var localFileModTime time.Time
-		if fileInfo, err := os.Stat(destPath); err == nil {
-			localFileModTime = fileInfo.ModTime()
-			if !localFileModTime.IsZero() {
-				req.Header.Set("If-Modified-Since", localFileModTime.UTC().Format(http.TimeFormat))
-			}
+		if changed {
+			staged[destPath] = stagePath
 		}
+	}
 
-		resp, err := client.Do(req)
-		if err != nil {
-			return common.NewErrorf("Failed to download Geofile from %s: %v", url, err)
-		}
-		defer resp.Body.Close()
-
-		// Parse Last-Modified header from server
-		var serverModTime time.Time
-		serverModTimeStr := resp.Header.Get("Last-Modified")
-		if serverModTimeStr != "" {
-			parsedTime, err := time.Parse(http.TimeFormat, serverModTimeStr)
-			if err != nil {
-				logger.Warningf("Failed to parse Last-Modified header for %s: %v", url, err)
-			} else {
-				serverModTime = parsedTime
-			}
-		}
-
-		// Function to update local file's modification time
-		updateFileModTime := func() {
-			if !serverModTime.IsZero() {
-				if err := os.Chtimes(destPath, serverModTime, serverModTime); err != nil {
-					logger.Warningf("Failed to update modification time for %s: %v", destPath, err)
-				}
-			}
-		}
-
-		// Handle 304 Not Modified
-		if resp.StatusCode == http.StatusNotModified {
-			updateFileModTime()
-			return nil
-		}
-
-		if resp.StatusCode != http.StatusOK {
-			return common.NewErrorf("Failed to download Geofile from %s: received status code %d", url, resp.StatusCode)
-		}
-
-		file, err := os.Create(destPath)
-		if err != nil {
-			return common.NewErrorf("Failed to create Geofile %s: %v", destPath, err)
-		}
-		defer file.Close()
-
-		_, err = io.Copy(file, resp.Body)
-		if err != nil {
-			return common.NewErrorf("Failed to save Geofile %s: %v", destPath, err)
-		}
-
-		updateFileModTime()
+	// Every upstream answered 304, so there is nothing to install and no reason
+	// to restart the core and drop every client connection.
+	if len(staged) == 0 {
 		return nil
 	}
 
-	var errorMessages []string
-
-	if fileName == "" {
-		// Download all geofiles
-		for _, entry := range geofileAllowlist {
-			destPath := filepath.Join(config.GetBinFolderPath(), entry.FileName)
-			if err := downloadFile(entry.URL, destPath); err != nil {
-				errorMessages = append(errorMessages, fmt.Sprintf("Error downloading Geofile '%s': %v", entry.FileName, err))
-			}
-		}
-	} else {
-		entry := geofileAllowlist[fileName]
-		destPath := filepath.Join(config.GetBinFolderPath(), entry.FileName)
-		if err := downloadFile(entry.URL, destPath); err != nil {
-			errorMessages = append(errorMessages, fmt.Sprintf("Error downloading Geofile '%s': %v", entry.FileName, err))
+	for destPath, stagePath := range staged {
+		if err := os.Rename(stagePath, destPath); err != nil {
+			return common.NewErrorf("Failed to install Geofile %s: %v", destPath, err)
 		}
 	}
 
-	err := s.RestartXrayService()
-	if err != nil {
-		errorMessages = append(errorMessages, fmt.Sprintf("Updated Geofile '%s' but Failed to start Xray: %v", fileName, err))
-	}
-
-	if len(errorMessages) > 0 {
-		return common.NewErrorf("%s", strings.Join(errorMessages, "\r\n"))
+	if err := restartXrayAfterGeofileUpdate(s); err != nil {
+		return common.NewErrorf("Updated Geofile '%s' but Failed to start Xray: %v", fileName, err)
 	}
 
 	return nil
+}
+
+// stageGeofile downloads one database into stagePath and checks it against the
+// SHA-256 its upstream publishes. It reports false on 304, staging nothing.
+func (s *ServerService) stageGeofile(client *http.Client, entry geofileEntry, destPath, stagePath string) (bool, error) {
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, entry.URL, nil)
+	if err != nil {
+		return false, common.NewErrorf("Failed to create HTTP request for %s: %v", entry.URL, err)
+	}
+
+	if fileInfo, err := os.Stat(destPath); err == nil {
+		if localFileModTime := fileInfo.ModTime(); !localFileModTime.IsZero() {
+			req.Header.Set("If-Modified-Since", localFileModTime.UTC().Format(http.TimeFormat))
+		}
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return false, common.NewErrorf("Failed to download Geofile from %s: %v", entry.URL, err)
+	}
+	defer resp.Body.Close()
+
+	// Parse Last-Modified header from server
+	var serverModTime time.Time
+	if serverModTimeStr := resp.Header.Get("Last-Modified"); serverModTimeStr != "" {
+		parsedTime, err := time.Parse(http.TimeFormat, serverModTimeStr)
+		if err != nil {
+			logger.Warningf("Failed to parse Last-Modified header for %s: %v", entry.URL, err)
+		} else {
+			serverModTime = parsedTime
+		}
+	}
+
+	// The conditional GET above reads this back, so it must survive the rename.
+	setModTime := func(target string) {
+		if !serverModTime.IsZero() {
+			if err := os.Chtimes(target, serverModTime, serverModTime); err != nil {
+				logger.Warningf("Failed to update modification time for %s: %v", target, err)
+			}
+		}
+	}
+
+	// Handle 304 Not Modified
+	if resp.StatusCode == http.StatusNotModified {
+		setModTime(destPath)
+		return false, nil
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return false, common.NewErrorf("Failed to download Geofile from %s: received status code %d", entry.URL, resp.StatusCode)
+	}
+
+	file, err := os.Create(stagePath)
+	if err != nil {
+		return false, common.NewErrorf("Failed to create Geofile %s: %v", stagePath, err)
+	}
+	hasher := sha256.New()
+	if _, err := io.Copy(io.MultiWriter(file, hasher), resp.Body); err != nil {
+		file.Close()
+		return false, common.NewErrorf("Failed to save Geofile %s: %v", stagePath, err)
+	}
+	if err := file.Close(); err != nil {
+		return false, common.NewErrorf("Failed to save Geofile %s: %v", stagePath, err)
+	}
+
+	// TLS protects the transport, not the artifact. Xray parses these databases
+	// when it builds its routing matchers, so a bad one takes the core down.
+	want, err := s.fetchGeofileDigest(client, entry.URL+".sha256sum", path.Base(entry.URL))
+	if err != nil {
+		return false, err
+	}
+	if got := hex.EncodeToString(hasher.Sum(nil)); !strings.EqualFold(got, want) {
+		return false, common.NewErrorf("does not match the published SHA-256 checksum, so the download is corrupted or has been tampered with (expected %s, got %s)", want, got)
+	}
+
+	setModTime(stagePath)
+	return true, nil
+}
+
+// fetchGeofileDigest downloads the .sha256sum sidecar published beside a geo
+// database and returns the digest it lists for assetName.
+func (s *ServerService) fetchGeofileDigest(client *http.Client, sumsURL, assetName string) (string, error) {
+	req, reqErr := http.NewRequestWithContext(context.Background(), http.MethodGet, sumsURL, nil)
+	if reqErr != nil {
+		return "", fmt.Errorf("download geofile checksum: %w", reqErr)
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("download geofile checksum: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("download geofile checksum: unexpected HTTP %d", resp.StatusCode)
+	}
+	raw, err := io.ReadAll(io.LimitReader(resp.Body, maxXrayDigestBytes))
+	if err != nil {
+		return "", fmt.Errorf("download geofile checksum: %w", err)
+	}
+	return parseGeofileDigest(raw, assetName)
+}
+
+// parseGeofileDigest returns the SHA-256 hex a sha256sum sidecar lists for
+// assetName. Upstreams record different paths for it ("geoip.dat" against
+// "release/geoip.dat"), so match the base name, not the recorded one.
+func parseGeofileDigest(sums []byte, assetName string) (string, error) {
+	for line := range strings.SplitSeq(string(sums), "\n") {
+		fields := strings.Fields(line)
+		if len(fields) != 2 {
+			continue
+		}
+		// A leading "*" is sha256sum's own binary-mode marker, not part of the name.
+		if path.Base(strings.TrimPrefix(fields[1], "*")) != assetName {
+			continue
+		}
+		digest := strings.ToLower(fields[0])
+		if _, err := hex.DecodeString(digest); err != nil || len(digest) != sha256.Size*2 {
+			return "", fmt.Errorf("geofile checksum: malformed SHA-256 entry for %s", assetName)
+		}
+		return digest, nil
+	}
+	return "", fmt.Errorf("geofile checksum: no SHA-256 entry for %s", assetName)
 }
 
 // parseXrayKeyPairOutput reads the two-line "Label: value" output that xray's

--- a/internal/web/service/server.go
+++ b/internal/web/service/server.go
@@ -14,6 +14,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"maps"
 	"math"
 	"mime/multipart"
 	stdnet "net"
@@ -2168,21 +2169,35 @@ func (s *ServerService) IsValidGeofileName(filename string) bool {
 	return matched
 }
 
+// Repo is the upstream release base and Asset the name it publishes under; all
+// three publish "geoip.dat", so only FileName tells the local copies apart.
 type geofileEntry struct {
-	URL      string
+	Repo     string
+	Asset    string
 	FileName string
 }
 
-// geofileAllowlist maps the local database name to its upstream release asset.
-// Three upstreams all publish "geoip.dat"/"geosite.dat", so only the local name
-// tells them apart.
 var geofileAllowlist = map[string]geofileEntry{
-	"geoip.dat":      {"https://github.com/Loyalsoldier/v2ray-rules-dat/releases/latest/download/geoip.dat", "geoip.dat"},
-	"geosite.dat":    {"https://github.com/Loyalsoldier/v2ray-rules-dat/releases/latest/download/geosite.dat", "geosite.dat"},
-	"geoip_IR.dat":   {"https://github.com/chocolate4u/Iran-v2ray-rules/releases/latest/download/geoip.dat", "geoip_IR.dat"},
-	"geosite_IR.dat": {"https://github.com/chocolate4u/Iran-v2ray-rules/releases/latest/download/geosite.dat", "geosite_IR.dat"},
-	"geoip_RU.dat":   {"https://github.com/runetfreedom/russia-v2ray-rules-dat/releases/latest/download/geoip.dat", "geoip_RU.dat"},
-	"geosite_RU.dat": {"https://github.com/runetfreedom/russia-v2ray-rules-dat/releases/latest/download/geosite.dat", "geosite_RU.dat"},
+	"geoip.dat":      {"https://github.com/Loyalsoldier/v2ray-rules-dat", "geoip.dat", "geoip.dat"},
+	"geosite.dat":    {"https://github.com/Loyalsoldier/v2ray-rules-dat", "geosite.dat", "geosite.dat"},
+	"geoip_IR.dat":   {"https://github.com/chocolate4u/Iran-v2ray-rules", "geoip.dat", "geoip_IR.dat"},
+	"geosite_IR.dat": {"https://github.com/chocolate4u/Iran-v2ray-rules", "geosite.dat", "geosite_IR.dat"},
+	"geoip_RU.dat":   {"https://github.com/runetfreedom/russia-v2ray-rules-dat", "geoip.dat", "geoip_RU.dat"},
+	"geosite_RU.dat": {"https://github.com/runetfreedom/russia-v2ray-rules-dat", "geosite.dat", "geosite_RU.dat"},
+}
+
+func (entry geofileEntry) latestURL() string {
+	return entry.Repo + "/releases/latest/download/" + entry.Asset
+}
+
+func (entry geofileEntry) taggedURL(tag string) string {
+	return entry.Repo + "/releases/download/" + tag + "/" + entry.Asset
+}
+
+// stagedGeofile is a verified download waiting to be moved into the asset folder.
+type stagedGeofile struct {
+	destPath  string
+	stagePath string
 }
 
 // restartXrayAfterGeofileUpdate is a seam: tests assert that an update which
@@ -2202,6 +2217,14 @@ func (s *ServerService) UpdateGeofile(fileName string) error {
 		wanted = map[string]geofileEntry{fileName: geofileAllowlist[fileName]}
 	}
 
+	// Atomic per upstream, not across all six: one release's databases belong
+	// together, but a failing repo must not discard another repo's good files.
+	byRepo := make(map[string][]geofileEntry, len(wanted))
+	for _, entry := range wanted {
+		byRepo[entry.Repo] = append(byRepo[entry.Repo], entry)
+	}
+	repos := slices.Sorted(maps.Keys(byRepo))
+
 	binFolder := config.GetBinFolderPath()
 	stageDir, err := os.MkdirTemp(binFolder, "geofile-")
 	if err != nil {
@@ -2211,46 +2234,112 @@ func (s *ServerService) UpdateGeofile(fileName string) error {
 
 	client := s.settingService.NewProxiedHTTPClient(0)
 
-	// Verify every database before installing any of them: a half-applied update
-	// leaves the core running databases from two different releases.
-	staged := make(map[string]string, len(wanted))
-	for _, entry := range wanted {
-		destPath := filepath.Join(binFolder, entry.FileName)
-		stagePath := filepath.Join(stageDir, entry.FileName)
-		changed, err := s.stageGeofile(client, entry, destPath, stagePath)
+	var errorMessages []string
+	installed := 0
+	for _, repo := range repos {
+		entries := byRepo[repo]
+		slices.SortFunc(entries, func(a, b geofileEntry) int { return strings.Compare(a.FileName, b.FileName) })
+
+		staged, err := s.stageGeofileRelease(client, entries, binFolder, stageDir)
 		if err != nil {
-			return common.NewErrorf("Error downloading Geofile '%s': %v", entry.FileName, err)
+			errorMessages = append(errorMessages, err.Error())
+			continue
 		}
-		if changed {
-			staged[destPath] = stagePath
-		}
-	}
-
-	// Every upstream answered 304, so there is nothing to install and no reason
-	// to restart the core and drop every client connection.
-	if len(staged) == 0 {
-		return nil
-	}
-
-	for destPath, stagePath := range staged {
-		if err := os.Rename(stagePath, destPath); err != nil {
-			return common.NewErrorf("Failed to install Geofile %s: %v", destPath, err)
+		for _, file := range staged {
+			if err := os.Rename(file.stagePath, file.destPath); err != nil {
+				errorMessages = append(errorMessages, fmt.Sprintf("Failed to install Geofile %s: %v", file.destPath, err))
+				continue
+			}
+			installed++
 		}
 	}
 
-	if err := restartXrayAfterGeofileUpdate(s); err != nil {
-		return common.NewErrorf("Updated Geofile '%s' but Failed to start Xray: %v", fileName, err)
+	// Nothing changed, so there is no reason to restart the core and drop every
+	// client connection.
+	if installed > 0 {
+		if err := restartXrayAfterGeofileUpdate(s); err != nil {
+			errorMessages = append(errorMessages, fmt.Sprintf("Updated Geofiles but Failed to start Xray: %v", err))
+		}
+	}
+
+	if len(errorMessages) > 0 {
+		return common.NewErrorf("%s", strings.Join(errorMessages, "\r\n"))
 	}
 
 	return nil
 }
 
+// stageGeofileRelease downloads one upstream's databases and verifies each
+// against a digest from the same release, staging all of them or none.
+func (s *ServerService) stageGeofileRelease(client *http.Client, entries []geofileEntry, binFolder, stageDir string) ([]stagedGeofile, error) {
+	// Resolve "latest" once. These upstreams publish several times a day, and a
+	// release landing mid-batch would check one release's digest against another's bytes.
+	tag, err := resolveGeofileTag(client, entries[0].latestURL())
+	if err != nil {
+		return nil, common.NewErrorf("Error resolving Geofile release from %s: %v", entries[0].Repo, err)
+	}
+
+	var staged []stagedGeofile
+	for _, entry := range entries {
+		destPath := filepath.Join(binFolder, entry.FileName)
+		stagePath := filepath.Join(stageDir, entry.FileName)
+		changed, err := s.stageGeofile(client, entry, tag, destPath, stagePath)
+		if err != nil {
+			return nil, common.NewErrorf("Error downloading Geofile '%s': %v", entry.FileName, err)
+		}
+		if changed {
+			staged = append(staged, stagedGeofile{destPath: destPath, stagePath: stagePath})
+		}
+	}
+	return staged, nil
+}
+
+// resolveGeofileTag reads the immutable release tag a `latest` download
+// redirects to, so the asset and its digest cannot come from two releases.
+func resolveGeofileTag(client *http.Client, latestURL string) (string, error) {
+	pinned := *client
+	pinned.CheckRedirect = func(*http.Request, []*http.Request) error { return http.ErrUseLastResponse }
+
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, latestURL, nil)
+	if err != nil {
+		return "", err
+	}
+	resp, err := pinned.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+	_, _ = io.Copy(io.Discard, resp.Body)
+
+	location := resp.Header.Get("Location")
+	if location == "" {
+		return "", common.NewErrorf("expected a redirect to a tagged release, got HTTP %d", resp.StatusCode)
+	}
+	return geofileTagFromLocation(location)
+}
+
+// geofileTagFromLocation pulls <tag> out of a .../releases/download/<tag>/<asset>
+// redirect target.
+func geofileTagFromLocation(location string) (string, error) {
+	const marker = "/releases/download/"
+	idx := strings.Index(location, marker)
+	if idx < 0 {
+		return "", common.NewErrorf("unexpected release redirect %q", location)
+	}
+	tag, _, found := strings.Cut(location[idx+len(marker):], "/")
+	if !found || tag == "" {
+		return "", common.NewErrorf("unexpected release redirect %q", location)
+	}
+	return tag, nil
+}
+
 // stageGeofile downloads one database into stagePath and checks it against the
 // SHA-256 its upstream publishes. It reports false on 304, staging nothing.
-func (s *ServerService) stageGeofile(client *http.Client, entry geofileEntry, destPath, stagePath string) (bool, error) {
-	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, entry.URL, nil)
+func (s *ServerService) stageGeofile(client *http.Client, entry geofileEntry, tag, destPath, stagePath string) (bool, error) {
+	assetURL := entry.taggedURL(tag)
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, assetURL, nil)
 	if err != nil {
-		return false, common.NewErrorf("Failed to create HTTP request for %s: %v", entry.URL, err)
+		return false, common.NewErrorf("Failed to create HTTP request for %s: %v", assetURL, err)
 	}
 
 	if fileInfo, err := os.Stat(destPath); err == nil {
@@ -2261,7 +2350,7 @@ func (s *ServerService) stageGeofile(client *http.Client, entry geofileEntry, de
 
 	resp, err := client.Do(req)
 	if err != nil {
-		return false, common.NewErrorf("Failed to download Geofile from %s: %v", entry.URL, err)
+		return false, common.NewErrorf("Failed to download Geofile from %s: %v", assetURL, err)
 	}
 	defer resp.Body.Close()
 
@@ -2270,7 +2359,7 @@ func (s *ServerService) stageGeofile(client *http.Client, entry geofileEntry, de
 	if serverModTimeStr := resp.Header.Get("Last-Modified"); serverModTimeStr != "" {
 		parsedTime, err := time.Parse(http.TimeFormat, serverModTimeStr)
 		if err != nil {
-			logger.Warningf("Failed to parse Last-Modified header for %s: %v", entry.URL, err)
+			logger.Warningf("Failed to parse Last-Modified header for %s: %v", assetURL, err)
 		} else {
 			serverModTime = parsedTime
 		}
@@ -2292,7 +2381,7 @@ func (s *ServerService) stageGeofile(client *http.Client, entry geofileEntry, de
 	}
 
 	if resp.StatusCode != http.StatusOK {
-		return false, common.NewErrorf("Failed to download Geofile from %s: received status code %d", entry.URL, resp.StatusCode)
+		return false, common.NewErrorf("Failed to download Geofile from %s: received status code %d", assetURL, resp.StatusCode)
 	}
 
 	file, err := os.Create(stagePath)
@@ -2310,7 +2399,7 @@ func (s *ServerService) stageGeofile(client *http.Client, entry geofileEntry, de
 
 	// TLS protects the transport, not the artifact. Xray parses these databases
 	// when it builds its routing matchers, so a bad one takes the core down.
-	want, err := s.fetchGeofileDigest(client, entry.URL+".sha256sum", path.Base(entry.URL))
+	want, err := s.fetchGeofileDigest(client, assetURL+".sha256sum", entry.Asset)
 	if err != nil {
 		return false, err
 	}
@@ -2344,9 +2433,8 @@ func (s *ServerService) fetchGeofileDigest(client *http.Client, sumsURL, assetNa
 	return parseGeofileDigest(raw, assetName)
 }
 
-// parseGeofileDigest returns the SHA-256 hex a sha256sum sidecar lists for
-// assetName. Upstreams record different paths for it ("geoip.dat" against
-// "release/geoip.dat"), so match the base name, not the recorded one.
+// parseGeofileDigest returns the SHA-256 hex a sidecar lists for assetName,
+// matching on base name since upstreams record "geoip.dat" or "release/geoip.dat".
 func parseGeofileDigest(sums []byte, assetName string) (string, error) {
 	for line := range strings.SplitSeq(string(sums), "\n") {
 		fields := strings.Fields(line)

--- a/internal/web/service/server_geofile_test.go
+++ b/internal/web/service/server_geofile_test.go
@@ -9,14 +9,14 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/mhsanaei/3x-ui/v3/internal/database"
 )
 
-// The three upstreams record the asset differently in their .sha256sum files:
-// Loyalsoldier and runetfreedom write "geoip.dat", chocolate4u writes
-// "release/geoip.dat" — the path from its own build.
+// Loyalsoldier and runetfreedom write "<hash>  geoip.dat"; chocolate4u writes
+// "<hash>  release/geoip.dat", the path from its own build.
 func TestParseGeofileDigest(t *testing.T) {
 	const digest = "0d5d2ba0c5a5c58027fd1347a6afd57c9470799b6bb3cbc274fd4657ed8de382"
 
@@ -48,27 +48,94 @@ func TestParseGeofileDigest_Errors(t *testing.T) {
 	const digest = "0d5d2ba0c5a5c58027fd1347a6afd57c9470799b6bb3cbc274fd4657ed8de382"
 
 	for _, tc := range []struct {
-		name  string
-		sums  string
-		asset string
+		name    string
+		sums    string
+		asset   string
+		wantErr string
 	}{
-		// The sidecar describes a different asset; accepting it would verify
-		// geoip.dat against the digest published for geosite.dat.
-		{"names-another-asset", digest + "  geosite.dat\n", "geoip.dat"},
-		{"malformed-short", "deadbeef  geoip.dat\n", "geoip.dat"},
-		{"not-hex", strings.Repeat("z", 64) + "  geoip.dat\n", "geoip.dat"},
-		{"empty", "", "geoip.dat"},
+		// Accepting this would verify geoip.dat against geosite.dat's digest.
+		{"names-another-asset", digest + "  geosite.dat\n", "geoip.dat", "no SHA-256 entry for geoip.dat"},
+		{"empty", "", "geoip.dat", "no SHA-256 entry for geoip.dat"},
+		{"malformed-short", "deadbeef  geoip.dat\n", "geoip.dat", "malformed SHA-256 entry for geoip.dat"},
+		{"not-hex", strings.Repeat("z", 64) + "  geoip.dat\n", "geoip.dat", "malformed SHA-256 entry for geoip.dat"},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			if _, err := parseGeofileDigest([]byte(tc.sums), tc.asset); err == nil {
+			_, err := parseGeofileDigest([]byte(tc.sums), tc.asset)
+			if err == nil {
 				t.Fatalf("%s: expected an error", tc.name)
+			}
+			if !strings.Contains(err.Error(), tc.wantErr) {
+				t.Fatalf("error = %q, want it to contain %q", err, tc.wantErr)
 			}
 		})
 	}
 }
 
-// geofileTestEnv points the service at a temp asset folder and a throwaway DB,
-// and swaps in an allowlist served by srv. It returns the asset folder.
+func TestGeofileTagFromLocation(t *testing.T) {
+	got, err := geofileTagFromLocation("https://github.com/o/r/releases/download/202609022346/geoip.dat")
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if got != "202609022346" {
+		t.Fatalf("tag = %q, want 202609022346", got)
+	}
+	for _, bad := range []string{
+		"https://github.com/o/r/releases/latest/download/geoip.dat",
+		"https://github.com/o/r/releases/download/202609022346",
+		"",
+	} {
+		if _, err := geofileTagFromLocation(bad); err == nil {
+			t.Fatalf("expected an error for %q", bad)
+		}
+	}
+}
+
+// fakeUpstream serves one repo's release: a `latest` download redirecting to a
+// tagged asset, the asset itself, and its .sha256sum sidecar.
+type fakeUpstream struct {
+	repo    string
+	assets  map[string]string
+	corrupt map[string]bool
+}
+
+// geofileServer mounts every upstream on one test server, mimicking GitHub's
+// `releases/latest/download` -> `releases/download/<tag>` redirect.
+func geofileServer(t *testing.T, ups []fakeUpstream) (*httptest.Server, *sync.Map) {
+	t.Helper()
+
+	hits := &sync.Map{}
+	mux := http.NewServeMux()
+	for _, up := range ups {
+		for asset, body := range up.assets {
+			tagged := "/" + up.repo + "/releases/download/v1/" + asset
+
+			mux.HandleFunc("/"+up.repo+"/releases/latest/download/"+asset, func(w http.ResponseWriter, r *http.Request) {
+				hits.Store("latest:"+up.repo, true)
+				http.Redirect(w, r, tagged, http.StatusFound)
+			})
+			mux.HandleFunc(tagged, func(w http.ResponseWriter, r *http.Request) {
+				hits.Store("body:"+up.repo+"/"+asset, true)
+				_, _ = w.Write([]byte(body))
+			})
+
+			payload := body
+			if up.corrupt[asset] {
+				payload = body + " tampered"
+			}
+			sum := sha256.Sum256([]byte(payload))
+			line := fmt.Sprintf("%s  %s\n", hex.EncodeToString(sum[:]), asset)
+			mux.HandleFunc(tagged+".sha256sum", func(w http.ResponseWriter, r *http.Request) {
+				_, _ = w.Write([]byte(line))
+			})
+		}
+	}
+
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	return srv, hits
+}
+
+// geofileTestEnv points the service at a temp asset folder and a throwaway DB.
 func geofileTestEnv(t *testing.T, entries map[string]geofileEntry) string {
 	t.Helper()
 
@@ -89,37 +156,20 @@ func geofileTestEnv(t *testing.T, entries map[string]geofileEntry) string {
 	return binFolder
 }
 
-// geofileServer serves each asset in files plus its .sha256sum sidecar. A
-// sidecar whose digest is deliberately wrong is registered through corrupt.
-func geofileServer(t *testing.T, files map[string]string, corrupt map[string]bool) *httptest.Server {
+func restartStub(t *testing.T, called *bool) {
 	t.Helper()
-
-	mux := http.NewServeMux()
-	for asset, body := range files {
-		mux.HandleFunc("/"+asset, func(w http.ResponseWriter, r *http.Request) {
-			_, _ = w.Write([]byte(body))
-		})
-
-		payload := body
-		if corrupt[asset] {
-			payload = body + " tampered"
-		}
-		sum := sha256.Sum256([]byte(payload))
-		line := fmt.Sprintf("%s  %s\n", hex.EncodeToString(sum[:]), asset)
-		mux.HandleFunc("/"+asset+".sha256sum", func(w http.ResponseWriter, r *http.Request) {
-			_, _ = w.Write([]byte(line))
-		})
+	original := restartXrayAfterGeofileUpdate
+	restartXrayAfterGeofileUpdate = func(*ServerService) error {
+		*called = true
+		return nil
 	}
-
-	srv := httptest.NewServer(mux)
-	t.Cleanup(srv.Close)
-	return srv
+	t.Cleanup(func() { restartXrayAfterGeofileUpdate = original })
 }
 
 func TestUpdateGeofileInstallsVerifiedFile(t *testing.T) {
-	srv := geofileServer(t, map[string]string{"geoip.dat": "good geoip payload"}, nil)
+	srv, _ := geofileServer(t, []fakeUpstream{{repo: "a", assets: map[string]string{"geoip.dat": "good geoip payload"}}})
 	binFolder := geofileTestEnv(t, map[string]geofileEntry{
-		"geoip.dat": {srv.URL + "/geoip.dat", "geoip.dat"},
+		"geoip.dat": {srv.URL + "/a", "geoip.dat", "geoip.dat"},
 	})
 
 	var restarted bool
@@ -142,12 +192,13 @@ func TestUpdateGeofileInstallsVerifiedFile(t *testing.T) {
 }
 
 func TestUpdateGeofileRejectsDigestMismatch(t *testing.T) {
-	srv := geofileServer(t,
-		map[string]string{"geoip.dat": "good geoip payload"},
-		map[string]bool{"geoip.dat": true},
-	)
+	srv, _ := geofileServer(t, []fakeUpstream{{
+		repo:    "a",
+		assets:  map[string]string{"geoip.dat": "good geoip payload"},
+		corrupt: map[string]bool{"geoip.dat": true},
+	}})
 	binFolder := geofileTestEnv(t, map[string]geofileEntry{
-		"geoip.dat": {srv.URL + "/geoip.dat", "geoip.dat"},
+		"geoip.dat": {srv.URL + "/a", "geoip.dat", "geoip.dat"},
 	})
 
 	var restarted bool
@@ -169,16 +220,17 @@ func TestUpdateGeofileRejectsDigestMismatch(t *testing.T) {
 	}
 }
 
-// All six or none: one bad database must not leave the core running a mix of
-// releases, so a single failure installs nothing at all.
-func TestUpdateGeofileInstallsNothingWhenOneFileFails(t *testing.T) {
-	srv := geofileServer(t,
-		map[string]string{"geoip.dat": "good geoip payload", "geosite.dat": "good geosite payload"},
-		map[string]bool{"geosite.dat": true},
-	)
+// Within one upstream the pair installs together. geoip sorts before geosite
+// and is staged first, so a trivially-passing "abort before download" is ruled out.
+func TestUpdateGeofileInstallsNeitherFileOfAFailedUpstream(t *testing.T) {
+	srv, hits := geofileServer(t, []fakeUpstream{{
+		repo:    "a",
+		assets:  map[string]string{"geoip.dat": "good geoip", "geosite.dat": "good geosite"},
+		corrupt: map[string]bool{"geosite.dat": true},
+	}})
 	binFolder := geofileTestEnv(t, map[string]geofileEntry{
-		"geoip.dat":   {srv.URL + "/geoip.dat", "geoip.dat"},
-		"geosite.dat": {srv.URL + "/geosite.dat", "geosite.dat"},
+		"geoip.dat":   {srv.URL + "/a", "geoip.dat", "geoip.dat"},
+		"geosite.dat": {srv.URL + "/a", "geosite.dat", "geosite.dat"},
 	})
 
 	var restarted bool
@@ -188,9 +240,12 @@ func TestUpdateGeofileInstallsNothingWhenOneFileFails(t *testing.T) {
 		t.Fatal("expected an error when one of the databases fails verification")
 	}
 
+	if _, ok := hits.Load("body:a/geoip.dat"); !ok {
+		t.Fatal("geoip.dat was never downloaded, so this run never exercised staging")
+	}
 	for _, name := range []string{"geoip.dat", "geosite.dat"} {
 		if _, statErr := os.Stat(filepath.Join(binFolder, name)); !os.IsNotExist(statErr) {
-			t.Fatalf("%s was installed even though a sibling failed verification", name)
+			t.Fatalf("%s was installed even though its sibling failed verification", name)
 		}
 	}
 	if restarted {
@@ -198,22 +253,106 @@ func TestUpdateGeofileInstallsNothingWhenOneFileFails(t *testing.T) {
 	}
 }
 
+// A broken upstream must not discard a healthy one's verified download.
+func TestUpdateGeofileKeepsGoodUpstreamWhenAnotherFails(t *testing.T) {
+	srv, _ := geofileServer(t, []fakeUpstream{
+		{repo: "aaa", assets: map[string]string{"geoip.dat": "healthy payload"}},
+		{
+			repo:    "zzz",
+			assets:  map[string]string{"geoip.dat": "broken payload"},
+			corrupt: map[string]bool{"geoip.dat": true},
+		},
+	})
+	binFolder := geofileTestEnv(t, map[string]geofileEntry{
+		"geoip.dat":    {srv.URL + "/aaa", "geoip.dat", "geoip.dat"},
+		"geoip_RU.dat": {srv.URL + "/zzz", "geoip.dat", "geoip_RU.dat"},
+	})
+
+	var restarted bool
+	restartStub(t, &restarted)
+
+	err := (&ServerService{}).UpdateGeofile("")
+	if err == nil {
+		t.Fatal("expected an error naming the failing upstream")
+	}
+	if !strings.Contains(err.Error(), "geoip_RU.dat") {
+		t.Fatalf("error = %q, want it to name geoip_RU.dat", err)
+	}
+
+	got, readErr := os.ReadFile(filepath.Join(binFolder, "geoip.dat"))
+	if readErr != nil {
+		t.Fatalf("the healthy upstream's file must still be installed: %v", readErr)
+	}
+	if string(got) != "healthy payload" {
+		t.Fatalf("installed content = %q, want %q", got, "healthy payload")
+	}
+	if _, statErr := os.Stat(filepath.Join(binFolder, "geoip_RU.dat")); !os.IsNotExist(statErr) {
+		t.Fatal("the failing upstream's file must not be installed")
+	}
+	if !restarted {
+		t.Fatal("a file was installed, so xray should have been restarted")
+	}
+}
+
+// The upstreams publish several times a day. Once `latest` is resolved, the
+// asset and its digest must both come from that release, not from a newer one.
+func TestUpdateGeofileSurvivesReleaseRotation(t *testing.T) {
+	const oldBody = "release one payload"
+	oldSum := sha256.Sum256([]byte(oldBody))
+	newSum := sha256.Sum256([]byte("release two payload"))
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/a/releases/latest/download/geoip.dat", func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, "/a/releases/download/v1/geoip.dat", http.StatusFound)
+	})
+	mux.HandleFunc("/a/releases/download/v1/geoip.dat", func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(oldBody))
+	})
+	mux.HandleFunc("/a/releases/download/v1/geoip.dat.sha256sum", func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write(fmt.Appendf(nil, "%s  geoip.dat\n", hex.EncodeToString(oldSum[:])))
+	})
+	// "latest" has already moved on to v2. Anything still resolving it gets a
+	// digest for bytes we never downloaded.
+	mux.HandleFunc("/a/releases/latest/download/geoip.dat.sha256sum", func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write(fmt.Appendf(nil, "%s  geoip.dat\n", hex.EncodeToString(newSum[:])))
+	})
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+
+	binFolder := geofileTestEnv(t, map[string]geofileEntry{
+		"geoip.dat": {srv.URL + "/a", "geoip.dat", "geoip.dat"},
+	})
+
+	var restarted bool
+	restartStub(t, &restarted)
+
+	if err := (&ServerService{}).UpdateGeofile(""); err != nil {
+		t.Fatalf("a release landing mid-batch must not look like tampering: %v", err)
+	}
+	if got, err := os.ReadFile(filepath.Join(binFolder, "geoip.dat")); err != nil || string(got) != oldBody {
+		t.Fatalf("installed = %q (err %v), want the pinned release's bytes", got, err)
+	}
+}
+
 func TestUpdateGeofileSkipsRestartWhenNotModified(t *testing.T) {
 	mux := http.NewServeMux()
-	mux.HandleFunc("/geoip.dat", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/a/releases/latest/download/geoip.dat", func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, "/a/releases/download/v1/geoip.dat", http.StatusFound)
+	})
+	mux.HandleFunc("/a/releases/download/v1/geoip.dat", func(w http.ResponseWriter, r *http.Request) {
 		if r.Header.Get("If-Modified-Since") == "" {
 			t.Errorf("expected a conditional GET carrying If-Modified-Since")
 		}
 		w.WriteHeader(http.StatusNotModified)
 	})
-	mux.HandleFunc("/geoip.dat.sha256sum", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/a/releases/download/v1/geoip.dat.sha256sum", func(w http.ResponseWriter, r *http.Request) {
 		t.Error("the sidecar must not be fetched when the asset is unchanged")
 	})
 	srv := httptest.NewServer(mux)
 	t.Cleanup(srv.Close)
 
 	binFolder := geofileTestEnv(t, map[string]geofileEntry{
-		"geoip.dat": {srv.URL + "/geoip.dat", "geoip.dat"},
+		"geoip.dat": {srv.URL + "/a", "geoip.dat", "geoip.dat"},
 	})
 
 	existing := filepath.Join(binFolder, "geoip.dat")
@@ -242,7 +381,7 @@ func TestUpdateGeofileSkipsRestartWhenNotModified(t *testing.T) {
 
 func TestUpdateGeofileRejectsNameOutsideAllowlist(t *testing.T) {
 	geofileTestEnv(t, map[string]geofileEntry{
-		"geoip.dat": {"https://example.invalid/geoip.dat", "geoip.dat"},
+		"geoip.dat": {"https://example.invalid", "geoip.dat", "geoip.dat"},
 	})
 
 	err := (&ServerService{}).UpdateGeofile("../../etc/passwd")
@@ -252,14 +391,4 @@ func TestUpdateGeofileRejectsNameOutsideAllowlist(t *testing.T) {
 	if !strings.Contains(err.Error(), "not in allowlist") {
 		t.Fatalf("error = %q, want it to name the allowlist", err)
 	}
-}
-
-func restartStub(t *testing.T, called *bool) {
-	t.Helper()
-	original := restartXrayAfterGeofileUpdate
-	restartXrayAfterGeofileUpdate = func(*ServerService) error {
-		*called = true
-		return nil
-	}
-	t.Cleanup(func() { restartXrayAfterGeofileUpdate = original })
 }

--- a/internal/web/service/server_geofile_test.go
+++ b/internal/web/service/server_geofile_test.go
@@ -1,0 +1,265 @@
+package service
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/mhsanaei/3x-ui/v3/internal/database"
+)
+
+// The three upstreams record the asset differently in their .sha256sum files:
+// Loyalsoldier and runetfreedom write "geoip.dat", chocolate4u writes
+// "release/geoip.dat" — the path from its own build.
+func TestParseGeofileDigest(t *testing.T) {
+	const digest = "0d5d2ba0c5a5c58027fd1347a6afd57c9470799b6bb3cbc274fd4657ed8de382"
+
+	for _, tc := range []struct {
+		name  string
+		sums  string
+		asset string
+		want  string
+	}{
+		{"bare-name", digest + "  geoip.dat\n", "geoip.dat", digest},
+		{"build-path", digest + "  release/geoip.dat\n", "geoip.dat", digest},
+		{"binary-mode-marker", digest + "  *geoip.dat\n", "geoip.dat", digest},
+		{"uppercase-digest", strings.ToUpper(digest) + "  geoip.dat\n", "geoip.dat", digest},
+		{"picks-matching-line", "aaaa  geosite.dat\n" + digest + "  geoip.dat\n", "geoip.dat", digest},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := parseGeofileDigest([]byte(tc.sums), tc.asset)
+			if err != nil {
+				t.Fatalf("parse: %v", err)
+			}
+			if got != tc.want {
+				t.Fatalf("digest = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestParseGeofileDigest_Errors(t *testing.T) {
+	const digest = "0d5d2ba0c5a5c58027fd1347a6afd57c9470799b6bb3cbc274fd4657ed8de382"
+
+	for _, tc := range []struct {
+		name  string
+		sums  string
+		asset string
+	}{
+		// The sidecar describes a different asset; accepting it would verify
+		// geoip.dat against the digest published for geosite.dat.
+		{"names-another-asset", digest + "  geosite.dat\n", "geoip.dat"},
+		{"malformed-short", "deadbeef  geoip.dat\n", "geoip.dat"},
+		{"not-hex", strings.Repeat("z", 64) + "  geoip.dat\n", "geoip.dat"},
+		{"empty", "", "geoip.dat"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if _, err := parseGeofileDigest([]byte(tc.sums), tc.asset); err == nil {
+				t.Fatalf("%s: expected an error", tc.name)
+			}
+		})
+	}
+}
+
+// geofileTestEnv points the service at a temp asset folder and a throwaway DB,
+// and swaps in an allowlist served by srv. It returns the asset folder.
+func geofileTestEnv(t *testing.T, entries map[string]geofileEntry) string {
+	t.Helper()
+
+	dbDir := t.TempDir()
+	t.Setenv("XUI_DB_FOLDER", dbDir)
+	if err := database.InitDB(filepath.Join(dbDir, "x-ui.db")); err != nil {
+		t.Fatalf("InitDB: %v", err)
+	}
+	t.Cleanup(func() { _ = database.CloseDB() })
+
+	binFolder := t.TempDir()
+	t.Setenv("XUI_BIN_FOLDER", binFolder)
+
+	originalAllowlist := geofileAllowlist
+	geofileAllowlist = entries
+	t.Cleanup(func() { geofileAllowlist = originalAllowlist })
+
+	return binFolder
+}
+
+// geofileServer serves each asset in files plus its .sha256sum sidecar. A
+// sidecar whose digest is deliberately wrong is registered through corrupt.
+func geofileServer(t *testing.T, files map[string]string, corrupt map[string]bool) *httptest.Server {
+	t.Helper()
+
+	mux := http.NewServeMux()
+	for asset, body := range files {
+		mux.HandleFunc("/"+asset, func(w http.ResponseWriter, r *http.Request) {
+			_, _ = w.Write([]byte(body))
+		})
+
+		payload := body
+		if corrupt[asset] {
+			payload = body + " tampered"
+		}
+		sum := sha256.Sum256([]byte(payload))
+		line := fmt.Sprintf("%s  %s\n", hex.EncodeToString(sum[:]), asset)
+		mux.HandleFunc("/"+asset+".sha256sum", func(w http.ResponseWriter, r *http.Request) {
+			_, _ = w.Write([]byte(line))
+		})
+	}
+
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+func TestUpdateGeofileInstallsVerifiedFile(t *testing.T) {
+	srv := geofileServer(t, map[string]string{"geoip.dat": "good geoip payload"}, nil)
+	binFolder := geofileTestEnv(t, map[string]geofileEntry{
+		"geoip.dat": {srv.URL + "/geoip.dat", "geoip.dat"},
+	})
+
+	var restarted bool
+	restartStub(t, &restarted)
+
+	if err := (&ServerService{}).UpdateGeofile(""); err != nil {
+		t.Fatalf("UpdateGeofile: %v", err)
+	}
+
+	got, err := os.ReadFile(filepath.Join(binFolder, "geoip.dat"))
+	if err != nil {
+		t.Fatalf("read installed geofile: %v", err)
+	}
+	if string(got) != "good geoip payload" {
+		t.Fatalf("installed content = %q, want %q", got, "good geoip payload")
+	}
+	if !restarted {
+		t.Fatal("a file was installed, so xray should have been restarted")
+	}
+}
+
+func TestUpdateGeofileRejectsDigestMismatch(t *testing.T) {
+	srv := geofileServer(t,
+		map[string]string{"geoip.dat": "good geoip payload"},
+		map[string]bool{"geoip.dat": true},
+	)
+	binFolder := geofileTestEnv(t, map[string]geofileEntry{
+		"geoip.dat": {srv.URL + "/geoip.dat", "geoip.dat"},
+	})
+
+	var restarted bool
+	restartStub(t, &restarted)
+
+	err := (&ServerService{}).UpdateGeofile("")
+	if err == nil {
+		t.Fatal("expected an error when the download does not match its published digest")
+	}
+	if !strings.Contains(err.Error(), "does not match the published SHA-256 checksum") {
+		t.Fatalf("error = %q, want it to name the checksum mismatch", err)
+	}
+
+	if _, statErr := os.Stat(filepath.Join(binFolder, "geoip.dat")); !os.IsNotExist(statErr) {
+		t.Fatalf("a file failing verification must not be installed (stat: %v)", statErr)
+	}
+	if restarted {
+		t.Fatal("nothing was installed, so xray must not be restarted")
+	}
+}
+
+// All six or none: one bad database must not leave the core running a mix of
+// releases, so a single failure installs nothing at all.
+func TestUpdateGeofileInstallsNothingWhenOneFileFails(t *testing.T) {
+	srv := geofileServer(t,
+		map[string]string{"geoip.dat": "good geoip payload", "geosite.dat": "good geosite payload"},
+		map[string]bool{"geosite.dat": true},
+	)
+	binFolder := geofileTestEnv(t, map[string]geofileEntry{
+		"geoip.dat":   {srv.URL + "/geoip.dat", "geoip.dat"},
+		"geosite.dat": {srv.URL + "/geosite.dat", "geosite.dat"},
+	})
+
+	var restarted bool
+	restartStub(t, &restarted)
+
+	if err := (&ServerService{}).UpdateGeofile(""); err == nil {
+		t.Fatal("expected an error when one of the databases fails verification")
+	}
+
+	for _, name := range []string{"geoip.dat", "geosite.dat"} {
+		if _, statErr := os.Stat(filepath.Join(binFolder, name)); !os.IsNotExist(statErr) {
+			t.Fatalf("%s was installed even though a sibling failed verification", name)
+		}
+	}
+	if restarted {
+		t.Fatal("nothing was installed, so xray must not be restarted")
+	}
+}
+
+func TestUpdateGeofileSkipsRestartWhenNotModified(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/geoip.dat", func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("If-Modified-Since") == "" {
+			t.Errorf("expected a conditional GET carrying If-Modified-Since")
+		}
+		w.WriteHeader(http.StatusNotModified)
+	})
+	mux.HandleFunc("/geoip.dat.sha256sum", func(w http.ResponseWriter, r *http.Request) {
+		t.Error("the sidecar must not be fetched when the asset is unchanged")
+	})
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+
+	binFolder := geofileTestEnv(t, map[string]geofileEntry{
+		"geoip.dat": {srv.URL + "/geoip.dat", "geoip.dat"},
+	})
+
+	existing := filepath.Join(binFolder, "geoip.dat")
+	if err := os.WriteFile(existing, []byte("already current"), 0o644); err != nil {
+		t.Fatalf("seed existing geofile: %v", err)
+	}
+
+	var restarted bool
+	restartStub(t, &restarted)
+
+	if err := (&ServerService{}).UpdateGeofile(""); err != nil {
+		t.Fatalf("UpdateGeofile: %v", err)
+	}
+
+	if restarted {
+		t.Fatal("a 304 from every upstream must not restart xray and drop client connections")
+	}
+	got, err := os.ReadFile(existing)
+	if err != nil {
+		t.Fatalf("read existing geofile: %v", err)
+	}
+	if string(got) != "already current" {
+		t.Fatalf("existing content = %q, want it left alone", got)
+	}
+}
+
+func TestUpdateGeofileRejectsNameOutsideAllowlist(t *testing.T) {
+	geofileTestEnv(t, map[string]geofileEntry{
+		"geoip.dat": {"https://example.invalid/geoip.dat", "geoip.dat"},
+	})
+
+	err := (&ServerService{}).UpdateGeofile("../../etc/passwd")
+	if err == nil {
+		t.Fatal("expected an error for a name outside the allowlist")
+	}
+	if !strings.Contains(err.Error(), "not in allowlist") {
+		t.Fatalf("error = %q, want it to name the allowlist", err)
+	}
+}
+
+func restartStub(t *testing.T, called *bool) {
+	t.Helper()
+	original := restartXrayAfterGeofileUpdate
+	restartXrayAfterGeofileUpdate = func(*ServerService) error {
+		*called = true
+		return nil
+	}
+	t.Cleanup(func() { restartXrayAfterGeofileUpdate = original })
+}


### PR DESCRIPTION
## Summary

`ServerService.UpdateGeofile` now verifies every downloaded geo database against the SHA-256 its upstream publishes, pins each download to one immutable release, installs an upstream's databases atomically, and no longer restarts Xray when nothing changed.

## Why

`UpdateGeofile` wrote whatever the three upstreams returned straight into the Xray asset folder with `os.Create` + `io.Copy` and no integrity check of any kind. Xray parses these databases when it builds its domain and IP matchers, so a corrupted or substituted file takes the core down at its next start.

The panel already does the right thing for the other artifact it downloads. `installXray` verifies the release archive against the SHA-256 published in its `.dgst` sidecar (`fetchXrayDigestSHA256` / `parseXrayDigestSHA256`, covered by `server_xray_checksum_test.go`). The geo databases were the only download in the panel that skipped that step, even though all three upstreams publish a `<asset>.sha256sum` next to every `.dat`:

- `Loyalsoldier/v2ray-rules-dat`
- `runetfreedom/russia-v2ray-rules-dat`
- `chocolate4u/Iran-v2ray-rules`

## What changed

**1. Verify before installing.** Each `.dat` is downloaded to a staging folder, its `.sha256sum` sidecar is fetched, and the digest is compared against the bytes that actually arrived.

**2. Pin the release.** The asset and its sidecar are two requests, so fetching both from `releases/latest/download/…` lets GitHub re-resolve `latest` in between. These upstreams publish several times a day — `202609022346`, `202609030908` and `202609031849` are three tags from a single day — so a release landing mid-batch would check release N+1's digest against release N's bytes and report a healthy upstream as tampered with. The tag is now resolved once per upstream from the redirect GitHub already returns, and both the asset and its digest are fetched from it. This is why an entry is modelled as repo + asset rather than an opaque URL.

**3. Atomic per upstream, not across all six.** A `geoip`/`geosite` pair from one release installs together or not at all. Coupling the three independent repositories buys no integrity and costs a lot: one transient 5xx would discard every verified download and re-fetch tens of megabytes on the next attempt. Each upstream now succeeds or aborts on its own and errors are collected, as the function did before this change.

**4. No restart on a no-op refresh.** The conditional `If-Modified-Since` GET was already there, but `RestartXrayService()` ran unconditionally afterwards, dropping every client connection even when all six upstreams answered `304`.

### The digest line is matched by base name

The upstreams disagree on the name field, so `sha256sum --check` semantics — look up the name written in the file — fail on a perfectly good download from chocolate4u:

```
0d5d2ba0…de382  geoip.dat          # Loyalsoldier, runetfreedom
cb2d2752…82ff   release/geoip.dat  # chocolate4u — the path from its own build
```

A leading `*`, `sha256sum`'s binary-mode marker, is stripped for the same reason: nothing stops an upstream regenerating with `-b`.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactoring (no behavior change)
- [ ] Documentation
- [ ] Tests only
- [ ] Build / CI / tooling
- [ ] Other

## Areas affected

- [ ] Frontend (UI / panel pages)
- [x] Backend (API endpoints, login, settings)
- [ ] Xray config generation
- [ ] Subscription (share links / Clash / JSON)
- [ ] Statistics / traffic counters
- [ ] Database / migrations
- [ ] Install / upgrade script
- [ ] Docker image
- [ ] Multi-node (sub-nodes)
- [ ] Telegram bot

## How was this tested?

New suite in `internal/web/service/server_geofile_test.go`, stdlib `testing` with `httptest` upstreams that mimic GitHub's `releases/latest/download` → `releases/download/<tag>` redirect, and a throwaway DB. Each test was checked to fail without the fix by reverting the relevant part and watching it go red:

| Test | Fails without |
|---|---|
| `TestParseGeofileDigest` (`build-path`, `binary-mode-marker`) | the base-name match — a literal match reports "no SHA-256 entry", the chocolate4u failure |
| `TestParseGeofileDigest_Errors` | each row pins the concrete message, so the two error branches cannot swallow each other's cases |
| `TestUpdateGeofileRejectsDigestMismatch` | the digest comparison |
| `TestUpdateGeofileInstallsNeitherFileOfAFailedUpstream` | staging within an upstream; iteration is sorted so `geoip.dat` is provably downloaded before the corrupt `geosite.dat`, rather than relying on map order |
| `TestUpdateGeofileKeepsGoodUpstreamWhenAnotherFails` | per-upstream isolation — a broken repo must not discard a healthy one's verified file |
| `TestUpdateGeofileSurvivesReleaseRotation` | release pinning — with `latest` re-resolved, a healthy upstream is reported as "corrupted or has been tampered with" |
| `TestUpdateGeofileSkipsRestartWhenNotModified` | the restart gate |

```
go build ./...
go test ./... -shuffle=on -count=1
golangci-lint run          # 0 issues
gofumpt -l                 # clean
```

The `.sha256sum` asset names and the `304` behaviour were also checked against the live upstreams: all six sidecars exist at `releases/latest/download/`, GitHub honours `If-Modified-Since` through the release redirect and answers `304` with a zero-byte body, and the first hop of that redirect is what carries the concrete tag:

```
location: https://github.com/Loyalsoldier/v2ray-rules-dat/releases/download/202609022346/geoip.dat
```

Endpoint level: `POST /panel/api/server/updateGeofile` (and `/updateGeofile/:fileName`). The first run installs and restarts; an immediate second run gets `304` for all six, installs nothing, and does not restart the core.

## Screenshots / recordings

N/A — no UI change.

## Breaking changes

None for configuration or API shape. One behaviour change worth calling out: a failed download or digest check now aborts that **upstream's** update and returns an error, where before every failure was collected into a message and whatever succeeded was installed regardless. Files from the other upstreams are still installed, so a single flaky repository no longer costs the whole refresh — but a repository whose `geoip` verifies and whose `geosite` does not will now install neither, by design.

## Checklist

- [x] I tested the change locally and confirmed the described behavior.
- [x] I added or updated tests for the new behavior (when applicable).
- [x] `go build ./...` and the test suite pass locally.
- [ ] For frontend changes: `npm run lint`, `npm run typecheck`, and `npm run build` pass. — N/A, no frontend change
- [ ] I updated the Wiki / README / API docs if user-facing behavior changed. — N/A, no endpoint or payload change
- [x] My commits follow the project's existing message style.
- [x] I have no unrelated changes mixed into this PR.
