### PR TITLE
fix(sub): skip AmneziaWG JSON entries

### DIFF
--- a/internal/sub/json_service.go
+++ b/internal/sub/json_service.go
@@ -589,6 +589,8 @@ func (s *SubJsonService) getConfig(subReq *SubService, inbound *model.Inbound, c
 				continue
 			}
 			newOutbounds = append(newOutbounds, wgOutbound)
+		case "amneziawg":
+			continue
 		}
 
 		newOutbounds = append(newOutbounds, s.defaultOutbounds...)

--- a/internal/sub/json_service_test.go
+++ b/internal/sub/json_service_test.go
@@ -470,3 +470,9 @@ func TestSubJsonServiceWireguardNoKey(t *testing.T) {
 		t.Fatalf("genWireguard = %s, want nil for a keyless wireguard client", raw)
 	}
 }
+
+func TestSubJsonServiceSkipsAmneziaWG(t *testing.T) {
+	if got := NewSubJsonService("", "", "", nil).getConfig(&SubService{address: "sub.example.com"}, &model.Inbound{Listen: "203.0.113.8", Port: 51820, Protocol: model.AmneziaWG}, model.Client{}, "sub.example.com"); len(got) != 0 {
+		t.Fatalf("getConfig emitted %d unsupported AmneziaWG Xray config(s)", len(got))
+	}
+}


### PR DESCRIPTION
## Summary

- Skip AmneziaWG entries when rendering Xray JSON subscriptions.

## Why

AmneziaWG uses its native `vpn://` configuration format and cannot be represented by an Xray outbound. Previously, JSON subscriptions emitted an entry with no `proxy` outbound for these clients.

Fixes #6410

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactoring (no behavior change)
- [ ] Documentation
- [ ] Tests only
- [ ] Build / CI / tooling
- [ ] Other

## Areas affected

- [ ] Frontend (UI / panel pages)
- [ ] Backend (API endpoints, login, settings)
- [ ] Xray config generation
- [x] Subscription (share links / Clash / JSON)
- [ ] Statistics / traffic counters
- [ ] Database / migrations
- [ ] Install / upgrade script
- [ ] Docker image
- [ ] Multi-node (sub-nodes)
- [ ] Telegram bot

## How was this tested?

- `go test ./internal/sub -run '^(TestSubJsonServiceSkipsAmneziaWG|TestSubJsonServiceWireguard)$' -count=1`

## Screenshots / recordings

N/A

## Breaking changes

None. Unsupported AmneziaWG entries are now omitted from the Xray-only JSON subscription instead of producing invalid configurations.

## Checklist

- [x] I tested the change locally and confirmed the described behavior.
- [x] I added or updated tests for the new behavior (when applicable).
- [ ] `go build ./...` and the test suite pass locally.
- [ ] For frontend changes: `npm run lint`, `npm run typecheck`, and `npm run build` pass.
- [ ] I updated the Wiki / README / API docs if user-facing behavior changed.
- [x] My commits follow the project's existing message style.
- [x] I have no unrelated changes mixed into this PR.
