### PR TITLE
fix(inbounds): reject missing TLS certificates before saving

### DIFF
--- a/frontend/src/pages/inbounds/form/InboundFormModal.tsx
+++ b/frontend/src/pages/inbounds/form/InboundFormModal.tsx
@@ -559,6 +559,7 @@ export default function InboundFormModal({
     const parsed = InboundFormSchema.safeParse(values);
     if (!parsed.success) {
       const issues = parsed.error.issues;
+      setActiveTab(tabForValidationPath(issues[0].path));
       messageApi.error(formatInboundValidation(issues, values, t));
       console.error(
         '[InboundFormModal] schema validation failed:',

--- a/frontend/src/pages/inbounds/form/formatValidationError.ts
+++ b/frontend/src/pages/inbounds/form/formatValidationError.ts
@@ -18,6 +18,12 @@ export function formatInboundIssue(issue: IssueLike, values: unknown, t: TFuncti
   const path = Array.isArray(issue?.path) ? issue.path : [];
   const reason = t(issue?.message, { defaultValue: issue?.message });
 
+  if (path[0] === 'streamSettings' && path[1] === 'tlsSettings' && path[2] === 'certificates') {
+    return typeof path[3] === 'number'
+      ? t('pages.inbounds.toasts.invalidCertificate', { index: path[3] + 1, reason })
+      : reason;
+  }
+
   if (path[0] === 'settings' && path[1] === 'clients' && typeof path[2] === 'number') {
     const index = path[2];
     const clients = (values as { settings?: { clients?: ClientLike[] } })?.settings?.clients;

--- a/frontend/src/schemas/forms/inbound-form.ts
+++ b/frontend/src/schemas/forms/inbound-form.ts
@@ -2,11 +2,78 @@ import { z } from 'zod';
 
 import { InboundPortSchema, SniffingSchema } from '@/schemas/primitives';
 import { InboundSettingsSchema } from '@/schemas/protocols/inbound';
-import { SecuritySettingsSchema } from '@/schemas/protocols/security';
+import {
+  RealityStreamSettingsSchema,
+  TlsCertInlineSchema,
+  TlsStreamSettingsSchema,
+} from '@/schemas/protocols/security';
 import { NetworkSettingsSchema, StreamExtrasSchema } from '@/schemas/protocols/stream';
 
-export const InboundStreamFormSchema =
-  NetworkSettingsSchema.and(SecuritySettingsSchema).and(StreamExtrasSchema);
+// Inbound certificates must follow the selected editor mode. The shared wire
+// union also serves outbound TLS, where a client certificate is optional.
+const InboundTlsCertFieldsSchema = TlsCertInlineSchema.extend({
+  useFile: z.boolean().optional(),
+  certificateFile: z.string().default(''),
+  keyFile: z.string().default(''),
+  certificate: z.array(z.string()).default([]),
+  key: z.array(z.string()).default([]),
+});
+
+function usesCertificateFiles(cert: z.infer<typeof InboundTlsCertFieldsSchema>): boolean {
+  return (
+    cert.useFile ??
+    (!!cert.certificateFile || !!cert.keyFile || (!cert.certificate.length && !cert.key.length))
+  );
+}
+
+const InboundTlsCertSchema = InboundTlsCertFieldsSchema.superRefine((cert, ctx) => {
+  const useFile = usesCertificateFiles(cert);
+  const hasCertificate = useFile
+    ? cert.certificateFile.trim() !== ''
+    : cert.certificate.some((line) => line.trim() !== '');
+  const hasKey = useFile ? cert.keyFile.trim() !== '' : cert.key.some((line) => line.trim() !== '');
+  if (!hasCertificate) {
+    ctx.addIssue({
+      code: 'custom',
+      path: [useFile ? 'certificateFile' : 'certificate'],
+      message: 'pages.inbounds.form.tlsCertificateRequired',
+    });
+  }
+  if (cert.usage !== 'verify' && !hasKey) {
+    ctx.addIssue({
+      code: 'custom',
+      path: [useFile ? 'keyFile' : 'key'],
+      message: 'pages.inbounds.form.tlsPrivateKeyRequired',
+    });
+  }
+}).transform((cert) => {
+  const { useFile: _useFile, certificateFile, keyFile, certificate, key, ...settings } = cert;
+  return usesCertificateFiles(cert)
+    ? { ...settings, certificateFile, keyFile }
+    : { ...settings, certificate, key };
+});
+
+const InboundTlsSettingsSchema = TlsStreamSettingsSchema.extend({
+  certificates: z
+    .array(InboundTlsCertSchema)
+    .default([])
+    .refine((certificates) => certificates.some((cert) => cert.usage !== 'verify'), {
+      message: 'pages.inbounds.form.tlsServerCertificateRequired',
+    }),
+});
+
+const InboundSecuritySettingsSchema = z.union([
+  z.discriminatedUnion('security', [
+    z.object({ security: z.literal('none') }),
+    z.object({ security: z.literal('tls'), tlsSettings: InboundTlsSettingsSchema }),
+    z.object({ security: z.literal('reality'), realitySettings: RealityStreamSettingsSchema }),
+  ]),
+  z.object({ security: z.never().optional() }),
+]);
+
+export const InboundStreamFormSchema = NetworkSettingsSchema.and(InboundSecuritySettingsSchema).and(
+  StreamExtrasSchema,
+);
 export type InboundStreamFormValues = z.infer<typeof InboundStreamFormSchema>;
 
 export const TrafficResetSchema = z.enum(['never', 'hourly', 'daily', 'weekly', 'monthly']);

--- a/frontend/src/schemas/protocols/security/tls.ts
+++ b/frontend/src/schemas/protocols/security/tls.ts
@@ -52,7 +52,14 @@ export const TlsCertInlineSchema = z.object({
   usage: TlsCertUsageSchema.default('encipherment'),
   buildChain: z.boolean().default(false),
 });
-export const TlsCertSchema = z.union([TlsCertFileSchema, TlsCertInlineSchema]);
+export const TlsCertSchema = z.union([
+  TlsCertFileSchema,
+  TlsCertInlineSchema,
+  // Verification CAs contain only public certificates. Their omitted private
+  // keys must survive reading a saved inbound for details and share links.
+  TlsCertFileSchema.extend({ usage: z.literal('verify'), keyFile: z.string().optional() }),
+  TlsCertInlineSchema.extend({ usage: z.literal('verify'), key: z.array(z.string()).optional() }),
+]);
 export type TlsCert = z.infer<typeof TlsCertSchema>;
 
 export const TlsClientSettingsSchema = z.object({

--- a/frontend/src/test/format-validation-error.test.ts
+++ b/frontend/src/test/format-validation-error.test.ts
@@ -12,6 +12,7 @@ const templates: Record<string, string> = {
   'pages.inbounds.toasts.invalidClientField': 'Client {client}: {field} — {reason}',
   'pages.inbounds.toasts.invalidField': '{field} — {reason}',
   'pages.inbounds.toasts.moreIssues': '{message}  (+{count} more)',
+  'pages.inbounds.toasts.invalidCertificate': 'TLS certificate {index}: {reason}',
   clients: 'clients',
 };
 
@@ -57,6 +58,14 @@ describe('formatInboundValidation', () => {
   it('formats non-client paths plainly', () => {
     const issue = { path: ['port'], message: 'Invalid input' };
     expect(formatInboundIssue(issue, {}, t)).toBe('port — Invalid input');
+  });
+
+  it('identifies the certificate by its displayed row number', () => {
+    const issue = {
+      path: ['streamSettings', 'tlsSettings', 'certificates', 1, 'keyFile'],
+      message: 'Private key is required',
+    };
+    expect(formatInboundIssue(issue, {}, t)).toBe('TLS certificate 2: Private key is required');
   });
 
   it('appends a count when several fields fail', () => {

--- a/frontend/src/test/inbound-form-modal.test.tsx
+++ b/frontend/src/test/inbound-form-modal.test.tsx
@@ -240,6 +240,28 @@ describe('InboundFormModal', () => {
     expect(post).not.toHaveBeenCalled();
   });
 
+  it('blocks adding TLS without a certificate and directs the user to Security', async () => {
+    const post = vi.mocked(HttpUtil.post);
+    post.mockClear();
+    messageError.mockClear();
+    renderModal();
+
+    fireEvent.click(screen.getByRole('tab', { name: 'Security' }));
+    fireEvent.click(screen.getByRole('radio', { name: 'TLS' }));
+    fireEvent.click(screen.getByRole('tab', { name: 'Basics' }));
+    fireEvent.click(primaryButton());
+
+    await waitFor(() => {
+      expect(screen.getByRole('tab', { name: 'Security' }).getAttribute('aria-selected')).toBe(
+        'true',
+      );
+      expect(messageError).toHaveBeenCalledWith(
+        expect.stringContaining('TLS certificate 1: Import a TLS certificate'),
+      );
+    });
+    expect(post).not.toHaveBeenCalled();
+  });
+
   it('submits a valid clone-like Reality inbound', async () => {
     const post = vi.mocked(HttpUtil.post);
     post.mockClear();

--- a/frontend/src/test/inbound-tls-validation.test.ts
+++ b/frontend/src/test/inbound-tls-validation.test.ts
@@ -1,0 +1,145 @@
+import { describe, expect, it } from 'vitest';
+
+import { InboundFormSchema, InboundStreamFormSchema } from '@/schemas/forms/inbound-form';
+import { TlsCertSchema, TlsStreamSettingsSchema } from '@/schemas/protocols/security';
+import { createTlsSettingsWithDefaultCert } from '@/lib/xray/inbound-tls-defaults';
+import { formValuesToWirePayload } from '@/lib/xray/inbound-form-adapter';
+import { inboundFromDb } from '@/lib/xray/inbound-from-db';
+
+const fileCert = { certificateFile: '/cert/server.pem', keyFile: '/cert/server.key' };
+const inlineCert = { certificate: ['certificate content'], key: ['private key content'] };
+
+function parseCertificates(certificates?: unknown[]) {
+  return InboundFormSchema.safeParse({
+    port: 443,
+    protocol: 'vless',
+    settings: { clients: [] },
+    streamSettings: {
+      network: 'tcp',
+      tcpSettings: {},
+      security: 'tls',
+      tlsSettings: { certificates },
+    },
+  });
+}
+
+describe('inbound TLS certificate validation', () => {
+  it('rejects the empty certificate seeded by the TLS editor with a useful field error', () => {
+    const result = parseCertificates(createTlsSettingsWithDefaultCert().certificates as unknown[]);
+    expect(result.success).toBe(false);
+    if (result.success) return;
+    expect(result.error.issues[0]).toMatchObject({
+      path: ['streamSettings', 'tlsSettings', 'certificates', 0, 'certificateFile'],
+      message: 'pages.inbounds.form.tlsCertificateRequired',
+    });
+  });
+
+  it.each([
+    ['missing certificates', undefined],
+    ['empty certificates', []],
+    ['empty row', [{}]],
+    ['blank paths', [{ certificateFile: '  ', keyFile: '\t' }]],
+    ['certificate path only', [{ certificateFile: fileCert.certificateFile }]],
+    ['private key path only', [{ keyFile: fileCert.keyFile }]],
+    ['empty content', [{ useFile: false, certificate: [], key: [] }]],
+    ['blank content', [{ useFile: false, certificate: [' ', '\n'], key: ['\t'] }]],
+    ['certificate content only', [{ useFile: false, certificate: inlineCert.certificate }]],
+    ['private key content only', [{ useFile: false, key: inlineCert.key }]],
+    ['empty file mode with stale inline content', [{ useFile: true, ...inlineCert }]],
+    ['empty content mode with stale file paths', [{ useFile: false, ...fileCert }]],
+    ['valid certificate followed by an empty row', [fileCert, {}]],
+    ['verify certificate only', [{ certificateFile: '/ca.pem', usage: 'verify' }]],
+    ['issue certificate without its key', [{ certificate: ['CA'], usage: 'issue' }]],
+    ['empty verify certificate alongside server certificate', [fileCert, { usage: 'verify' }]],
+  ])('rejects %s', (_name, certificates) => {
+    expect(parseCertificates(certificates as unknown[] | undefined).success).toBe(false);
+  });
+
+  it.each([
+    ['file certificate', [fileCert]],
+    ['inline certificate', [inlineCert]],
+    ['explicit file mode', [{ useFile: true, ...fileCert }]],
+    ['explicit inline mode', [{ useFile: false, ...inlineCert }]],
+    ['multiple certificates', [fileCert, inlineCert]],
+    ['issuing CA with its key', [{ ...inlineCert, usage: 'issue' }]],
+    [
+      'file verification CA without a key',
+      [fileCert, { certificateFile: '/ca.pem', usage: 'verify' }],
+    ],
+    [
+      'inline verification CA without a key',
+      [inlineCert, { certificate: ['CA'], usage: 'verify' }],
+    ],
+  ])('accepts %s', (_name, certificates) => {
+    expect(parseCertificates(certificates).success).toBe(true);
+  });
+
+  it.each([true, false])('serializes only the selected mode (useFile=%s)', (useFile) => {
+    const result = parseCertificates([{ useFile, ...fileCert, ...inlineCert }]);
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    const stream = JSON.parse(formValuesToWirePayload(result.data).streamSettings);
+    const cert = stream.tlsSettings.certificates[0];
+    expect(cert).toMatchObject(useFile ? fileCert : inlineCert);
+    expect(cert).not.toHaveProperty('useFile');
+    expect(cert).not.toHaveProperty(useFile ? 'certificate' : 'certificateFile');
+    expect(cert).not.toHaveProperty(useFile ? 'key' : 'keyFile');
+  });
+
+  it.each([
+    ['file', { certificateFile: '/cert/ca.pem', usage: 'verify' }],
+    ['inline', { certificate: ['CA certificate'], usage: 'verify' }],
+  ])('preserves TLS settings when reading back a %s verification CA without a key', (_mode, ca) => {
+    const tlsSettings = {
+      serverName: 'tls.example.test',
+      alpn: ['h3'],
+      certificates: [fileCert, ca],
+      settings: { fingerprint: 'firefox', pinnedPeerCertSha256: ['test-pin'] },
+    };
+    const values = InboundFormSchema.parse({
+      port: 443,
+      protocol: 'vless',
+      settings: { clients: [] },
+      streamSettings: { network: 'tcp', tcpSettings: {}, security: 'tls', tlsSettings },
+    });
+
+    const restored = inboundFromDb(formValuesToWirePayload(values));
+
+    expect(restored.streamSettings).toMatchObject({ security: 'tls', tlsSettings });
+  });
+
+  it.each([undefined, 'encipherment', 'issue'])(
+    'keeps wire private keys required for usage=%s',
+    (usage) => {
+      expect(TlsCertSchema.safeParse({ certificateFile: '/cert.pem', usage }).success).toBe(false);
+      expect(
+        TlsCertSchema.safeParse({ certificateFile: '/cert.pem', keyFile: '', usage }).success,
+      ).toBe(false);
+      expect(TlsCertSchema.safeParse({ certificate: ['certificate'], usage }).success).toBe(false);
+    },
+  );
+
+  it('applies the same certificate requirement to Hysteria TLS', () => {
+    const stream = {
+      network: 'hysteria',
+      hysteriaSettings: {},
+      security: 'tls',
+      tlsSettings: createTlsSettingsWithDefaultCert(),
+    };
+    expect(InboundStreamFormSchema.safeParse(stream).success).toBe(false);
+    expect(
+      InboundStreamFormSchema.safeParse({ ...stream, tlsSettings: { certificates: [fileCert] } })
+        .success,
+    ).toBe(true);
+  });
+
+  it('keeps Reality, unsecured, transportless and outbound TLS certificate-free', () => {
+    for (const security of [{ security: 'reality', realitySettings: {} }, { security: 'none' }]) {
+      expect(
+        InboundStreamFormSchema.safeParse({ network: 'tcp', tcpSettings: {}, ...security }).success,
+      ).toBe(true);
+    }
+    expect(InboundStreamFormSchema.safeParse({}).success).toBe(true);
+    expect(TlsStreamSettingsSchema.safeParse({}).success).toBe(true);
+  });
+});

--- a/frontend/src/test/stream-wire-normalize.test.ts
+++ b/frontend/src/test/stream-wire-normalize.test.ts
@@ -488,6 +488,7 @@ describe('inbound formValuesToWirePayload integration', () => {
         },
         tlsSettings: {
           alpn: ['h3'],
+          certificates: [{ certificateFile: '/cert/server.pem', keyFile: '/cert/server.key' }],
           settings: {
             fingerprint: '',
           },

--- a/internal/web/service/inbound.go
+++ b/internal/web/service/inbound.go
@@ -589,6 +589,65 @@ func canonicalizeStreamNetworkKey(streamSettings string) string {
 	return string(out)
 }
 
+// validateInboundTLSCertificates rejects incomplete TLS credentials before a
+// save can request an Xray restart. File paths belong to the target node, so
+// only their presence is checked here, not the panel's local filesystem.
+func validateInboundTLSCertificates(streamSettings string) error {
+	if strings.TrimSpace(streamSettings) == "" {
+		return nil
+	}
+	var stream struct {
+		Security    string          `json:"security"`
+		TLSSettings json.RawMessage `json:"tlsSettings"`
+	}
+	if err := json.Unmarshal([]byte(streamSettings), &stream); err != nil {
+		return common.NewError("Invalid inbound stream settings: ", err)
+	}
+	if !strings.EqualFold(stream.Security, "tls") {
+		return nil
+	}
+	var settings struct {
+		Certificates []struct {
+			CertificateFile string   `json:"certificateFile"`
+			KeyFile         string   `json:"keyFile"`
+			Certificate     []string `json:"certificate"`
+			Key             []string `json:"key"`
+			Usage           string   `json:"usage"`
+		} `json:"certificates"`
+	}
+	if len(stream.TLSSettings) > 0 {
+		if err := json.Unmarshal(stream.TLSSettings, &settings); err != nil {
+			return common.NewError("Invalid inbound TLS settings: ", err)
+		}
+	}
+	hasServerCertificate := false
+	for i, cert := range settings.Certificates {
+		// Match Xray's file-over-inline precedence for each credential.
+		certificate := cert.CertificateFile
+		if certificate == "" {
+			certificate = strings.Join(cert.Certificate, "\n")
+		}
+		if strings.TrimSpace(certificate) == "" {
+			return common.NewErrorf("TLS certificate %d is missing. Configure a certificate file path or certificate content before saving the inbound.", i+1)
+		}
+		if strings.EqualFold(cert.Usage, "verify") {
+			continue
+		}
+		key := cert.KeyFile
+		if key == "" {
+			key = strings.Join(cert.Key, "\n")
+		}
+		if strings.TrimSpace(key) == "" {
+			return common.NewErrorf("TLS certificate %d is missing its private key. Configure a private key file path or private key content before saving the inbound.", i+1)
+		}
+		hasServerCertificate = true
+	}
+	if !hasServerCertificate {
+		return common.NewError("TLS requires a server certificate and private key. Configure an encipherment or issue certificate before saving the inbound.")
+	}
+	return nil
+}
+
 // finalMaskRealityTcpMasks returns the stream's finalmask.tcp masks when the
 // stream uses REALITY security, or nil otherwise. A non-empty result means
 // this stream carries the finalmask+REALITY combination that panics
@@ -946,6 +1005,9 @@ func (s *InboundService) AddInbound(inbound *model.Inbound) (*model.Inbound, boo
 	inbound.TrafficResetDay = normalizeTrafficResetDay(inbound.TrafficResetDay)
 	// Normalize streamSettings based on protocol
 	s.normalizeStreamSettings(inbound)
+	if err := validateInboundTLSCertificates(inbound.StreamSettings); err != nil {
+		return inbound, false, err
+	}
 	if err := validateFinalMaskRealityCombo(inbound.StreamSettings); err != nil {
 		return inbound, false, err
 	}
@@ -1466,6 +1528,9 @@ func (s *InboundService) UpdateInbound(inbound *model.Inbound) (*model.Inbound, 
 	inbound.TrafficResetDay = normalizeTrafficResetDay(inbound.TrafficResetDay)
 	// Normalize streamSettings based on protocol
 	s.normalizeStreamSettings(inbound)
+	if err := validateInboundTLSCertificates(inbound.StreamSettings); err != nil {
+		return inbound, false, err
+	}
 	if err := validateFinalMaskRealityCombo(inbound.StreamSettings); err != nil {
 		return inbound, false, err
 	}

--- a/internal/web/service/inbound_durable_postgres_test.go
+++ b/internal/web/service/inbound_durable_postgres_test.go
@@ -35,7 +35,7 @@ func durableTestInbound(nodeID *int, tag string, port int) *model.Inbound {
 		Enable:         true,
 		Port:           port,
 		Protocol:       model.VLESS,
-		StreamSettings: `{"network":"tcp","security":"tls"}`,
+		StreamSettings: `{"network":"tcp","security":"tls","tlsSettings":{"certificates":[{"certificateFile":"/node/cert.pem","keyFile":"/node/key.pem"}]}}`,
 		Settings:       `{"clients":[],"decryption":"none"}`,
 	}
 }

--- a/internal/web/service/inbound_tls_test.go
+++ b/internal/web/service/inbound_tls_test.go
@@ -1,0 +1,142 @@
+package service
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/mhsanaei/3x-ui/v3/internal/database"
+	"github.com/mhsanaei/3x-ui/v3/internal/database/model"
+)
+
+func TestValidateInboundTLSCertificates(t *testing.T) {
+	tests := []struct {
+		name           string
+		streamSettings string
+		wantErr        bool
+	}{
+		{"empty stream", "", false},
+		{"whitespace stream", " \t\n", false},
+		{"none ignores stale TLS settings", `{"security":"none","tlsSettings":{"certificates":[{}]}}`, false},
+		{"reality needs no TLS certificate", `{"security":"reality","realitySettings":{}}`, false},
+		{"missing TLS settings", `{"security":"tls"}`, true},
+		{"uppercase TLS security", `{"security":"TLS","tlsSettings":{}}`, true},
+		{"mixed-case TLS security", `{"security":"Tls","tlsSettings":{}}`, true},
+		{"null TLS settings", `{"security":"tls","tlsSettings":null}`, true},
+		{"missing certificates", `{"security":"tls","tlsSettings":{}}`, true},
+		{"null certificates", `{"security":"tls","tlsSettings":{"certificates":null}}`, true},
+		{"empty certificates", `{"security":"tls","tlsSettings":{"certificates":[]}}`, true},
+		{"null certificate row", `{"security":"tls","tlsSettings":{"certificates":[null]}}`, true},
+		{"empty default file fields", `{"security":"tls","tlsSettings":{"certificates":[{"certificateFile":"","keyFile":""}]}}`, true},
+		{"empty default inline fields", `{"security":"tls","tlsSettings":{"certificates":[{"certificate":[],"key":[]}]}}`, true},
+		{"whitespace file fields", `{"security":"tls","tlsSettings":{"certificates":[{"certificateFile":" \t","keyFile":" \n"}]}}`, true},
+		{"whitespace inline certificate", `{"security":"tls","tlsSettings":{"certificates":[{"certificate":[" ","\t"],"key":["private key"]}]}}`, true},
+		{"whitespace inline key", `{"security":"tls","tlsSettings":{"certificates":[{"certificate":["certificate"],"key":[" ","\n"]}]}}`, true},
+		{"missing private key", `{"security":"tls","tlsSettings":{"certificates":[{"certificateFile":"/node/cert.pem"}]}}`, true},
+		{"missing certificate", `{"security":"tls","tlsSettings":{"certificates":[{"keyFile":"/node/key.pem"}]}}`, true},
+		{"verify only", `{"security":"tls","tlsSettings":{"certificates":[{"usage":"verify","certificateFile":"/node/ca.pem"}]}}`, true},
+		{"verify with private key still needs server certificate", `{"security":"tls","tlsSettings":{"certificates":[{"usage":"verify","certificateFile":"/node/ca.pem","keyFile":"/node/key.pem"}]}}`, true},
+		{"issue needs private key", `{"security":"tls","tlsSettings":{"certificates":[{"usage":"issue","certificateFile":"/node/ca.pem"}]}}`, true},
+		{"file credentials with default usage", `{"security":"tls","tlsSettings":{"certificates":[{"certificateFile":"/node/cert.pem","keyFile":"/node/key.pem"}]}}`, false},
+		{"inline credentials", `{"security":"tls","tlsSettings":{"certificates":[{"certificate":["certificate"],"key":["private key"]}]}}`, false},
+		{"certificate file and inline key", `{"security":"tls","tlsSettings":{"certificates":[{"certificateFile":"/node/cert.pem","key":["private key"]}]}}`, false},
+		{"inline certificate and key file", `{"security":"tls","tlsSettings":{"certificates":[{"certificate":["certificate"],"keyFile":"/node/key.pem"}]}}`, false},
+		{"encipherment usage", `{"security":"tls","tlsSettings":{"certificates":[{"usage":"encipherment","certificateFile":"/node/cert.pem","keyFile":"/node/key.pem"}]}}`, false},
+		{"issue usage", `{"security":"tls","tlsSettings":{"certificates":[{"usage":"issue","certificateFile":"/node/ca.pem","keyFile":"/node/ca-key.pem"}]}}`, false},
+		{"unknown usage defaults to encipherment like Xray", `{"security":"tls","tlsSettings":{"certificates":[{"usage":"custom","certificateFile":"/node/cert.pem","keyFile":"/node/key.pem"}]}}`, false},
+		{"verify and server certificates", `{"security":"tls","tlsSettings":{"certificates":[{"usage":"verify","certificateFile":"/node/ca.pem"},{"certificateFile":"/node/cert.pem","keyFile":"/node/key.pem"}]}}`, false},
+		{"verify usage is case insensitive", `{"security":"tls","tlsSettings":{"certificates":[{"usage":"VERIFY","certificateFile":"/node/ca.pem"},{"certificateFile":"/node/cert.pem","keyFile":"/node/key.pem"}]}}`, false},
+		{"empty extra certificate row", `{"security":"tls","tlsSettings":{"certificates":[{"certificateFile":"/node/cert.pem","keyFile":"/node/key.pem"},{}]}}`, true},
+		{"empty extra verify certificate", `{"security":"tls","tlsSettings":{"certificates":[{"certificateFile":"/node/cert.pem","keyFile":"/node/key.pem"},{"usage":"verify"}]}}`, true},
+		{"whitespace certificate file overrides inline content", `{"security":"tls","tlsSettings":{"certificates":[{"certificateFile":" ","certificate":["certificate"],"key":["private key"]}]}}`, true},
+		{"whitespace key file overrides inline content", `{"security":"tls","tlsSettings":{"certificates":[{"certificate":["certificate"],"keyFile":" ","key":["private key"]}]}}`, true},
+		{"malformed stream", `{"security":"tls"`, true},
+		{"malformed TLS settings", `{"security":"tls","tlsSettings":"invalid"}`, true},
+		{"malformed certificate list", `{"security":"tls","tlsSettings":{"certificates":{}}}`, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateInboundTLSCertificates(tt.streamSettings)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("validateInboundTLSCertificates() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestValidateInboundTLSCertificatesIdentifiesIncompleteRow(t *testing.T) {
+	err := validateInboundTLSCertificates(`{"security":"tls","tlsSettings":{"certificates":[{"certificateFile":"/node/cert.pem","keyFile":"/node/key.pem"},{"certificateFile":"/node/other.pem"}]}}`)
+	if err == nil || !strings.Contains(err.Error(), "TLS certificate 2") || !strings.Contains(err.Error(), "private key") {
+		t.Fatalf("expected actionable error for the second certificate's private key, got %v", err)
+	}
+}
+
+func TestAddInboundRejectsMissingTLSCertificates(t *testing.T) {
+	setupConflictDB(t)
+	mgr := useTestRuntimeManager(t)
+	fake := &fakeNodeRuntime{}
+	mgr.SetLocalRuntimeOverride(fake)
+
+	inbound := &model.Inbound{
+		Tag:            "tls-missing-44310",
+		Enable:         true,
+		Listen:         "0.0.0.0",
+		Port:           44310,
+		Protocol:       model.VLESS,
+		StreamSettings: `{"network":"tcp","security":"tls","tlsSettings":{"certificates":[{"certificateFile":"","keyFile":""}]}}`,
+		Settings:       `{"clients":[]}`,
+	}
+	_, needRestart, err := (&InboundService{}).AddInbound(inbound)
+	if err == nil || !strings.Contains(err.Error(), "TLS") {
+		t.Fatalf("AddInbound: expected TLS validation error, got %v", err)
+	}
+	if needRestart {
+		t.Fatal("AddInbound: rejected TLS configuration requested a restart")
+	}
+	var count int64
+	if err := database.GetDB().Model(&model.Inbound{}).Count(&count).Error; err != nil {
+		t.Fatalf("count inbounds: %v", err)
+	}
+	if count != 0 {
+		t.Fatalf("AddInbound: rejected TLS configuration created %d rows", count)
+	}
+	if fake.addInbound.Load() != 0 || fake.updateInbound.Load() != 0 || fake.delInbound.Load() != 0 {
+		t.Fatal("AddInbound: rejected TLS configuration reached the runtime")
+	}
+}
+
+func TestUpdateInboundRejectsMissingTLSCertificates(t *testing.T) {
+	setupConflictDB(t)
+	mgr := useTestRuntimeManager(t)
+	fake := &fakeNodeRuntime{}
+	mgr.SetLocalRuntimeOverride(fake)
+
+	seedInboundConflict(t, "tls-existing-44311", "0.0.0.0", 44311, model.VLESS,
+		`{"network":"tcp","security":"tls","tlsSettings":{"certificates":[{"certificateFile":"/node/cert.pem","keyFile":"/node/key.pem"}]}}`, `{"clients":[]}`)
+	var existing model.Inbound
+	if err := database.GetDB().Where("tag = ?", "tls-existing-44311").First(&existing).Error; err != nil {
+		t.Fatalf("load existing inbound: %v", err)
+	}
+	update := existing
+	update.Remark = "must not be saved"
+	update.Port = 44312
+	update.StreamSettings = `{"network":"tcp","security":"tls","tlsSettings":{"certificates":[{"certificateFile":"/node/cert.pem"}]}}`
+	_, needRestart, err := (&InboundService{}).UpdateInbound(&update)
+	if err == nil || !strings.Contains(err.Error(), "TLS") {
+		t.Fatalf("UpdateInbound: expected TLS validation error, got %v", err)
+	}
+	if needRestart {
+		t.Fatal("UpdateInbound: rejected TLS configuration requested a restart")
+	}
+	var reloaded model.Inbound
+	if err := database.GetDB().First(&reloaded, existing.Id).Error; err != nil {
+		t.Fatalf("reload existing inbound: %v", err)
+	}
+	if !reflect.DeepEqual(reloaded, existing) {
+		t.Fatal("UpdateInbound: rejected TLS configuration changed the stored inbound")
+	}
+	if fake.addInbound.Load() != 0 || fake.updateInbound.Load() != 0 || fake.delInbound.Load() != 0 {
+		t.Fatal("UpdateInbound: rejected TLS configuration reached the runtime")
+	}
+}

--- a/internal/web/translation/ar-EG.json
+++ b/internal/web/translation/ar-EG.json
@@ -453,6 +453,7 @@
         "scanRealityTargetPrivate": "الهدف يعمل لكنه في شبكة خاصة/محلية.",
         "invalidClientField": "العميل {client}: الحقل {field} — {reason}",
         "invalidField": "{field} — {reason}",
+        "invalidCertificate": "شهادة TLS رقم {index}: {reason}",
         "moreIssues": "{message}  (+{count} أخرى)"
       },
       "form": {
@@ -609,6 +610,9 @@
         "shortIds": "Short IDs",
         "realityTargetHint": "مطلوب. يجب أن يتضمّن منفذًا (مثل example.com:443). بدون منفذ يرفض Xray-core البدء.",
         "realityTargetRequired": "هدف REALITY مطلوب",
+        "tlsCertificateRequired": "استورد شهادة TLS أو أدخل مسار ملفها قبل الحفظ",
+        "tlsPrivateKeyRequired": "استورد مفتاح TLS الخاص أو أدخل مسار ملفه قبل الحفظ",
+        "tlsServerCertificateRequired": "يتطلب TLS شهادة خادم واحدة على الأقل مع مفتاحها الخاص (encipherment أو issue)",
         "realityTargetNeedsPort": "يجب أن يتضمّن هدف REALITY منفذًا (مثل example.com:443)",
         "realityTargetInvalidPort": "هدف REALITY يحتوي على منفذ غير صالح",
         "scan": "فحص",

--- a/internal/web/translation/en-US.json
+++ b/internal/web/translation/en-US.json
@@ -453,6 +453,7 @@
         "scanRealityTargetPrivate": "Target is reachable but sits on a private/local network.",
         "invalidClientField": "Client {client}: {field} — {reason}",
         "invalidField": "{field} — {reason}",
+        "invalidCertificate": "TLS certificate {index}: {reason}",
         "moreIssues": "{message}  (+{count} more)"
       },
       "form": {
@@ -621,6 +622,9 @@
         "shortIds": "Short IDs",
         "realityTargetHint": "Required. Must include a port (e.g. example.com:443). Without a port Xray-core refuses to start.",
         "realityTargetRequired": "REALITY target is required",
+        "tlsCertificateRequired": "Import a TLS certificate or enter its file path before saving",
+        "tlsPrivateKeyRequired": "Import the TLS private key or enter its file path before saving",
+        "tlsServerCertificateRequired": "TLS requires at least one server certificate with its private key (encipherment or issue)",
         "realityTargetNeedsPort": "REALITY target must include a port (e.g. example.com:443)",
         "realityTargetInvalidPort": "REALITY target has an invalid port",
         "scan": "Scan",

--- a/internal/web/translation/es-ES.json
+++ b/internal/web/translation/es-ES.json
@@ -453,6 +453,7 @@
         "scanRealityTargetPrivate": "El destino funciona, pero está en una red privada/local.",
         "invalidClientField": "Cliente {client}: campo {field} — {reason}",
         "invalidField": "{field} — {reason}",
+        "invalidCertificate": "Certificado TLS {index}: {reason}",
         "moreIssues": "{message}  (+{count} más)"
       },
       "form": {
@@ -630,6 +631,9 @@
         "shortIds": "Short IDs",
         "realityTargetHint": "Obligatorio. Debe incluir un puerto (p. ej. example.com:443). Sin puerto, Xray-core no arranca.",
         "realityTargetRequired": "El destino REALITY es obligatorio",
+        "tlsCertificateRequired": "Importe un certificado TLS o introduzca la ruta de su archivo antes de guardar",
+        "tlsPrivateKeyRequired": "Importe la clave privada TLS o introduzca la ruta de su archivo antes de guardar",
+        "tlsServerCertificateRequired": "TLS requiere al menos un certificado de servidor con su clave privada (encipherment o issue)",
         "realityTargetNeedsPort": "El destino REALITY debe incluir un puerto (p. ej. example.com:443)",
         "realityTargetInvalidPort": "El destino REALITY tiene un puerto no válido",
         "scan": "Escanear",

--- a/internal/web/translation/fa-IR.json
+++ b/internal/web/translation/fa-IR.json
@@ -453,6 +453,7 @@
         "scanRealityTargetPrivate": "هدف کار می‌کند اما در شبکهٔ خصوصی/محلی قرار دارد.",
         "invalidClientField": "کلاینت {client}: فیلد {field} — {reason}",
         "invalidField": "{field} — {reason}",
+        "invalidCertificate": "گواهی TLS شماره {index}: {reason}",
         "moreIssues": "{message}  (+{count} مورد دیگر)"
       },
       "form": {
@@ -621,6 +622,9 @@
         "shortIds": "Short IDها",
         "realityTargetHint": "الزامی است. باید شامل پورت باشد (مثلاً example.com:443). بدون پورت، Xray-core اجرا نمی‌شود.",
         "realityTargetRequired": "هدف REALITY الزامی است",
+        "tlsCertificateRequired": "پیش از ذخیره، گواهی TLS را وارد کنید یا مسیر فایل آن را بنویسید",
+        "tlsPrivateKeyRequired": "پیش از ذخیره، کلید خصوصی TLS را وارد کنید یا مسیر فایل آن را بنویسید",
+        "tlsServerCertificateRequired": "TLS به حداقل یک گواهی سرور همراه با کلید خصوصی آن نیاز دارد (encipherment یا issue)",
         "realityTargetNeedsPort": "هدف REALITY باید شامل پورت باشد (مثلاً example.com:443)",
         "realityTargetInvalidPort": "پورت هدف REALITY نامعتبر است",
         "scan": "اسکن",

--- a/internal/web/translation/id-ID.json
+++ b/internal/web/translation/id-ID.json
@@ -453,6 +453,7 @@
         "scanRealityTargetPrivate": "Target dapat dijangkau, tetapi berada di jaringan privat/lokal.",
         "invalidClientField": "Klien {client}: kolom {field} — {reason}",
         "invalidField": "{field} — {reason}",
+        "invalidCertificate": "Sertifikat TLS {index}: {reason}",
         "moreIssues": "{message}  (+{count} lainnya)"
       },
       "form": {
@@ -609,6 +610,9 @@
         "shortIds": "Short IDs",
         "realityTargetHint": "Wajib. Harus menyertakan port (mis. example.com:443). Tanpa port, Xray-core menolak untuk mulai.",
         "realityTargetRequired": "Target REALITY wajib diisi",
+        "tlsCertificateRequired": "Impor sertifikat TLS atau masukkan jalur file sertifikat sebelum menyimpan",
+        "tlsPrivateKeyRequired": "Impor kunci privat TLS atau masukkan jalur file kunci privat sebelum menyimpan",
+        "tlsServerCertificateRequired": "TLS memerlukan setidaknya satu sertifikat server beserta kunci privatnya (encipherment atau issue)",
         "realityTargetNeedsPort": "Target REALITY harus menyertakan port (mis. example.com:443)",
         "realityTargetInvalidPort": "Target REALITY memiliki port yang tidak valid",
         "scan": "Pindai",

--- a/internal/web/translation/ja-JP.json
+++ b/internal/web/translation/ja-JP.json
@@ -453,6 +453,7 @@
         "scanRealityTargetPrivate": "ターゲットは利用可能ですが、プライベート/ローカルネットワーク上にあります。",
         "invalidClientField": "クライアント {client}: フィールド {field} — {reason}",
         "invalidField": "{field} — {reason}",
+        "invalidCertificate": "TLS 証明書 {index}: {reason}",
         "moreIssues": "{message}  (他 {count} 件)"
       },
       "form": {
@@ -630,6 +631,9 @@
         "shortIds": "Short IDs",
         "realityTargetHint": "必須です。ポートを含める必要があります（例: example.com:443）。ポートがないと Xray-core は起動しません。",
         "realityTargetRequired": "REALITY ターゲットは必須です",
+        "tlsCertificateRequired": "保存する前に TLS 証明書をインポートするか、証明書ファイルのパスを入力してください",
+        "tlsPrivateKeyRequired": "保存する前に TLS 秘密鍵をインポートするか、秘密鍵ファイルのパスを入力してください",
+        "tlsServerCertificateRequired": "TLS には、秘密鍵を含むサーバー証明書が少なくとも 1 組必要です（encipherment または issue）",
         "realityTargetNeedsPort": "REALITY ターゲットにはポートを含める必要があります（例: example.com:443）",
         "realityTargetInvalidPort": "REALITY ターゲットのポートが無効です",
         "scan": "スキャン",

--- a/internal/web/translation/pt-BR.json
+++ b/internal/web/translation/pt-BR.json
@@ -453,6 +453,7 @@
         "scanRealityTargetPrivate": "O destino funciona, mas está em uma rede privada/local.",
         "invalidClientField": "Cliente {client}: campo {field} — {reason}",
         "invalidField": "{field} — {reason}",
+        "invalidCertificate": "Certificado TLS {index}: {reason}",
         "moreIssues": "{message}  (+{count} mais)"
       },
       "form": {
@@ -630,6 +631,9 @@
         "shortIds": "Short IDs",
         "realityTargetHint": "Obrigatório. Deve incluir uma porta (ex.: example.com:443). Sem porta, o Xray-core não inicia.",
         "realityTargetRequired": "O alvo REALITY é obrigatório",
+        "tlsCertificateRequired": "Importe um certificado TLS ou informe o caminho do arquivo antes de salvar",
+        "tlsPrivateKeyRequired": "Importe a chave privada TLS ou informe o caminho do arquivo antes de salvar",
+        "tlsServerCertificateRequired": "O TLS exige pelo menos um certificado de servidor com sua chave privada (encipherment ou issue)",
         "realityTargetNeedsPort": "O alvo REALITY deve incluir uma porta (ex.: example.com:443)",
         "realityTargetInvalidPort": "O alvo REALITY tem uma porta inválida",
         "scan": "Escanear",

--- a/internal/web/translation/ru-RU.json
+++ b/internal/web/translation/ru-RU.json
@@ -453,6 +453,7 @@
         "scanRealityTargetPrivate": "Цель работает, но находится в приватной (локальной) сети.",
         "invalidClientField": "Клиент {client}: поле {field} — {reason}",
         "invalidField": "{field} — {reason}",
+        "invalidCertificate": "Сертификат TLS {index}: {reason}",
         "moreIssues": "{message}  (+{count} ещё)"
       },
       "form": {
@@ -630,6 +631,9 @@
         "shortIds": "Short IDs",
         "realityTargetHint": "Обязательно. Должно содержать порт (например, example.com:443). Без порта Xray-core не запускается.",
         "realityTargetRequired": "Цель REALITY обязательна",
+        "tlsCertificateRequired": "Перед сохранением импортируйте сертификат TLS или укажите путь к его файлу",
+        "tlsPrivateKeyRequired": "Перед сохранением импортируйте закрытый ключ TLS или укажите путь к его файлу",
+        "tlsServerCertificateRequired": "Для TLS требуется хотя бы один сертификат сервера с закрытым ключом (encipherment или issue)",
         "realityTargetNeedsPort": "Цель REALITY должна содержать порт (например, example.com:443)",
         "realityTargetInvalidPort": "У цели REALITY указан недопустимый порт",
         "scan": "Сканировать",

--- a/internal/web/translation/tr-TR.json
+++ b/internal/web/translation/tr-TR.json
@@ -453,6 +453,7 @@
         "scanRealityTargetPrivate": "Hedef çalışıyor ancak özel/yerel bir ağda.",
         "invalidClientField": "Kullanıcı {client}: {field} — {reason}",
         "invalidField": "{field} — {reason}",
+        "invalidCertificate": "TLS sertifikası {index}: {reason}",
         "moreIssues": "{message}  (+{count} tane daha)"
       },
       "form": {
@@ -609,6 +610,9 @@
         "shortIds": "Kısa Kimlikler",
         "realityTargetHint": "Zorunlu. Bir port içermelidir (ör. example.com:443). Port belirtilmezse Xray-core başlamaz.",
         "realityTargetRequired": "REALITY hedefi zorunludur",
+        "tlsCertificateRequired": "Kaydetmeden önce bir TLS sertifikası içe aktarın veya sertifika dosyasının yolunu girin",
+        "tlsPrivateKeyRequired": "Kaydetmeden önce TLS özel anahtarını içe aktarın veya özel anahtar dosyasının yolunu girin",
+        "tlsServerCertificateRequired": "TLS, özel anahtarıyla birlikte en az bir sunucu sertifikası gerektirir (encipherment veya issue)",
         "realityTargetNeedsPort": "REALITY hedefi bir port içermelidir (ör. example.com:443)",
         "realityTargetInvalidPort": "REALITY hedefinde geçersiz bir port var",
         "scan": "Tara",

--- a/internal/web/translation/uk-UA.json
+++ b/internal/web/translation/uk-UA.json
@@ -453,6 +453,7 @@
         "scanRealityTargetPrivate": "Ціль працює, але розташована у приватній (локальній) мережі.",
         "invalidClientField": "Клієнт {client}: поле {field} — {reason}",
         "invalidField": "{field} — {reason}",
+        "invalidCertificate": "Сертифікат TLS {index}: {reason}",
         "moreIssues": "{message}  (+{count} ще)"
       },
       "form": {
@@ -609,6 +610,9 @@
         "shortIds": "Short IDs",
         "realityTargetHint": "Обов'язково. Має містити порт (напр., example.com:443). Без порту Xray-core не запускається.",
         "realityTargetRequired": "Ціль REALITY обов'язкова",
+        "tlsCertificateRequired": "Перед збереженням імпортуйте сертифікат TLS або вкажіть шлях до його файлу",
+        "tlsPrivateKeyRequired": "Перед збереженням імпортуйте приватний ключ TLS або вкажіть шлях до його файлу",
+        "tlsServerCertificateRequired": "Для TLS потрібен принаймні один сертифікат сервера з приватним ключем (encipherment або issue)",
         "realityTargetNeedsPort": "Ціль REALITY має містити порт (напр., example.com:443)",
         "realityTargetInvalidPort": "Ціль REALITY має недійсний порт",
         "scan": "Сканувати",

--- a/internal/web/translation/vi-VN.json
+++ b/internal/web/translation/vi-VN.json
@@ -453,6 +453,7 @@
         "scanRealityTargetPrivate": "Đích hoạt động nhưng nằm trong mạng riêng/nội bộ.",
         "invalidClientField": "Khách hàng {client}: trường {field} — {reason}",
         "invalidField": "{field} — {reason}",
+        "invalidCertificate": "Chứng chỉ TLS {index}: {reason}",
         "moreIssues": "{message}  (+{count} lỗi khác)"
       },
       "form": {
@@ -630,6 +631,9 @@
         "shortIds": "Short IDs",
         "realityTargetHint": "Bắt buộc. Phải bao gồm cổng (ví dụ example.com:443). Không có cổng, Xray-core sẽ không khởi động.",
         "realityTargetRequired": "Mục tiêu REALITY là bắt buộc",
+        "tlsCertificateRequired": "Nhập chứng chỉ TLS hoặc điền đường dẫn tệp chứng chỉ trước khi lưu",
+        "tlsPrivateKeyRequired": "Nhập khóa riêng TLS hoặc điền đường dẫn tệp khóa riêng trước khi lưu",
+        "tlsServerCertificateRequired": "TLS yêu cầu ít nhất một chứng chỉ máy chủ kèm khóa riêng (encipherment hoặc issue)",
         "realityTargetNeedsPort": "Mục tiêu REALITY phải bao gồm cổng (ví dụ example.com:443)",
         "realityTargetInvalidPort": "Mục tiêu REALITY có cổng không hợp lệ",
         "scan": "Quét",

--- a/internal/web/translation/zh-CN.json
+++ b/internal/web/translation/zh-CN.json
@@ -453,6 +453,7 @@
         "scanRealityTargetPrivate": "目标可用，但位于内网/本地网络中。",
         "invalidClientField": "客户端 {client}：字段 {field} — {reason}",
         "invalidField": "{field} — {reason}",
+        "invalidCertificate": "第 {index} 组 TLS 证书：{reason}",
         "moreIssues": "{message}  (另有 {count} 项)"
       },
       "form": {
@@ -629,6 +630,9 @@
         "shortIds": "Short IDs",
         "realityTargetHint": "必填。必须包含端口（例如 example.com:443）。没有端口时 Xray-core 将无法启动。",
         "realityTargetRequired": "REALITY 目标为必填项",
+        "tlsCertificateRequired": "请先导入 TLS 证书或填写证书文件路径，再保存入站",
+        "tlsPrivateKeyRequired": "请先导入 TLS 私钥或填写私钥文件路径，再保存入站",
+        "tlsServerCertificateRequired": "TLS 至少需要一组包含私钥的服务端证书（encipherment 或 issue）",
         "realityTargetNeedsPort": "REALITY 目标必须包含端口（例如 example.com:443）",
         "realityTargetInvalidPort": "REALITY 目标的端口无效",
         "scan": "扫描",

--- a/internal/web/translation/zh-TW.json
+++ b/internal/web/translation/zh-TW.json
@@ -453,6 +453,7 @@
         "scanRealityTargetPrivate": "目標可用，但位於內網/本機網路中。",
         "invalidClientField": "用戶端 {client}：欄位 {field} — {reason}",
         "invalidField": "{field} — {reason}",
+        "invalidCertificate": "第 {index} 組 TLS 憑證：{reason}",
         "moreIssues": "{message}  (另有 {count} 項)"
       },
       "form": {
@@ -609,6 +610,9 @@
         "shortIds": "Short IDs",
         "realityTargetHint": "必填。必須包含連接埠（例如 example.com:443）。沒有連接埠時 Xray-core 將無法啟動。",
         "realityTargetRequired": "REALITY 目標為必填項",
+        "tlsCertificateRequired": "請先匯入 TLS 憑證或填寫憑證檔案路徑，再儲存入站",
+        "tlsPrivateKeyRequired": "請先匯入 TLS 私鑰或填寫私鑰檔案路徑，再儲存入站",
+        "tlsServerCertificateRequired": "TLS 至少需要一組包含私鑰的伺服器憑證（encipherment 或 issue）",
         "realityTargetNeedsPort": "REALITY 目標必須包含連接埠（例如 example.com:443）",
         "realityTargetInvalidPort": "REALITY 目標的連接埠無效",
         "scan": "掃描",


### PR DESCRIPTION
## Summary

Reject incomplete TLS certificates when adding or editing an inbound. The form shows an actionable, localized certificate error and opens the Security tab; the backend rejects the same configuration before database writes or runtime updates can request an Xray restart.

## Why

The default TLS certificate row contains empty file paths and empty inline arrays. The shared certificate union previously accepted the empty inline branch, and the backend saved it before attempting to apply it to Xray. A failed runtime update could then request a restart with the invalid configuration.

The inbound form now validates each certificate in the selected file/content mode and requires a server certificate with its private key. Verification CAs may omit their private keys, but cannot be the only certificates. The shared reader also preserves valid verification CAs so saving and reading back an inbound does not discard SNI, ALPN or client TLS settings.

## Type of change

- [x] Bug fix

## Areas affected

- [x] Frontend (UI / panel pages)
- [x] Backend (API endpoints, login, settings)
- [x] Subscription (share links / Clash / JSON)

## How was this tested?

- `go build ./...`
- `go test ./internal/web/service -count=1`
- `npm run lint`, `npm run typecheck`, and `npm run build` in `frontend/`.
- 124 frontend tests passed across these six files:
  ```sh
  npm test -- src/test/inbound-tls-validation.test.ts src/test/inbound-from-db.test.ts src/test/stream-wire-normalize.test.ts src/test/inbound-form-modal.test.tsx src/test/format-validation-error.test.ts src/test/inbound-form-adapter.test.ts
  ```
- Component regression: choose TLS in Add Inbound, leave the certificate empty, return to Basics and save. Assert that Security opens, an actionable certificate error is shown, and no HTTP save request is made.
- Backend regressions verify that rejected adds/updates do not persist changes, call the runtime or request a restart, including case-insensitive TLS security values.
- File and inline CA round trips preserve certificates, SNI, ALPN, fingerprint and certificate pins.
- `git diff --check`. The production build introduced no tracked generated-file changes.

The complete repository-wide Go test suite and a live Xray deployment were not run.

## Screenshots / recordings

No visual layout changes. The validation interaction is covered by the component regression described above.

## Breaking changes

Valid configurations retain their behavior. Add/update requests with incomplete TLS credentials are now rejected. Existing database rows are not migrated. File paths are checked for presence only; this does not validate remote file accessibility or PEM contents.

## Checklist

- [x] I tested the change locally and confirmed the described behavior.
- [x] I added or updated tests for the new behavior.
- [ ] `go build ./...` and the full test suite pass locally (build and the affected service package passed; the full suite was not run).
- [x] For frontend changes: `npm run lint`, `npm run typecheck`, and `npm run build` pass.
- [x] My commits follow the project's existing message style.
- [x] I have no unrelated changes mixed into this PR.
