### PR TITLE
docs(api): mark collection responses nullable

### DIFF
--- a/docs/public/openapi.json
+++ b/docs/public/openapi.json
@@ -4340,7 +4340,13 @@
                     "msg": {
                       "type": "string"
                     },
-                    "obj": {}
+                    "obj": {
+                      "type": "array",
+                      "nullable": true,
+                      "items": {
+                        "type": "string"
+                      }
+                    }
                   }
                 },
                 "example": {
@@ -6399,6 +6405,7 @@
                     },
                     "obj": {
                       "type": "array",
+                      "nullable": true,
                       "items": {
                         "type": "string"
                       }

--- a/docs/public/openapi.json
+++ b/docs/public/openapi.json
@@ -6487,6 +6487,7 @@
                     },
                     "obj": {
                       "type": "array",
+                      "nullable": true,
                       "items": {
                         "$ref": "#/components/schemas/LogEntry"
                       }

--- a/frontend/public/openapi.json
+++ b/frontend/public/openapi.json
@@ -4340,7 +4340,13 @@
                     "msg": {
                       "type": "string"
                     },
-                    "obj": {}
+                    "obj": {
+                      "type": "array",
+                      "nullable": true,
+                      "items": {
+                        "type": "string"
+                      }
+                    }
                   }
                 },
                 "example": {
@@ -6399,6 +6405,7 @@
                     },
                     "obj": {
                       "type": "array",
+                      "nullable": true,
                       "items": {
                         "type": "string"
                       }

--- a/frontend/public/openapi.json
+++ b/frontend/public/openapi.json
@@ -6487,6 +6487,7 @@
                     },
                     "obj": {
                       "type": "array",
+                      "nullable": true,
                       "items": {
                         "$ref": "#/components/schemas/LogEntry"
                       }

--- a/frontend/scripts/build-openapi.mjs
+++ b/frontend/scripts/build-openapi.mjs
@@ -245,7 +245,13 @@ function buildOperation(ep, tag) {
       );
     }
     const ref = { $ref: `#/components/schemas/${ep.responseSchema}` };
-    objSchema = ep.responseSchemaArray ? { type: 'array', items: ref } : ref;
+    objSchema = ep.responseSchemaArray
+      ? {
+          type: 'array',
+          ...(ep.responseSchemaArrayNullable ? { nullable: true } : {}),
+          items: ref,
+        }
+      : ref;
     if (successExample === undefined) {
       successExample = { success: true, obj: ep.responseSchemaArray ? [obj] : obj };
     }

--- a/frontend/src/pages/api-docs/endpoints.ts
+++ b/frontend/src/pages/api-docs/endpoints.ts
@@ -265,6 +265,7 @@ export const sections: readonly Section[] = [
       {
         method: 'GET',
         path: '/panel/api/inbounds/allLinks',
+        responseObjectSchema: { type: 'array', nullable: true, items: { type: 'string' } },
         summary:
           'Return every protocol URL (vless://, vmess://, trojan://, ss://, hysteria://, mtproto) across all inbounds and all of their clients. Links are rendered through the subscription engine, so the configured remark template (name-only display part) is applied per client — the same output the client info/QR pages use. Protocols without a URL form (socks, http, mixed, wireguard, dokodemo, tunnel) contribute nothing. Used by the panel’s "Export all inbound links" action.',
         response:
@@ -709,7 +710,7 @@ export const sections: readonly Section[] = [
           },
         ],
         body: 'level=info&syslog=false',
-        responseObjectSchema: { type: 'array', items: { type: 'string' } },
+        responseObjectSchema: { type: 'array', nullable: true, items: { type: 'string' } },
         response:
           '{\n  "success": true,\n  "obj": [\n    "2025/01/01 12:00:00 [INFO] Server started",\n    "2025/01/01 12:00:01 [INFO] Xray is running"\n  ]\n}',
       },

--- a/frontend/src/pages/api-docs/endpoints.ts
+++ b/frontend/src/pages/api-docs/endpoints.ts
@@ -46,6 +46,7 @@ export interface Endpoint {
   bodyRequiredOneOf?: string[];
   responseSchema?: string;
   responseSchemaArray?: boolean;
+  responseSchemaArrayNullable?: boolean;
   responseObjectSchema?: Record<string, unknown>;
   responses?: Record<string, Record<string, unknown>>;
   security?: readonly Record<string, readonly string[]>[];
@@ -752,6 +753,7 @@ export const sections: readonly Section[] = [
         body: 'filter=error&showDirect=false&showBlocked=true&showProxy=true',
         responseSchema: 'LogEntry',
         responseSchemaArray: true,
+        responseSchemaArrayNullable: true,
       },
       {
         method: 'POST',

--- a/frontend/src/test/openapi-runtime-contracts.test.ts
+++ b/frontend/src/test/openapi-runtime-contracts.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
 import { buildSpec } from '../../scripts/build-openapi.mjs';
+import { EXAMPLES } from '../generated/examples';
 
 interface OpenApiSchema {
   $ref?: string;
@@ -31,7 +32,7 @@ interface OpenApiOperation {
   responses: Record<
     string,
     {
-      content?: Record<string, { schema: OpenApiSchema }>;
+      content?: Record<string, { schema: OpenApiSchema; example?: unknown }>;
     }
   >;
   security?: Record<string, never[]>[];
@@ -143,8 +144,14 @@ describe('generated OpenAPI runtime contracts', () => {
     });
     expect(responseObjectSchema('/panel/api/server/xraylogs/{count}', 'post')).toEqual({
       type: 'array',
+      nullable: true,
       items: { $ref: '#/components/schemas/LogEntry' },
     });
+    expect(
+      operation('/panel/api/server/xraylogs/{count}', 'post').responses['200'].content?.[
+        'application/json'
+      ].example,
+    ).toEqual({ success: true, obj: [EXAMPLES.LogEntry] });
     expect(responseObjectSchema('/panel/api/server/getNewUUID')).toEqual({
       $ref: '#/components/schemas/NewUUIDResponse',
     });

--- a/frontend/src/test/openapi-runtime-contracts.test.ts
+++ b/frontend/src/test/openapi-runtime-contracts.test.ts
@@ -127,9 +127,18 @@ describe('generated OpenAPI runtime contracts', () => {
     });
   });
 
+  it('documents all inbound links as a nullable string array', () => {
+    expect(responseObjectSchema('/panel/api/inbounds/allLinks')).toEqual({
+      type: 'array',
+      nullable: true,
+      items: { type: 'string' },
+    });
+  });
+
   it('uses the runtime REST response schemas', () => {
     expect(responseObjectSchema('/panel/api/server/logs/{count}', 'post')).toEqual({
       type: 'array',
+      nullable: true,
       items: { type: 'string' },
     });
     expect(responseObjectSchema('/panel/api/server/xraylogs/{count}', 'post')).toEqual({


### PR DESCRIPTION
## Summary

Document three existing nullable collection responses in OpenAPI:

- `GET /panel/api/inbounds/allLinks`: `string[] | null`.
- `POST /panel/api/server/logs/{count}`: `string[] | null`.
- `POST /panel/api/server/xraylogs/{count}`: `LogEntry[] | null`.

Add opt-in nullable support for generated response arrays, preserving the Xray log example generated from `LogEntry`, and regression coverage for all three contracts.

Runtime behavior remains unchanged.

## Why

Related to #6411.

These endpoints can return a nil Go slice, which the panel envelope serializes as `"obj": null`, including successful empty responses. OpenAPI previously left the allLinks response object unconstrained and described both log responses as non-nullable arrays. Explicit nullable array schemas let generated clients account for the existing wire format. Other generated array schemas retain their current nullability.

## Type of change

- [x] Documentation
- [ ] Bug fix
- [ ] New feature
- [ ] Refactoring (no behavior change)
- [ ] Tests only
- [ ] Build / CI / tooling
- [ ] Other

## Areas affected

- [x] Frontend (API documentation metadata and regression tests)
- [ ] Backend (API endpoints, login, settings)
- [ ] Xray config generation
- [ ] Subscription (share links / Clash / JSON)
- [ ] Statistics / traffic counters
- [ ] Database / migrations
- [ ] Install / upgrade script
- [ ] Docker image
- [ ] Multi-node (sub-nodes)
- [ ] Telegram bot

## How was this tested?

Local toolchains: Node 24.20.0, Go 1.27.1, pnpm 11.25.0 (via Corepack).

- `cd frontend && npm test -- src/test/openapi-runtime-contracts.test.ts src/test/openapi-request-bodies.test.ts`: 2 files / 7 tests passed. All three affected schema assertions were confirmed failing before their fixes; the Xray log test also verifies the generated example is preserved.
- `cd frontend && npm run format:check && npm run lint && npm run typecheck`: passed.
- `make gen`: passed; repeated generation produced an identical diff.
- `cp frontend/public/openapi.json docs/public/openapi.json` and `cd docs && pnpm gen:api`: completed. MDX regeneration produced no changes.
- `cd docs && pnpm format:check && pnpm lint && pnpm typecheck && pnpm test`: passed (12 test files, 106 tests).
- `cmp frontend/public/openapi.json docs/public/openapi.json` and `git diff --check`: passed.

Full `make verify` is left to GitHub Actions. The diff contains only API metadata, the OpenAPI generator, regression tests, and the two generated OpenAPI copies; no Go or frontend runtime changes.

## Breaking changes

None.

## Checklist

- [x] I tested the change locally and confirmed the described behavior.
- [x] I added or updated tests for the new behavior (when applicable).
- [ ] `go build ./...` and the test suite pass locally.
- [ ] For frontend changes: `npm run lint`, `npm run typecheck`, and `npm run build` pass.
- [x] I updated the Wiki / README / API docs if user-facing behavior changed.
- [x] My commits follow the project's existing message style.
- [x] I have no unrelated changes mixed into this PR.
