### PR TITLE
fix(hosts): keep TLS override fields visible when Security is same

### DIFF
--- a/frontend/src/pages/hosts/HostFormModal.tsx
+++ b/frontend/src/pages/hosts/HostFormModal.tsx
@@ -91,8 +91,8 @@ export default function HostFormModal({
   const [loading, setLoading] = useState(false);
 
   const security = (useWatch({ control: methods.control, name: 'security' }) ?? 'same') as string;
-  const showTls = security === 'tls' || security === 'reality';
-  const showTlsExtras = security === 'tls';
+  const showTls = security === 'tls' || security === 'reality' || security === 'same';
+  const showTlsExtras = security === 'tls' || security === 'same';
 
   // React resets this during render rather than in an effect so the modal's
   // first open frame already shows cleared fields.


### PR DESCRIPTION
## Summary
Fixes #6444.

When a host's Security is set to `same`, Fingerprint / SNI (and related TLS override fields) were unmounted from `HostFormModal` while their values remained in the form store and continued to be saved. That trapped stale fingerprints so subscription links kept overriding the inbound's fingerprint.

Widen `showTls` / `showTlsExtras` so those fields stay reachable under `same`, using the existing allowClear / None controls as the escape hatch. No backend change — host fingerprint override on emission is intentional.

## Test plan
- [ ] Edit a host that previously had a fingerprint, set Security to `same`, confirm Fingerprint (and SNI) still appear
- [ ] Clear Fingerprint to None, save, confirm subscription link inherits inbound `fp` instead of the stale host value
- [ ] Sanity-check Security `tls` / `reality` / `none` still show the expected fields