### PR TITLE
fix(frontend): fold sockopt v6only into V6Only on inbound load

### DIFF
--- a/frontend/src/lib/xray/inbound-form-adapter.ts
+++ b/frontend/src/lib/xray/inbound-form-adapter.ts
@@ -183,9 +183,17 @@ export function rawInboundToFormValues(row: RawInboundRow): InboundFormValues {
     }
     const so = streamRecord.sockopt;
     if (so && typeof so === 'object' && !Array.isArray(so)) {
-      const parsed = SockoptStreamSettingsSchema.safeParse(so);
+      const raw = { ...(so as Record<string, unknown>) };
+      // Imported/API configs may use lowercase v6only; the form key is V6Only.
+      if ('v6only' in raw) {
+        if (!('V6Only' in raw)) raw.V6Only = Boolean(raw.v6only);
+        delete raw.v6only;
+      }
+      const parsed = SockoptStreamSettingsSchema.safeParse(raw);
       if (parsed.success) {
-        streamRecord.sockopt = { ...(so as Record<string, unknown>), ...parsed.data };
+        streamRecord.sockopt = { ...raw, ...parsed.data };
+      } else {
+        streamRecord.sockopt = raw;
       }
     }
   }


### PR DESCRIPTION
## Summary
Fixes #6421.

Loading a stored sockopt that uses Xray-style lowercase `v6only` merged the raw object with Zod defaults and produced both `v6only` and `V6Only` in Advanced Configuration. The form switch binds to `V6Only`, so a stored `v6only: true` rendered as off and could not be cleared.

Fold `v6only` into `V6Only` at the load boundary in `rawInboundToFormValues` and drop the lowercase key before the raw∪parsed merge. Port-conflict / multi-address listener behavior is intentionally out of scope here.

## Test plan
- [ ] Store or import an inbound sockopt with `"v6only": true`
- [ ] Open inbound edit → Advanced Configuration: only `V6Only` appears (no duplicate lowercase key)
- [ ] Sockopt form switch reflects on; toggling off and saving clears the option
- [ ] Inbounds that already use `V6Only` still round-trip unchanged