### PR TITLE
feat(clients): add Generate button for WireGuard/AmneziaWG PresharedKey

### DIFF
--- a/frontend/src/pages/clients/ClientFormModal.tsx
+++ b/frontend/src/pages/clients/ClientFormModal.tsx
@@ -270,7 +270,6 @@ export default function ClientFormModal({
   const limitHwid = useWatch({ control: methods.control, name: 'limitHwid' });
   const auth = useWatch({ control: methods.control, name: 'auth' });
   const wgPrivateKey = useWatch({ control: methods.control, name: 'wgPrivateKey' });
-  const wgPreSharedKey = useWatch({ control: methods.control, name: 'wgPreSharedKey' });
   const limitIp = useWatch({ control: methods.control, name: 'limitIp' });
   const {
     fields: externalLinkFields,
@@ -510,10 +509,7 @@ export default function ClientFormModal({
   }
 
   function regenerateWireguardPresharedKey() {
-    methods.setValue(
-      'wgPreSharedKey',
-      Wireguard.keyToBase64(Wireguard.generatePresharedKey()),
-    );
+    methods.setValue('wgPreSharedKey', Wireguard.keyToBase64(Wireguard.generatePresharedKey()));
   }
 
   function regenerateMtprotoSecret() {
@@ -1248,13 +1244,9 @@ export default function ClientFormModal({
                             )}
                           >
                             <Space.Compact style={{ display: 'flex' }}>
-                              <Input
-                                value={wgPreSharedKey}
-                                style={{ flex: 1 }}
-                                onChange={(e) =>
-                                  methods.setValue('wgPreSharedKey', e.target.value)
-                                }
-                              />
+                              <FormField name="wgPreSharedKey" noStyle>
+                                <Input style={{ flex: 1 }} />
+                              </FormField>
                               <Button
                                 aria-label={t('regenerate')}
                                 icon={<ReloadOutlined />}

--- a/frontend/src/pages/clients/ClientFormModal.tsx
+++ b/frontend/src/pages/clients/ClientFormModal.tsx
@@ -270,6 +270,7 @@ export default function ClientFormModal({
   const limitHwid = useWatch({ control: methods.control, name: 'limitHwid' });
   const auth = useWatch({ control: methods.control, name: 'auth' });
   const wgPrivateKey = useWatch({ control: methods.control, name: 'wgPrivateKey' });
+  const wgPreSharedKey = useWatch({ control: methods.control, name: 'wgPreSharedKey' });
   const limitIp = useWatch({ control: methods.control, name: 'limitIp' });
   const {
     fields: externalLinkFields,
@@ -506,6 +507,13 @@ export default function ClientFormModal({
     const kp = Wireguard.generateKeypair();
     methods.setValue('wgPrivateKey', kp.privateKey);
     methods.setValue('wgPublicKey', kp.publicKey);
+  }
+
+  function regenerateWireguardPresharedKey() {
+    methods.setValue(
+      'wgPreSharedKey',
+      Wireguard.keyToBase64(Wireguard.generatePresharedKey()),
+    );
   }
 
   function regenerateMtprotoSecret() {
@@ -1232,16 +1240,28 @@ export default function ClientFormModal({
                           >
                             <Input disabled />
                           </FormField>
-                          <FormField
-                            name="wgPreSharedKey"
+                          <Form.Item
                             label={t(
                               showAmneziawg
                                 ? 'pages.clients.amneziaWgPreSharedKey'
                                 : 'pages.clients.wireguardPreSharedKey',
                             )}
                           >
-                            <Input />
-                          </FormField>
+                            <Space.Compact style={{ display: 'flex' }}>
+                              <Input
+                                value={wgPreSharedKey}
+                                style={{ flex: 1 }}
+                                onChange={(e) =>
+                                  methods.setValue('wgPreSharedKey', e.target.value)
+                                }
+                              />
+                              <Button
+                                aria-label={t('regenerate')}
+                                icon={<ReloadOutlined />}
+                                onClick={regenerateWireguardPresharedKey}
+                              />
+                            </Space.Compact>
+                          </Form.Item>
                           {showWireguard && showAmneziawg ? (
                             <>
                               <FormField


### PR DESCRIPTION
## Summary
Fixes #6343.

Adds a regenerate button next to the WireGuard/AmneziaWG client `PresharedKey` field in `ClientFormModal`, matching the existing private-key / password regenerate controls (`Space.Compact` + `ReloadOutlined`).

Value is 32 random bytes encoded as base64 via the existing `Wireguard.generatePresharedKey()` + `keyToBase64()` helpers (same format as `wg genpsk`). Client-side only; field remains optional.

## Test plan
- [ ] Open add/edit client on a WireGuard inbound → Credentials tab shows PresharedKey with regenerate button
- [ ] Same for AmneziaWG inbound (shared field set)
- [ ] Click regenerate → fills a 44-char base64 key; click again → new value
- [ ] Leave empty → client saves and config omits `PresharedKey` line
- [ ] Set a generated PSK → subscription / `.conf` includes `PresharedKey = …`