### PR TITLE
fix(clients): snap EOM 23:59:59 expiry to billing midnight without renew

### DIFF
--- a/internal/web/service/inbound_autorenew_calendar_test.go
+++ b/internal/web/service/inbound_autorenew_calendar_test.go
@@ -389,3 +389,109 @@ func TestAutoRenewClients_CalendarModeSpendsOneAllowancePerMonth(t *testing.T) {
 		t.Fatalf("counters zeroed for a month the client can never use: up=%d down=%d", row.Up, row.Down)
 	}
 }
+
+
+// Inclusive end-of-month 23:59:59 is the same period end as the next billing
+// midnight. Snapping onto that boundary must not spend a renewal allowance, or
+// resetMax=1 is exhausted on a one-second step and the client stays expired (#6300).
+func TestAutoRenewClients_CalendarModeEndOfMonthExpiryDoesNotConsumeAllowance(t *testing.T) {
+	setupBulkDB(t)
+	svc := &InboundService{}
+	db := database.GetDB()
+	zone := pinPanelZone(t, "UTC")
+
+	now := time.Now().In(zone)
+	// Find billing-day (1st) midnight B with B < now < B+1 month so one
+	// charged renewal lands in the future.
+	boundary := time.Date(now.Year(), now.Month(), 1, 0, 0, 0, 0, zone)
+	for !(boundary.Before(now) && boundary.AddDate(0, 1, 0).After(now)) {
+		boundary = boundary.AddDate(0, -1, 0)
+	}
+	past := boundary.Add(-time.Second)
+	want := boundary.AddDate(0, 1, 0)
+
+	clients := []model.Client{
+		{Email: "eomcap@x", ID: "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa", Enable: false, ResetDay: 1, ResetMax: 1, ExpiryTime: past.UnixMilli()},
+	}
+	ib := mkInbound(t, 30207, model.VLESS, clientsSettings(t, clients))
+	if err := svc.clientService.SyncInbound(nil, ib.Id, clients); err != nil {
+		t.Fatalf("SyncInbound: %v", err)
+	}
+	if err := db.Create(&xray.ClientTraffic{
+		InboundId: ib.Id, Email: "eomcap@x", Enable: false, ResetDay: 1, ResetMax: 1, ResetCount: 0,
+		Up: 7, Down: 8, ExpiryTime: past.UnixMilli(),
+	}).Error; err != nil {
+		t.Fatalf("seed client_traffics: %v", err)
+	}
+
+	if _, count, err := svc.autoRenewClients(db, newTrafficMutationBatch()); err != nil {
+		t.Fatalf("autoRenewClients: %v", err)
+	} else if count != 1 {
+		t.Fatalf("renewed count = %d, want 1", count)
+	}
+
+	var row xray.ClientTraffic
+	if err := db.Where("email = ?", "eomcap@x").First(&row).Error; err != nil {
+		t.Fatal(err)
+	}
+	got := time.UnixMilli(row.ExpiryTime).In(zone)
+	if !got.Equal(want) {
+		t.Fatalf("renewed to %s, want %s (one full month after the billing midnight)", got.Format(time.RFC3339), want.Format(time.RFC3339))
+	}
+	if row.ResetCount != 1 {
+		t.Fatalf("resetCount = %d, want 1: the EOM snap must not consume an allowance", row.ResetCount)
+	}
+	if !row.Enable {
+		t.Fatal("client remained expired: the single allowance was spent on the one-second alignment")
+	}
+	if row.Up != 0 || row.Down != 0 {
+		t.Fatalf("counters not reset: up=%d down=%d", row.Up, row.Down)
+	}
+}
+
+// Same inclusive EOM expiry with an unlimited cap must still charge only one
+// renewal for the month, not two (alignment + month).
+func TestAutoRenewClients_CalendarModeEndOfMonthUnlimitedChargesOnce(t *testing.T) {
+	setupBulkDB(t)
+	svc := &InboundService{}
+	db := database.GetDB()
+	zone := pinPanelZone(t, "UTC")
+
+	now := time.Now().In(zone)
+	boundary := time.Date(now.Year(), now.Month(), 1, 0, 0, 0, 0, zone)
+	for !(boundary.Before(now) && boundary.AddDate(0, 1, 0).After(now)) {
+		boundary = boundary.AddDate(0, -1, 0)
+	}
+	past := boundary.Add(-time.Second)
+	want := boundary.AddDate(0, 1, 0)
+
+	clients := []model.Client{
+		{Email: "eomunc@x", ID: "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb", Enable: false, ResetDay: 1, ExpiryTime: past.UnixMilli()},
+	}
+	ib := mkInbound(t, 30208, model.VLESS, clientsSettings(t, clients))
+	if err := svc.clientService.SyncInbound(nil, ib.Id, clients); err != nil {
+		t.Fatalf("SyncInbound: %v", err)
+	}
+	if err := db.Create(&xray.ClientTraffic{
+		InboundId: ib.Id, Email: "eomunc@x", Enable: false, ResetDay: 1, ResetCount: 0,
+		ExpiryTime: past.UnixMilli(),
+	}).Error; err != nil {
+		t.Fatalf("seed client_traffics: %v", err)
+	}
+
+	if _, _, err := svc.autoRenewClients(db, newTrafficMutationBatch()); err != nil {
+		t.Fatalf("autoRenewClients: %v", err)
+	}
+
+	var row xray.ClientTraffic
+	if err := db.Where("email = ?", "eomunc@x").First(&row).Error; err != nil {
+		t.Fatal(err)
+	}
+	got := time.UnixMilli(row.ExpiryTime).In(zone)
+	if !got.Equal(want) {
+		t.Fatalf("renewed to %s, want %s", got.Format(time.RFC3339), want.Format(time.RFC3339))
+	}
+	if row.ResetCount != 1 {
+		t.Fatalf("resetCount = %d, want 1: unlimited must not double-count the EOM alignment", row.ResetCount)
+	}
+}

--- a/internal/web/service/inbound_autorenew_calendar_test.go
+++ b/internal/web/service/inbound_autorenew_calendar_test.go
@@ -390,10 +390,8 @@ func TestAutoRenewClients_CalendarModeSpendsOneAllowancePerMonth(t *testing.T) {
 	}
 }
 
-
-// Inclusive end-of-month 23:59:59 is the same period end as the next billing
-// midnight. Snapping onto that boundary must not spend a renewal allowance, or
-// resetMax=1 is exhausted on a one-second step and the client stays expired (#6300).
+// Inclusive EOM 23:59:59 must not spend an allowance on the one-second snap
+// to the billing midnight, or resetMax=1 leaves the client expired (#6300).
 func TestAutoRenewClients_CalendarModeEndOfMonthExpiryDoesNotConsumeAllowance(t *testing.T) {
 	setupBulkDB(t)
 	svc := &InboundService{}
@@ -401,14 +399,10 @@ func TestAutoRenewClients_CalendarModeEndOfMonthExpiryDoesNotConsumeAllowance(t 
 	zone := pinPanelZone(t, "UTC")
 
 	now := time.Now().In(zone)
-	// Find billing-day (1st) midnight B with B < now < B+1 month so one
-	// charged renewal lands in the future.
-	boundary := time.Date(now.Year(), now.Month(), 1, 0, 0, 0, 0, zone)
-	for !(boundary.Before(now) && boundary.AddDate(0, 1, 0).After(now)) {
-		boundary = boundary.AddDate(0, -1, 0)
-	}
+	// Prior billing midnight B with B < now < B+1mo so one charged step lands ahead.
+	want := firstBillingMidnightAfter(t, now, 1, zone)
+	boundary := want.AddDate(0, -1, 0)
 	past := boundary.Add(-time.Second)
-	want := boundary.AddDate(0, 1, 0)
 
 	clients := []model.Client{
 		{Email: "eomcap@x", ID: "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa", Enable: false, ResetDay: 1, ResetMax: 1, ExpiryTime: past.UnixMilli()},
@@ -449,8 +443,7 @@ func TestAutoRenewClients_CalendarModeEndOfMonthExpiryDoesNotConsumeAllowance(t 
 	}
 }
 
-// Same inclusive EOM expiry with an unlimited cap must still charge only one
-// renewal for the month, not two (alignment + month).
+// Unlimited EOM 23:59:59 must charge one renewal for the month, not two.
 func TestAutoRenewClients_CalendarModeEndOfMonthUnlimitedChargesOnce(t *testing.T) {
 	setupBulkDB(t)
 	svc := &InboundService{}
@@ -458,12 +451,9 @@ func TestAutoRenewClients_CalendarModeEndOfMonthUnlimitedChargesOnce(t *testing.
 	zone := pinPanelZone(t, "UTC")
 
 	now := time.Now().In(zone)
-	boundary := time.Date(now.Year(), now.Month(), 1, 0, 0, 0, 0, zone)
-	for !(boundary.Before(now) && boundary.AddDate(0, 1, 0).After(now)) {
-		boundary = boundary.AddDate(0, -1, 0)
-	}
+	want := firstBillingMidnightAfter(t, now, 1, zone)
+	boundary := want.AddDate(0, -1, 0)
 	past := boundary.Add(-time.Second)
-	want := boundary.AddDate(0, 1, 0)
 
 	clients := []model.Client{
 		{Email: "eomunc@x", ID: "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb", Enable: false, ResetDay: 1, ExpiryTime: past.UnixMilli()},
@@ -493,5 +483,51 @@ func TestAutoRenewClients_CalendarModeEndOfMonthUnlimitedChargesOnce(t *testing.
 	}
 	if row.ResetCount != 1 {
 		t.Fatalf("resetCount = %d, want 1: unlimited must not double-count the EOM alignment", row.ResetCount)
+	}
+}
+
+// Mid-day expiry on the day before billing still charges for alignment; only
+// the inclusive 23:59:59 instant is a free snap (#6300).
+func TestAutoRenewClients_CalendarModeMidDayBeforeBillingChargesAlignment(t *testing.T) {
+	setupBulkDB(t)
+	svc := &InboundService{}
+	db := database.GetDB()
+	zone := pinPanelZone(t, "UTC")
+
+	now := time.Now().In(zone)
+	boundary := firstBillingMidnightAfter(t, now, 1, zone).AddDate(0, -1, 0)
+	past := boundary.Add(-14 * time.Hour)
+
+	clients := []model.Client{
+		{Email: "eommid@x", ID: "cccccccc-cccc-cccc-cccc-cccccccccccc", Enable: false, ResetDay: 1, ResetMax: 1, ExpiryTime: past.UnixMilli()},
+	}
+	ib := mkInbound(t, 30209, model.VLESS, clientsSettings(t, clients))
+	if err := svc.clientService.SyncInbound(nil, ib.Id, clients); err != nil {
+		t.Fatalf("SyncInbound: %v", err)
+	}
+	if err := db.Create(&xray.ClientTraffic{
+		InboundId: ib.Id, Email: "eommid@x", Enable: false, ResetDay: 1, ResetMax: 1, ResetCount: 0,
+		ExpiryTime: past.UnixMilli(),
+	}).Error; err != nil {
+		t.Fatalf("seed client_traffics: %v", err)
+	}
+
+	if _, _, err := svc.autoRenewClients(db, newTrafficMutationBatch()); err != nil {
+		t.Fatalf("autoRenewClients: %v", err)
+	}
+
+	var row xray.ClientTraffic
+	if err := db.Where("email = ?", "eommid@x").First(&row).Error; err != nil {
+		t.Fatal(err)
+	}
+	got := time.UnixMilli(row.ExpiryTime).In(zone)
+	if !got.Equal(boundary) {
+		t.Fatalf("renewed to %s, want alignment onto %s (no free snap past midday)", got.Format(time.RFC3339), boundary.Format(time.RFC3339))
+	}
+	if row.ResetCount != 1 {
+		t.Fatalf("resetCount = %d, want 1: midday alignment must consume the allowance", row.ResetCount)
+	}
+	if row.Enable {
+		t.Fatal("midday alignment exhausted resetMax=1; client must stay expired")
 	}
 }

--- a/internal/web/service/inbound_traffic.go
+++ b/internal/web/service/inbound_traffic.go
@@ -448,6 +448,17 @@ func (s *InboundService) autoRenewClients(tx *gorm.DB, mutationBatch *trafficMut
 				continue
 			}
 			at := time.UnixMilli(newExpiryTime)
+			// Inclusive end-of-day expiries (e.g. 23:59:59 on the day before the
+			// billing midnight) are the same period end as that midnight. Snap up
+			// without spending an allowance so the first charged step is a full month (#6300).
+			if traffic.ResetDay > 0 {
+				boundary := nextCalendarRenewal(at, traffic.ResetDay, renewLocation)
+				lastDayStart := boundary.AddDate(0, 0, -1)
+				if !at.Before(lastDayStart) && at.Before(boundary) {
+					at = boundary
+					newExpiryTime = at.UnixMilli()
+				}
+			}
 			renewals := 0
 			for newExpiryTime < now {
 				if traffic.ResetMax > 0 && traffic.ResetCount+renewals >= traffic.ResetMax {

--- a/internal/web/service/inbound_traffic.go
+++ b/internal/web/service/inbound_traffic.go
@@ -448,13 +448,11 @@ func (s *InboundService) autoRenewClients(tx *gorm.DB, mutationBatch *trafficMut
 				continue
 			}
 			at := time.UnixMilli(newExpiryTime)
-			// Inclusive end-of-day expiries (e.g. 23:59:59 on the day before the
-			// billing midnight) are the same period end as that midnight. Snap up
-			// without spending an allowance so the first charged step is a full month (#6300).
+			// Inclusive end-of-day expiries share the next billing midnight; snap without
+			// spending an allowance so the first charged step is a full month (#6300).
 			if traffic.ResetDay > 0 {
 				boundary := nextCalendarRenewal(at, traffic.ResetDay, renewLocation)
-				lastDayStart := boundary.AddDate(0, 0, -1)
-				if !at.Before(lastDayStart) && at.Before(boundary) {
+				if !at.Before(boundary.Add(-time.Second)) && at.Before(boundary) {
 					at = boundary
 					newExpiryTime = at.UnixMilli()
 				}


### PR DESCRIPTION
Fixes #6300.

## Problem

Calendar auto-renew (`resetDay > 0`) treats an inclusive end-of-month expiry such as `2026-08-31 23:59:59` as a distinct instant before the billing-day midnight (`2026-09-01 00:00:00`). The catch-up loop in `autoRenewClients` then spends one renewal allowance on that one-second alignment. With `resetMax = 1` the client is left permanently expired; with an unlimited cap, `resetCount` increments twice for one intended monthly period.

## Fix

Before the catch-up loop, when `resetDay > 0` and the stored expiry falls on the calendar day immediately before its next billing midnight, snap `at` / `newExpiryTime` up to that boundary **without** counting a renewal. The first charged step then advances a full month.

`nextCalendarRenewal`, interval mode, and multi-month catch-up accounting are unchanged.

## Tests

Added in `inbound_autorenew_calendar_test.go`:

- capped (`resetMax = 1`) EOM `23:59:59` renews one full month and enables the client
- unlimited EOM case charges `resetCount` exactly once

Existing calendar allowance and landing-day tests remain green.