### PR TITLE
fix(api): return 401 for invalid Bearer token instead of 404

### DIFF
--- a/internal/web/controller/api.go
+++ b/internal/web/controller/api.go
@@ -61,7 +61,11 @@ func (a *APIController) checkAPIAuth(c *gin.Context) {
 		}
 	}
 	if !session.IsLogin(c) {
-		if c.GetHeader("X-Requested-With") == "XMLHttpRequest" {
+		// A presented Bearer token is not an anonymous scan: return 401 so
+		// callers can distinguish a bad/disabled token from a wrong base path
+		// (NoRoute still 404s). XHR keeps 401; bare unauthenticated stays 404.
+		authHdr := c.GetHeader("Authorization")
+		if strings.HasPrefix(authHdr, "Bearer ") || c.GetHeader("X-Requested-With") == "XMLHttpRequest" {
 			c.AbortWithStatus(http.StatusUnauthorized)
 		} else {
 			c.AbortWithStatus(http.StatusNotFound)

--- a/internal/web/controller/api_auth_test.go
+++ b/internal/web/controller/api_auth_test.go
@@ -219,24 +219,31 @@ func TestCheckAPIAuth_EmptyVerifiedChainsFallsThrough(t *testing.T) {
 	}
 }
 
-// TestCheckAPIAuth_RejectsUnauthenticated characterizes the reject paths: no
-// bearer token and no session yields 401 for XHR callers and 404 otherwise.
+// TestCheckAPIAuth_RejectsUnauthenticated characterizes the reject paths:
+// no credential → 404 (masking); XHR or a presented (but invalid) Bearer → 401
+// so script authors can tell auth failure from a wrong base path.
 func TestCheckAPIAuth_RejectsUnauthenticated(t *testing.T) {
 	engine, _ := newAPIAuthTestEngine(t)
 
 	cases := []struct {
-		name string
-		xhr  bool
-		want int
+		name   string
+		xhr    bool
+		bearer string // empty = omit Authorization header
+		want   int
 	}{
-		{"xhr gets 401", true, http.StatusUnauthorized},
-		{"non-xhr gets 404", false, http.StatusNotFound},
+		{"xhr gets 401", true, "", http.StatusUnauthorized},
+		{"non-xhr gets 404", false, "", http.StatusNotFound},
+		{"invalid bearer gets 401", false, "definitely-not-a-token", http.StatusUnauthorized},
+		{"invalid bearer xhr gets 401", true, "definitely-not-a-token", http.StatusUnauthorized},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
 			req := httptest.NewRequest(http.MethodGet, "/panel/api/ping", nil)
 			if c.xhr {
 				req.Header.Set("X-Requested-With", "XMLHttpRequest")
+			}
+			if c.bearer != "" {
+				req.Header.Set("Authorization", "Bearer "+c.bearer)
 			}
 			w := httptest.NewRecorder()
 			engine.ServeHTTP(w, req)


### PR DESCRIPTION
## Summary
- When `Authorization: Bearer` is present but the token does not match (or is disabled), `checkAPIAuth` now returns **401 Unauthorized** instead of masking as **404**.
- Requests with no `Authorization` header still get 404 (scanner masking preserved).
- Wrong `webBasePath` continues to 404 via `NoRoute`, so script authors can distinguish auth failure from a mistyped base path.

Fixes #6255

## Test plan
- [x] `go test ./internal/web/controller/ -run TestCheckAPIAuth_`
- [ ] Manual: valid Bearer → 200; invalid Bearer → 401; no Authorization → 404; wrong base path → 404