### PR TITLE
fix(amneziawg): honor inbound listen when binding UDP socket

### DIFF
--- a/internal/amneziawg/instance.go
+++ b/internal/amneziawg/instance.go
@@ -63,6 +63,7 @@ func InstanceFromInbound(ib *model.Inbound) (Instance, bool) {
 		Tag:                   ib.Tag,
 		InterfaceName:         interfaceNameForID(ib.Id),
 		ListenPort:            ib.Port,
+		Listen:                ib.Listen,
 		PrivateKey:            server.PrivateKey,
 		PublicKey:             server.PublicKey,
 		Address:               addresses,

--- a/internal/amneziawg/instance_test.go
+++ b/internal/amneziawg/instance_test.go
@@ -32,7 +32,7 @@ func TestInstanceFromInboundParsesEnabledPeers(t *testing.T) {
 		{Email: "c@x", Enable: true, PublicKey: "", AllowedIPs: []string{"10.8.1.4/32"}}, // no key: skipped
 		{Email: "d@x", Enable: true, PublicKey: "pubD", AllowedIPs: nil},                 // no address: skipped
 	})
-	ib := &model.Inbound{Id: 7, Tag: "awg-tag", Protocol: model.AmneziaWG, Port: 51820, Settings: settings}
+	ib := &model.Inbound{Id: 7, Tag: "awg-tag", Protocol: model.AmneziaWG, Port: 51820, Listen: "203.0.113.10", Settings: settings}
 
 	inst, ok := InstanceFromInbound(ib)
 	if !ok {
@@ -40,6 +40,9 @@ func TestInstanceFromInboundParsesEnabledPeers(t *testing.T) {
 	}
 	if inst.Id != 7 || inst.Tag != "awg-tag" || inst.ListenPort != 51820 {
 		t.Fatalf("instance identity not carried over: %+v", inst)
+	}
+	if inst.Listen != "203.0.113.10" {
+		t.Fatalf("Listen = %q, want inbound listen carried through", inst.Listen)
 	}
 	if inst.InterfaceName != "awg7" {
 		t.Fatalf("InterfaceName = %q, want awg7", inst.InterfaceName)

--- a/internal/amneziawg/types.go
+++ b/internal/amneziawg/types.go
@@ -75,8 +75,14 @@ type Instance struct {
 	Tag           string
 	InterfaceName string
 	ListenPort    int
-	PrivateKey    string
-	PublicKey     string
+	// Listen is the optional host bind address from the inbound's listen
+	// field (e.g. "203.0.113.10"). Empty, or a wildcard ("0.0.0.0" / "::"),
+	// means bind all addresses — the same default Xray-backed inbounds use.
+	// Carried into internal/amneziawgnet so the embedded device can open a
+	// Bind pinned to this address instead of always using the wildcard.
+	Listen     string
+	PrivateKey string
+	PublicKey  string
 	// Address holds the interface's own tunnel address(es), e.g. "10.8.1.1/24".
 	// Carries both the IPv4 and (when enabled) IPv6 server address.
 	Address []string

--- a/internal/amneziawg/types.go
+++ b/internal/amneziawg/types.go
@@ -75,11 +75,8 @@ type Instance struct {
 	Tag           string
 	InterfaceName string
 	ListenPort    int
-	// Listen is the optional host bind address from the inbound's listen
-	// field (e.g. "203.0.113.10"). Empty, or a wildcard ("0.0.0.0" / "::"),
-	// means bind all addresses — the same default Xray-backed inbounds use.
-	// Carried into internal/amneziawgnet so the embedded device can open a
-	// Bind pinned to this address instead of always using the wildcard.
+	// Listen is an optional host bind address (e.g. "203.0.113.10").
+	// Empty/wildcard keeps dual-stack StdNetBind; a real IP pins the UDP socket.
 	Listen     string
 	PrivateKey string
 	PublicKey  string

--- a/internal/amneziawgnet/client_device.go
+++ b/internal/amneziawgnet/client_device.go
@@ -114,11 +114,7 @@ func newUnconfiguredClientDevice(inst amneziawg.OutboundInstance, opts DeviceOpt
 	if logger == nil {
 		logger = device.NewLogger(device.LogLevelSilent, fmt.Sprintf("(awg-out %s) ", inst.Tag))
 	}
-	bind, err := newResolvingBind("")
-	if err != nil {
-		_ = tun.Close()
-		return nil, fmt.Errorf("amneziawgnet: listen address: %w", err)
-	}
+	bind := newResolvingBind("")
 	dev := device.NewDevice(tun, bind, logger)
 
 	return &Device{Device: dev, Stack: gstack, localAddrs: addrs}, nil

--- a/internal/amneziawgnet/client_device.go
+++ b/internal/amneziawgnet/client_device.go
@@ -114,7 +114,12 @@ func newUnconfiguredClientDevice(inst amneziawg.OutboundInstance, opts DeviceOpt
 	if logger == nil {
 		logger = device.NewLogger(device.LogLevelSilent, fmt.Sprintf("(awg-out %s) ", inst.Tag))
 	}
-	dev := device.NewDevice(tun, newResolvingBind(), logger)
+	bind, err := newResolvingBind("")
+	if err != nil {
+		_ = tun.Close()
+		return nil, fmt.Errorf("amneziawgnet: listen address: %w", err)
+	}
+	dev := device.NewDevice(tun, bind, logger)
 
 	return &Device{Device: dev, Stack: gstack, localAddrs: addrs}, nil
 }

--- a/internal/amneziawgnet/device.go
+++ b/internal/amneziawgnet/device.go
@@ -134,11 +134,7 @@ func newUnconfiguredDevice(inst amneziawg.Instance, opts DeviceOptions) (*Device
 	if logger == nil {
 		logger = device.NewLogger(device.LogLevelSilent, "")
 	}
-	bind, err := newResolvingBind(inst.Listen)
-	if err != nil {
-		_ = tun.Close()
-		return nil, fmt.Errorf("amneziawgnet: listen address: %w", err)
-	}
+	bind := newResolvingBind(inst.Listen)
 	dev := device.NewDevice(tun, bind, logger)
 
 	return &Device{Device: dev, Stack: gstack, localAddrs: addrs}, nil

--- a/internal/amneziawgnet/device.go
+++ b/internal/amneziawgnet/device.go
@@ -134,7 +134,12 @@ func newUnconfiguredDevice(inst amneziawg.Instance, opts DeviceOptions) (*Device
 	if logger == nil {
 		logger = device.NewLogger(device.LogLevelSilent, "")
 	}
-	dev := device.NewDevice(tun, newResolvingBind(), logger)
+	bind, err := newResolvingBind(inst.Listen)
+	if err != nil {
+		_ = tun.Close()
+		return nil, fmt.Errorf("amneziawgnet: listen address: %w", err)
+	}
+	dev := device.NewDevice(tun, bind, logger)
 
 	return &Device{Device: dev, Stack: gstack, localAddrs: addrs}, nil
 }

--- a/internal/amneziawgnet/manager.go
+++ b/internal/amneziawgnet/manager.go
@@ -258,11 +258,13 @@ func socksRelayForInstance(inst amneziawg.Instance) SocksRelay {
 }
 
 // addressFingerprint captures what IpcSet can't change on a running Device,
-// fixed when the netstack is built: address, and the S4-derived effective MTU.
+// fixed when the netstack/Bind is built: address, the S4-derived effective MTU,
+// and the host listen address the Bind was pinned to (empty = wildcard).
 func addressFingerprint(inst amneziawg.Instance) string {
-	return fmt.Sprintf("%d|%s",
+	return fmt.Sprintf("%d|%s|%s",
 		amneziawg.EffectiveMTU(inst.MTU, inst.Obfuscation.S4),
-		strings.Join(inst.Address, ","))
+		strings.Join(inst.Address, ","),
+		strings.TrimSpace(inst.Listen))
 }
 
 // Reconcile brings every desired instance's embedded interface up to date

--- a/internal/amneziawgnet/manager.go
+++ b/internal/amneziawgnet/manager.go
@@ -257,14 +257,12 @@ func socksRelayForInstance(inst amneziawg.Instance) SocksRelay {
 	}
 }
 
-// addressFingerprint captures what IpcSet can't change on a running Device,
-// fixed when the netstack/Bind is built: address, the S4-derived effective MTU,
-// and the host listen address the Bind was pinned to (empty = wildcard).
+// addressFingerprint captures Bind/netstack identity IpcSet cannot change.
 func addressFingerprint(inst amneziawg.Instance) string {
 	return fmt.Sprintf("%d|%s|%s",
 		amneziawg.EffectiveMTU(inst.MTU, inst.Obfuscation.S4),
 		strings.Join(inst.Address, ","),
-		strings.TrimSpace(inst.Listen))
+		normalizedListenFP(inst.Listen))
 }
 
 // Reconcile brings every desired instance's embedded interface up to date

--- a/internal/amneziawgnet/pinned_bind.go
+++ b/internal/amneziawgnet/pinned_bind.go
@@ -1,6 +1,7 @@
 package amneziawgnet
 
 import (
+	"context"
 	"fmt"
 	"net"
 	"net/netip"
@@ -36,7 +37,7 @@ func (b *pinnedBind) Open(uport uint16) ([]awgconn.ReceiveFunc, uint16, error) {
 	if b.addr.Is6() {
 		network = "udp6"
 	}
-	pc, err := net.ListenPacket(network, net.JoinHostPort(b.addr.String(), strconv.Itoa(int(uport))))
+	pc, err := (&net.ListenConfig{}).ListenPacket(context.Background(), network, net.JoinHostPort(b.addr.String(), strconv.Itoa(int(uport))))
 	if err != nil {
 		return nil, 0, err
 	}
@@ -144,7 +145,7 @@ func listenBindable(addr netip.Addr) bool {
 	if addr.Is6() {
 		network = "udp6"
 	}
-	pc, err := net.ListenPacket(network, net.JoinHostPort(addr.String(), "0"))
+	pc, err := (&net.ListenConfig{}).ListenPacket(context.Background(), network, net.JoinHostPort(addr.String(), "0"))
 	if err != nil {
 		return false
 	}

--- a/internal/amneziawgnet/pinned_bind.go
+++ b/internal/amneziawgnet/pinned_bind.go
@@ -9,16 +9,12 @@ import (
 	"sync"
 
 	awgconn "github.com/amnezia-vpn/amneziawg-go/v3/conn"
+
+	"github.com/mhsanaei/3x-ui/v3/internal/logger"
 )
 
-// pinnedBind is a Bind that opens its UDP socket on exactly one host
-// address. StdNetBind always listens on the wildcard ("0.0.0.0" / "::"),
-// which is what made AmneziaWG inbounds with a non-empty listen field
-// reply from the host's primary address on multi-IP setups (#6367).
-//
-// BatchSize is 1 and sticky/GSO offloads are omitted: correctness of the
-// source address is the point of this Bind, and the common empty-listen
-// path still uses StdNetBind via newListenBind.
+// pinnedBind opens its UDP socket on exactly one host address (#6367).
+// Empty/wildcard listen still uses StdNetBind via newListenBind.
 type pinnedBind struct {
 	mu   sync.Mutex
 	addr netip.Addr
@@ -81,8 +77,7 @@ func (b *pinnedBind) Close() error {
 	return err
 }
 
-// SetMark is a no-op: the panel never configures a WireGuard fwmark for
-// AmneziaWG, and pinning the listen address already fixes reply sourcing.
+// SetMark is a no-op: the panel never configures a WireGuard fwmark here.
 func (b *pinnedBind) SetMark(uint32) error { return nil }
 
 func (b *pinnedBind) Send(bufs [][]byte, ep awgconn.Endpoint) error {
@@ -114,31 +109,79 @@ func (b *pinnedBind) ParseEndpoint(s string) (awgconn.Endpoint, error) {
 
 func (b *pinnedBind) BatchSize() int { return 1 }
 
-// parseListenAddr interprets an inbound listen string. ok is false when the
-// value means "bind all addresses" (empty or a wildcard). An unparseable
-// non-wildcard value is an error so a typo fails loudly instead of silently
-// falling back to the wildcard that caused #6367.
-func parseListenAddr(listen string) (addr netip.Addr, ok bool, err error) {
-	listen = strings.TrimSpace(listen)
-	if listen == "" || listen == "0.0.0.0" || listen == "::" || listen == "[::]" {
-		return netip.Addr{}, false, nil
+// isWildcardListen reports empty / dual-stack wildcard listen values.
+// Includes ::0 (isAnyListen) and [::] so AmneziaWG keeps dual-stack StdNetBind.
+func isWildcardListen(listen string) bool {
+	switch strings.TrimSpace(listen) {
+	case "", "0.0.0.0", "::", "::0", "[::]", "[::0]":
+		return true
+	default:
+		return false
 	}
-	addr, err = netip.ParseAddr(listen)
-	if err != nil {
-		return netip.Addr{}, false, fmt.Errorf("invalid listen address %q: %w", listen, err)
-	}
-	return addr.Unmap(), true, nil
 }
 
-// newListenBind returns StdNetBind for wildcard listen values, or a
-// pinnedBind bound to a specific host address.
-func newListenBind(listen string) (awgconn.Bind, error) {
-	addr, pinned, err := parseListenAddr(listen)
+// parseListenAddr returns a concrete host address to pin. ok is false for
+// wildcards and for values that are not a bare IP (previously inert for AWG).
+func parseListenAddr(listen string) (addr netip.Addr, ok bool) {
+	listen = strings.TrimSpace(listen)
+	if isWildcardListen(listen) {
+		return netip.Addr{}, false
+	}
+	// Bracketed IPv6 literal e.g. [::1] — strip for ParseAddr.
+	if strings.HasPrefix(listen, "[") && strings.HasSuffix(listen, "]") {
+		listen = listen[1 : len(listen)-1]
+	}
+	addr, err := netip.ParseAddr(listen)
 	if err != nil {
-		return nil, err
+		return netip.Addr{}, false
 	}
+	return addr.Unmap(), true
+}
+
+// listenBindable probes whether addr can be used as a UDP local address.
+func listenBindable(addr netip.Addr) bool {
+	network := "udp4"
+	if addr.Is6() {
+		network = "udp6"
+	}
+	pc, err := net.ListenPacket(network, net.JoinHostPort(addr.String(), "0"))
+	if err != nil {
+		return false
+	}
+	_ = pc.Close()
+	return true
+}
+
+// newListenBind returns StdNetBind for wildcards / unusable listen values, or
+// a pinnedBind for a real local address. Never fails the inbound on bad listen.
+func newListenBind(listen string) awgconn.Bind {
+	raw := strings.TrimSpace(listen)
+	addr, pinned := parseListenAddr(raw)
 	if !pinned {
-		return awgconn.NewDefaultBind(), nil
+		if raw != "" && !isWildcardListen(raw) {
+			logger.Warningf("amneziawgnet: listen %q is not a bindable IP; using dual-stack wildcard", raw)
+		}
+		return awgconn.NewDefaultBind()
 	}
-	return newPinnedBind(addr), nil
+	if !listenBindable(addr) {
+		logger.Warningf("amneziawgnet: listen %q is not usable on this host; using dual-stack wildcard", raw)
+		return awgconn.NewDefaultBind()
+	}
+	return newPinnedBind(addr)
+}
+
+// normalizedListenFP collapses wildcard spellings so fingerprint rebuilds
+// only when the effective Bind actually changes.
+func normalizedListenFP(listen string) string {
+	if isWildcardListen(listen) {
+		return ""
+	}
+	addr, ok := parseListenAddr(listen)
+	if !ok {
+		return "" // unusable → same Bind as wildcard fallback
+	}
+	if !listenBindable(addr) {
+		return ""
+	}
+	return addr.String()
 }

--- a/internal/amneziawgnet/pinned_bind.go
+++ b/internal/amneziawgnet/pinned_bind.go
@@ -1,0 +1,144 @@
+package amneziawgnet
+
+import (
+	"fmt"
+	"net"
+	"net/netip"
+	"strconv"
+	"strings"
+	"sync"
+
+	awgconn "github.com/amnezia-vpn/amneziawg-go/v3/conn"
+)
+
+// pinnedBind is a Bind that opens its UDP socket on exactly one host
+// address. StdNetBind always listens on the wildcard ("0.0.0.0" / "::"),
+// which is what made AmneziaWG inbounds with a non-empty listen field
+// reply from the host's primary address on multi-IP setups (#6367).
+//
+// BatchSize is 1 and sticky/GSO offloads are omitted: correctness of the
+// source address is the point of this Bind, and the common empty-listen
+// path still uses StdNetBind via newListenBind.
+type pinnedBind struct {
+	mu   sync.Mutex
+	addr netip.Addr
+	conn *net.UDPConn
+}
+
+func newPinnedBind(addr netip.Addr) *pinnedBind {
+	return &pinnedBind{addr: addr.Unmap()}
+}
+
+func (b *pinnedBind) Open(uport uint16) ([]awgconn.ReceiveFunc, uint16, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if b.conn != nil {
+		return nil, 0, awgconn.ErrBindAlreadyOpen
+	}
+
+	network := "udp4"
+	if b.addr.Is6() {
+		network = "udp6"
+	}
+	pc, err := net.ListenPacket(network, net.JoinHostPort(b.addr.String(), strconv.Itoa(int(uport))))
+	if err != nil {
+		return nil, 0, err
+	}
+	uc, ok := pc.(*net.UDPConn)
+	if !ok {
+		pc.Close()
+		return nil, 0, fmt.Errorf("amneziawgnet: listen %s returned %T, want *net.UDPConn", network, pc)
+	}
+	laddr, ok := uc.LocalAddr().(*net.UDPAddr)
+	if !ok {
+		uc.Close()
+		return nil, 0, fmt.Errorf("amneziawgnet: unexpected local addr %T", uc.LocalAddr())
+	}
+	b.conn = uc
+	return []awgconn.ReceiveFunc{b.makeReceiveFunc(uc)}, uint16(laddr.Port), nil
+}
+
+func (b *pinnedBind) makeReceiveFunc(uc *net.UDPConn) awgconn.ReceiveFunc {
+	return func(bufs [][]byte, sizes []int, eps []awgconn.Endpoint) (int, error) {
+		n, addr, err := uc.ReadFromUDPAddrPort(bufs[0])
+		if err != nil {
+			return 0, err
+		}
+		sizes[0] = n
+		eps[0] = &awgconn.StdNetEndpoint{AddrPort: netip.AddrPortFrom(addr.Addr().Unmap(), addr.Port())}
+		return 1, nil
+	}
+}
+
+func (b *pinnedBind) Close() error {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if b.conn == nil {
+		return nil
+	}
+	err := b.conn.Close()
+	b.conn = nil
+	return err
+}
+
+// SetMark is a no-op: the panel never configures a WireGuard fwmark for
+// AmneziaWG, and pinning the listen address already fixes reply sourcing.
+func (b *pinnedBind) SetMark(uint32) error { return nil }
+
+func (b *pinnedBind) Send(bufs [][]byte, ep awgconn.Endpoint) error {
+	std, ok := ep.(*awgconn.StdNetEndpoint)
+	if !ok {
+		return awgconn.ErrWrongEndpointType
+	}
+	b.mu.Lock()
+	uc := b.conn
+	b.mu.Unlock()
+	if uc == nil {
+		return net.ErrClosed
+	}
+	for _, buf := range bufs {
+		if _, err := uc.WriteToUDPAddrPort(buf, std.AddrPort); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (b *pinnedBind) ParseEndpoint(s string) (awgconn.Endpoint, error) {
+	ap, err := netip.ParseAddrPort(s)
+	if err != nil {
+		return nil, err
+	}
+	return &awgconn.StdNetEndpoint{AddrPort: netip.AddrPortFrom(ap.Addr().Unmap(), ap.Port())}, nil
+}
+
+func (b *pinnedBind) BatchSize() int { return 1 }
+
+// parseListenAddr interprets an inbound listen string. ok is false when the
+// value means "bind all addresses" (empty or a wildcard). An unparseable
+// non-wildcard value is an error so a typo fails loudly instead of silently
+// falling back to the wildcard that caused #6367.
+func parseListenAddr(listen string) (addr netip.Addr, ok bool, err error) {
+	listen = strings.TrimSpace(listen)
+	if listen == "" || listen == "0.0.0.0" || listen == "::" || listen == "[::]" {
+		return netip.Addr{}, false, nil
+	}
+	addr, err = netip.ParseAddr(listen)
+	if err != nil {
+		return netip.Addr{}, false, fmt.Errorf("invalid listen address %q: %w", listen, err)
+	}
+	return addr.Unmap(), true, nil
+}
+
+// newListenBind returns StdNetBind for wildcard listen values, or a
+// pinnedBind bound to a specific host address.
+func newListenBind(listen string) (awgconn.Bind, error) {
+	addr, pinned, err := parseListenAddr(listen)
+	if err != nil {
+		return nil, err
+	}
+	if !pinned {
+		return awgconn.NewDefaultBind(), nil
+	}
+	return newPinnedBind(addr), nil
+}

--- a/internal/amneziawgnet/pinned_bind_test.go
+++ b/internal/amneziawgnet/pinned_bind_test.go
@@ -1,0 +1,173 @@
+package amneziawgnet
+
+import (
+	"net"
+	"net/netip"
+	"strconv"
+	"testing"
+	"time"
+
+	awgconn "github.com/amnezia-vpn/amneziawg-go/v3/conn"
+
+	"github.com/mhsanaei/3x-ui/v3/internal/amneziawg"
+)
+
+func TestParseListenAddr(t *testing.T) {
+	cases := []struct {
+		in      string
+		pinned  bool
+		want    string
+		wantErr bool
+	}{
+		{in: "", pinned: false},
+		{in: "  ", pinned: false},
+		{in: "0.0.0.0", pinned: false},
+		{in: "::", pinned: false},
+		{in: "[::]", pinned: false},
+		{in: "127.0.0.1", pinned: true, want: "127.0.0.1"},
+		{in: "::1", pinned: true, want: "::1"},
+		{in: "not-an-ip", wantErr: true},
+	}
+	for _, tc := range cases {
+		addr, ok, err := parseListenAddr(tc.in)
+		if tc.wantErr {
+			if err == nil {
+				t.Fatalf("parseListenAddr(%q) = (%v,%v), want error", tc.in, addr, ok)
+			}
+			continue
+		}
+		if err != nil {
+			t.Fatalf("parseListenAddr(%q): %v", tc.in, err)
+		}
+		if ok != tc.pinned {
+			t.Fatalf("parseListenAddr(%q) pinned=%v, want %v", tc.in, ok, tc.pinned)
+		}
+		if tc.pinned && addr.String() != tc.want {
+			t.Fatalf("parseListenAddr(%q) = %s, want %s", tc.in, addr, tc.want)
+		}
+	}
+}
+
+func TestNewListenBindPinsSpecificAddress(t *testing.T) {
+	bind, err := newListenBind("127.0.0.1")
+	if err != nil {
+		t.Fatalf("newListenBind: %v", err)
+	}
+	pb, ok := bind.(*pinnedBind)
+	if !ok {
+		t.Fatalf("bind type = %T, want *pinnedBind", bind)
+	}
+	fns, port, err := pb.Open(0)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer pb.Close()
+	if len(fns) != 1 {
+		t.Fatalf("ReceiveFuncs = %d, want 1", len(fns))
+	}
+	if port == 0 {
+		t.Fatal("expected a concrete ephemeral port")
+	}
+
+	laddr := pb.conn.LocalAddr().(*net.UDPAddr)
+	got := laddr.AddrPort().Addr().Unmap()
+	if got.String() != "127.0.0.1" {
+		t.Fatalf("LocalAddr = %v, want 127.0.0.1", got)
+	}
+
+	clash, err := newListenBind("127.0.0.1")
+	if err != nil {
+		t.Fatalf("second newListenBind: %v", err)
+	}
+	if _, _, err := clash.Open(port); err == nil {
+		clash.Close()
+		t.Fatalf("Open(%d) unexpectedly succeeded on an already-bound address", port)
+	}
+}
+
+func TestNewListenBindWildcardUsesDefault(t *testing.T) {
+	for _, listen := range []string{"", "0.0.0.0", "::"} {
+		bind, err := newListenBind(listen)
+		if err != nil {
+			t.Fatalf("newListenBind(%q): %v", listen, err)
+		}
+		if _, ok := bind.(*pinnedBind); ok {
+			t.Fatalf("newListenBind(%q) returned pinnedBind, want default StdNetBind", listen)
+		}
+	}
+}
+
+func TestPinnedBindRoundTrip(t *testing.T) {
+	server, err := newListenBind("127.0.0.1")
+	if err != nil {
+		t.Fatalf("server bind: %v", err)
+	}
+	recvFns, port, err := server.Open(0)
+	if err != nil {
+		t.Fatalf("server Open: %v", err)
+	}
+	defer server.Close()
+
+	client, err := net.ListenUDP("udp4", &net.UDPAddr{IP: net.IPv4(127, 0, 0, 1)})
+	if err != nil {
+		t.Fatalf("client listen: %v", err)
+	}
+	defer client.Close()
+
+	payload := []byte("hello-awg-listen")
+	dst := net.JoinHostPort("127.0.0.1", strconv.Itoa(int(port)))
+	ap, err := netip.ParseAddrPort(dst)
+	if err != nil {
+		t.Fatalf("ParseAddrPort: %v", err)
+	}
+	if _, err := client.WriteToUDPAddrPort(payload, ap); err != nil {
+		t.Fatalf("client write: %v", err)
+	}
+
+	bufs := [][]byte{make([]byte, 1500)}
+	sizes := make([]int, 1)
+	eps := make([]awgconn.Endpoint, 1)
+	n, err := recvFns[0](bufs, sizes, eps)
+	if err != nil {
+		t.Fatalf("receive: %v", err)
+	}
+	if n != 1 || sizes[0] != len(payload) {
+		t.Fatalf("receive n=%d size=%d, want 1/%d", n, sizes[0], len(payload))
+	}
+	if string(bufs[0][:sizes[0]]) != string(payload) {
+		t.Fatalf("payload = %q, want %q", bufs[0][:sizes[0]], payload)
+	}
+
+	reply := []byte("pong")
+	if err := server.Send([][]byte{reply}, eps[0]); err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+	_ = client.SetReadDeadline(time.Now().Add(2 * time.Second))
+	buf := make([]byte, 1500)
+	rn, _, err := client.ReadFromUDP(buf)
+	if err != nil {
+		t.Fatalf("client read: %v", err)
+	}
+	if string(buf[:rn]) != string(reply) {
+		t.Fatalf("reply = %q, want %q", buf[:rn], reply)
+	}
+}
+
+func TestAddressFingerprintIncludesListen(t *testing.T) {
+	base := amneziawg.Instance{
+		MTU:         1420,
+		Address:     []string{"10.8.1.1/24"},
+		Obfuscation: amneziawg.Obfuscation31{},
+	}
+	a := addressFingerprint(base)
+	base.Listen = "203.0.113.10"
+	b := addressFingerprint(base)
+	if a == b {
+		t.Fatalf("listen edit did not change addressFingerprint: %q", a)
+	}
+	if addressFingerprint(base) != b {
+		t.Fatal("identical listen should keep fingerprint stable")
+	}
+}
+
+var _ awgconn.Bind = (*pinnedBind)(nil)

--- a/internal/amneziawgnet/pinned_bind_test.go
+++ b/internal/amneziawgnet/pinned_bind_test.go
@@ -14,31 +14,25 @@ import (
 
 func TestParseListenAddr(t *testing.T) {
 	cases := []struct {
-		in      string
-		pinned  bool
-		want    string
-		wantErr bool
+		in     string
+		pinned bool
+		want   string
 	}{
 		{in: "", pinned: false},
 		{in: "  ", pinned: false},
 		{in: "0.0.0.0", pinned: false},
 		{in: "::", pinned: false},
+		{in: "::0", pinned: false},
 		{in: "[::]", pinned: false},
+		{in: "[::0]", pinned: false},
 		{in: "127.0.0.1", pinned: true, want: "127.0.0.1"},
 		{in: "::1", pinned: true, want: "::1"},
-		{in: "not-an-ip", wantErr: true},
+		{in: "[::1]", pinned: true, want: "::1"},
+		{in: "not-an-ip", pinned: false},
+		{in: "/var/run/awg.sock", pinned: false},
 	}
 	for _, tc := range cases {
-		addr, ok, err := parseListenAddr(tc.in)
-		if tc.wantErr {
-			if err == nil {
-				t.Fatalf("parseListenAddr(%q) = (%v,%v), want error", tc.in, addr, ok)
-			}
-			continue
-		}
-		if err != nil {
-			t.Fatalf("parseListenAddr(%q): %v", tc.in, err)
-		}
+		addr, ok := parseListenAddr(tc.in)
 		if ok != tc.pinned {
 			t.Fatalf("parseListenAddr(%q) pinned=%v, want %v", tc.in, ok, tc.pinned)
 		}
@@ -49,10 +43,7 @@ func TestParseListenAddr(t *testing.T) {
 }
 
 func TestNewListenBindPinsSpecificAddress(t *testing.T) {
-	bind, err := newListenBind("127.0.0.1")
-	if err != nil {
-		t.Fatalf("newListenBind: %v", err)
-	}
+	bind := newListenBind("127.0.0.1")
 	pb, ok := bind.(*pinnedBind)
 	if !ok {
 		t.Fatalf("bind type = %T, want *pinnedBind", bind)
@@ -75,10 +66,7 @@ func TestNewListenBindPinsSpecificAddress(t *testing.T) {
 		t.Fatalf("LocalAddr = %v, want 127.0.0.1", got)
 	}
 
-	clash, err := newListenBind("127.0.0.1")
-	if err != nil {
-		t.Fatalf("second newListenBind: %v", err)
-	}
+	clash := newListenBind("127.0.0.1")
 	if _, _, err := clash.Open(port); err == nil {
 		clash.Close()
 		t.Fatalf("Open(%d) unexpectedly succeeded on an already-bound address", port)
@@ -86,11 +74,8 @@ func TestNewListenBindPinsSpecificAddress(t *testing.T) {
 }
 
 func TestNewListenBindWildcardUsesDefault(t *testing.T) {
-	for _, listen := range []string{"", "0.0.0.0", "::"} {
-		bind, err := newListenBind(listen)
-		if err != nil {
-			t.Fatalf("newListenBind(%q): %v", listen, err)
-		}
+	for _, listen := range []string{"", "0.0.0.0", "::", "::0", "[::]", "hostname.example", "203.0.113.10", "not-an-ip"} {
+		bind := newListenBind(listen)
 		if _, ok := bind.(*pinnedBind); ok {
 			t.Fatalf("newListenBind(%q) returned pinnedBind, want default StdNetBind", listen)
 		}
@@ -98,10 +83,7 @@ func TestNewListenBindWildcardUsesDefault(t *testing.T) {
 }
 
 func TestPinnedBindRoundTrip(t *testing.T) {
-	server, err := newListenBind("127.0.0.1")
-	if err != nil {
-		t.Fatalf("server bind: %v", err)
-	}
+	server := newListenBind("127.0.0.1")
 	recvFns, port, err := server.Open(0)
 	if err != nil {
 		t.Fatalf("server Open: %v", err)
@@ -160,13 +142,18 @@ func TestAddressFingerprintIncludesListen(t *testing.T) {
 		Obfuscation: amneziawg.Obfuscation31{},
 	}
 	a := addressFingerprint(base)
-	base.Listen = "203.0.113.10"
+	base.Listen = "127.0.0.1"
 	b := addressFingerprint(base)
 	if a == b {
 		t.Fatalf("listen edit did not change addressFingerprint: %q", a)
 	}
-	if addressFingerprint(base) != b {
-		t.Fatal("identical listen should keep fingerprint stable")
+	base.Listen = "0.0.0.0"
+	if addressFingerprint(base) != a {
+		t.Fatal("wildcard spellings must share the empty-listen fingerprint")
+	}
+	base.Listen = "hostname.example"
+	if addressFingerprint(base) != a {
+		t.Fatal("unusable listen must fingerprint like wildcard fallback")
 	}
 }
 

--- a/internal/amneziawgnet/resolving_bind.go
+++ b/internal/amneziawgnet/resolving_bind.go
@@ -17,6 +17,8 @@ const endpointResolveTimeout = 5 * time.Second
 
 // resolvingBind lets peer endpoints be hostnames: StdNetBind has no DNS and
 // an unresolved name kills the whole IpcSet. Resolved once at configure.
+// When listen is a specific host address, the embedded Bind is a pinnedBind
+// so the UDP socket is bound only to that address (#6367).
 type resolvingBind struct {
 	awgconn.Bind
 }
@@ -35,8 +37,12 @@ func defaultLookupEndpointHost(ctx context.Context, host string) ([]netip.Addr, 
 	return out, nil
 }
 
-func newResolvingBind() *resolvingBind {
-	return &resolvingBind{Bind: awgconn.NewDefaultBind()}
+func newResolvingBind(listen string) (*resolvingBind, error) {
+	inner, err := newListenBind(listen)
+	if err != nil {
+		return nil, err
+	}
+	return &resolvingBind{Bind: inner}, nil
 }
 
 // ParseEndpoint resolves hostnames before handing the address to amneziawg-go

--- a/internal/amneziawgnet/resolving_bind.go
+++ b/internal/amneziawgnet/resolving_bind.go
@@ -15,10 +15,8 @@ import (
 // endpointResolveTimeout bounds the one-time DNS lookup in ParseEndpoint.
 const endpointResolveTimeout = 5 * time.Second
 
-// resolvingBind lets peer endpoints be hostnames: StdNetBind has no DNS and
-// an unresolved name kills the whole IpcSet. Resolved once at configure.
-// When listen is a specific host address, the embedded Bind is a pinnedBind
-// so the UDP socket is bound only to that address (#6367).
+// resolvingBind wraps a Bind so peer endpoints may be hostnames (#6367).
+// Concrete listen values use pinnedBind; wildcards keep StdNetBind.
 type resolvingBind struct {
 	awgconn.Bind
 }
@@ -37,12 +35,8 @@ func defaultLookupEndpointHost(ctx context.Context, host string) ([]netip.Addr, 
 	return out, nil
 }
 
-func newResolvingBind(listen string) (*resolvingBind, error) {
-	inner, err := newListenBind(listen)
-	if err != nil {
-		return nil, err
-	}
-	return &resolvingBind{Bind: inner}, nil
+func newResolvingBind(listen string) *resolvingBind {
+	return &resolvingBind{Bind: newListenBind(listen)}
 }
 
 // ParseEndpoint resolves hostnames before handing the address to amneziawg-go

--- a/internal/amneziawgnet/resolving_bind_test.go
+++ b/internal/amneziawgnet/resolving_bind_test.go
@@ -11,11 +11,7 @@ import (
 
 func mustResolvingBind(t *testing.T) *resolvingBind {
 	t.Helper()
-	b, err := newResolvingBind("")
-	if err != nil {
-		t.Fatalf("newResolvingBind: %v", err)
-	}
-	return b
+	return newResolvingBind("")
 }
 
 func endpointAddrPort(ep awgconn.Endpoint) netip.AddrPort {

--- a/internal/amneziawgnet/resolving_bind_test.go
+++ b/internal/amneziawgnet/resolving_bind_test.go
@@ -9,6 +9,15 @@ import (
 	awgconn "github.com/amnezia-vpn/amneziawg-go/v3/conn"
 )
 
+func mustResolvingBind(t *testing.T) *resolvingBind {
+	t.Helper()
+	b, err := newResolvingBind("")
+	if err != nil {
+		t.Fatalf("newResolvingBind: %v", err)
+	}
+	return b
+}
+
 func endpointAddrPort(ep awgconn.Endpoint) netip.AddrPort {
 	std, ok := ep.(*awgconn.StdNetEndpoint)
 	if !ok {
@@ -18,7 +27,7 @@ func endpointAddrPort(ep awgconn.Endpoint) netip.AddrPort {
 }
 
 func TestResolvingBind_ParseEndpointIPLiteral(t *testing.T) {
-	b := newResolvingBind()
+	b := mustResolvingBind(t)
 	ep, err := b.ParseEndpoint("203.0.113.7:51820")
 	if err != nil {
 		t.Fatalf("IP endpoint rejected: %v", err)
@@ -39,7 +48,7 @@ func TestResolvingBind_ParseEndpointHostnameResolves(t *testing.T) {
 	}
 	defer func() { lookupEndpointHost = orig }()
 
-	b := newResolvingBind()
+	b := mustResolvingBind(t)
 	ep, err := b.ParseEndpoint("peer.example.test:443")
 	if err != nil {
 		t.Fatalf("hostname endpoint rejected: %v", err)
@@ -56,14 +65,14 @@ func TestResolvingBind_ParseEndpointResolveFailureIsAnError(t *testing.T) {
 	}
 	defer func() { lookupEndpointHost = orig }()
 
-	b := newResolvingBind()
+	b := mustResolvingBind(t)
 	if _, err := b.ParseEndpoint("missing.example.test:80"); err == nil {
 		t.Fatal("expected resolve failure to surface as an error")
 	}
 }
 
 func TestResolvingBind_ParseEndpointBadPortRejected(t *testing.T) {
-	b := newResolvingBind()
+	b := mustResolvingBind(t)
 	if _, err := b.ParseEndpoint("203.0.113.7:none"); err == nil {
 		t.Fatal("expected bad port to be rejected")
 	}


### PR DESCRIPTION
## Summary
- AmneziaWG inbounds ignored `listen` and always bound `0.0.0.0`/`::` via `awgconn.NewDefaultBind()`, so multi-IP hosts replied from the primary address and clients connecting to a secondary IP never completed the handshake.
- Carry `Inbound.Listen` on `amneziawg.Instance`, open a `pinnedBind` for non-wildcard listen values (empty / `0.0.0.0` / `::` keep the default bind), and include listen in `addressFingerprint` so edits rebuild the Device instead of hot-applying an unchangeable Bind.

## Test plan
- [x] `go test ./internal/amneziawg/ ./internal/amneziawgnet/`
- [ ] Create AmneziaWG inbound with `listen: SECONDARY_IP`, add a client, confirm `ss -lunp` shows the socket bound to that address only
- [ ] Client handshake to `SECONDARY_IP:port` completes; replies source from `SECONDARY_IP`
- [ ] Empty / `0.0.0.0` listen still binds all addresses as before
- [ ] Editing listen rebuilds the device (fingerprint change)

Fixes #6367