### PR TITLE
fix(node): skip selected-inbound delete when import is pending

### DIFF
--- a/internal/web/service/inbound.go
+++ b/internal/web/service/inbound.go
@@ -1394,6 +1394,11 @@ func (s *InboundService) DelInbound(id int) (bool, error) {
 	}); err != nil {
 		return needRestart, err
 	}
+	// Record deletion intent before the remote push so a selected-mode
+	// reconcile can finish the sweep if the node was unreachable (#6329).
+	if loadErr == nil && ib.NodeID != nil {
+		tombstoneNodeInboundTag(*ib.NodeID, ib.Tag)
+	}
 	if postCommitApply != nil {
 		postCommitApply()
 	}

--- a/internal/web/service/inbound.go
+++ b/internal/web/service/inbound.go
@@ -1388,14 +1388,16 @@ func (s *InboundService) DelInbound(id int) (bool, error) {
 			}
 		}
 		if loadErr == nil && ib.NodeID != nil {
+			if err := (&NodeService{}).RemoveInboundTagAllowedTx(tx, *ib.NodeID, ib.Tag); err != nil {
+				return err
+			}
 			return (&NodeService{}).MarkNodeDirtyTx(tx, *ib.NodeID)
 		}
 		return nil
 	}); err != nil {
 		return needRestart, err
 	}
-	// Record deletion intent before the remote push so a selected-mode
-	// reconcile can finish the sweep if the node was unreachable (#6329).
+	// Tombstone before remote push so selected-mode reconcile finishes offline deletes (#6329).
 	if loadErr == nil && ib.NodeID != nil {
 		tombstoneNodeInboundTag(*ib.NodeID, ib.Tag)
 	}
@@ -1864,6 +1866,10 @@ func (s *InboundService) UpdateInbound(inbound *model.Inbound) (*model.Inbound, 
 			nodeID := *oldInbound.NodeID
 			if err := (&NodeService{}).EnsureInboundTagAllowedTx(tx, nodeID, oldInbound.Tag); err != nil {
 				return err
+			}
+			if tag != "" && tag != oldInbound.Tag {
+				tombstoneNodeInboundTag(nodeID, tag)
+				_ = (&NodeService{}).RemoveInboundTagAllowedTx(tx, nodeID, tag)
 			}
 		}
 

--- a/internal/web/service/inbound_node.go
+++ b/internal/web/service/inbound_node.go
@@ -23,12 +23,8 @@ var reportedRemoteTagConflict sync.Map
 
 var reportedForeignClientClaim sync.Map
 
-// Short-lived tombstones for node inbound tags the panel just deleted. In
-// "selected" sync mode a selected tag with no central row is otherwise
-// ambiguous: either the operator just picked it for import, or DelInbound
-// removed the central row while the node was unreachable. Only the latter
-// leaves a tombstone, so ReconcileNode can finish the remote delete without
-// wiping a pending import (#6329).
+// Tombstones for node inbound tags DelInbound removed (#6329).
+// Selected+missing without a tombstone is treated as a pending import.
 var (
 	recentlyDeletedNodeInboundMu sync.Mutex
 	recentlyDeletedNodeInbound   = map[string]time.Time{}
@@ -91,6 +87,26 @@ func clearNodeInboundTagTombstones() {
 	recentlyDeletedNodeInbound = map[string]time.Time{}
 }
 
+// selectedSnapTag reports whether a snapshot tag is in the node's selected set
+// (either spelling of the n<id>- prefix). Used to adopt pending imports while dirty.
+func selectedSnapTag(node model.Node, tag, prefix string) bool {
+	sel := nodeSelectedTagSet(&node)
+	if sel == nil {
+		return false
+	}
+	if _, ok := sel[tag]; ok {
+		return true
+	}
+	if prefix == "" {
+		return false
+	}
+	if stripped, found := strings.CutPrefix(tag, prefix); found {
+		_, ok := sel[stripped]
+		return ok
+	}
+	_, ok := sel[prefix+tag]
+	return ok
+}
 
 // nodeBulkPushThreshold caps how many per-client RPCs a single operation will
 // stream to a remote node. Above it, the panel marks the node dirty instead and
@@ -246,22 +262,17 @@ func (s *InboundService) ReconcileNode(ctx context.Context, rt *runtime.Remote, 
 	if n.InboundsAdoptedAt == 0 {
 		return errors.Join(errs...)
 	}
-	// In "selected" sync mode the panel only manages the selected tags: the
-	// rest were never imported, so their absence from the local DB must not
-	// delete them from the node. A selected tag missing locally is either a
-	// pending import (just selected, never held a central row) or a real
-	// deletion (DelInbound left a tombstone while the node was unreachable);
-	// only the latter may be swept (#6329).
+	// Selected mode: skip unselected tags. Selected+missing is a pending import
+	// unless DelInbound left a tombstone — those are swept even if deselected (#6329).
 	selected := nodeSelectedTagSet(n)
 	for _, tag := range remoteTags {
 		if _, want := desiredTags[tag]; want {
 			continue
 		}
 		if selected != nil {
-			if _, managed := selected[tag]; !managed {
-				continue
-			}
-			if !isNodeInboundTagTombstoned(nodeID, tag) {
+			if isNodeInboundTagTombstoned(nodeID, tag) {
+				// fall through — finish offline/deslected deletes
+			} else {
 				continue
 			}
 		}
@@ -746,7 +757,7 @@ func (s *InboundService) setRemoteTrafficLocked(nodeID int, snap *runtime.Traffi
 			}
 		}
 		if !ok {
-			if dirty {
+			if dirty && !selectedSnapTag(nodeRow, snapIb.Tag, prefix) {
 				continue
 			}
 			// Try snap.Tag first; on collision fall back to the n<id>-

--- a/internal/web/service/inbound_node.go
+++ b/internal/web/service/inbound_node.go
@@ -23,6 +23,75 @@ var reportedRemoteTagConflict sync.Map
 
 var reportedForeignClientClaim sync.Map
 
+// Short-lived tombstones for node inbound tags the panel just deleted. In
+// "selected" sync mode a selected tag with no central row is otherwise
+// ambiguous: either the operator just picked it for import, or DelInbound
+// removed the central row while the node was unreachable. Only the latter
+// leaves a tombstone, so ReconcileNode can finish the remote delete without
+// wiping a pending import (#6329).
+var (
+	recentlyDeletedNodeInboundMu sync.Mutex
+	recentlyDeletedNodeInbound   = map[string]time.Time{}
+)
+
+func nodeInboundTombstoneKey(nodeID int, tag string) string {
+	return fmt.Sprintf("%d\x00%s", nodeID, tag)
+}
+
+func tombstoneNodeInboundTag(nodeID int, tag string) {
+	if nodeID <= 0 || tag == "" {
+		return
+	}
+	now := time.Now()
+	cutoff := now.Add(-deleteTombstoneTTL)
+	recentlyDeletedNodeInboundMu.Lock()
+	defer recentlyDeletedNodeInboundMu.Unlock()
+	mark := func(t string) {
+		if t != "" {
+			recentlyDeletedNodeInbound[nodeInboundTombstoneKey(nodeID, t)] = now
+		}
+	}
+	mark(tag)
+	prefix := nodeTagPrefix(&nodeID)
+	if prefix != "" {
+		if stripped, found := strings.CutPrefix(tag, prefix); found {
+			mark(stripped)
+		} else {
+			mark(prefix + tag)
+		}
+	}
+	for k, ts := range recentlyDeletedNodeInbound {
+		if ts.Before(cutoff) {
+			delete(recentlyDeletedNodeInbound, k)
+		}
+	}
+}
+
+func isNodeInboundTagTombstoned(nodeID int, tag string) bool {
+	if nodeID <= 0 || tag == "" {
+		return false
+	}
+	recentlyDeletedNodeInboundMu.Lock()
+	defer recentlyDeletedNodeInboundMu.Unlock()
+	key := nodeInboundTombstoneKey(nodeID, tag)
+	ts, ok := recentlyDeletedNodeInbound[key]
+	if !ok {
+		return false
+	}
+	if time.Since(ts) > deleteTombstoneTTL {
+		delete(recentlyDeletedNodeInbound, key)
+		return false
+	}
+	return true
+}
+
+func clearNodeInboundTagTombstones() {
+	recentlyDeletedNodeInboundMu.Lock()
+	defer recentlyDeletedNodeInboundMu.Unlock()
+	recentlyDeletedNodeInbound = map[string]time.Time{}
+}
+
+
 // nodeBulkPushThreshold caps how many per-client RPCs a single operation will
 // stream to a remote node. Above it, the panel marks the node dirty instead and
 // lets one ReconcileNode push converge the whole inbound — far cheaper than M
@@ -179,8 +248,10 @@ func (s *InboundService) ReconcileNode(ctx context.Context, rt *runtime.Remote, 
 	}
 	// In "selected" sync mode the panel only manages the selected tags: the
 	// rest were never imported, so their absence from the local DB must not
-	// delete them from the node. Only a selected tag missing locally (the
-	// panel deleted it while the node was unreachable) may be swept.
+	// delete them from the node. A selected tag missing locally is either a
+	// pending import (just selected, never held a central row) or a real
+	// deletion (DelInbound left a tombstone while the node was unreachable);
+	// only the latter may be swept (#6329).
 	selected := nodeSelectedTagSet(n)
 	for _, tag := range remoteTags {
 		if _, want := desiredTags[tag]; want {
@@ -188,6 +259,9 @@ func (s *InboundService) ReconcileNode(ctx context.Context, rt *runtime.Remote, 
 		}
 		if selected != nil {
 			if _, managed := selected[tag]; !managed {
+				continue
+			}
+			if !isNodeInboundTagTombstoned(nodeID, tag) {
 				continue
 			}
 		}

--- a/internal/web/service/inbound_node_reconcile_test.go
+++ b/internal/web/service/inbound_node_reconcile_test.go
@@ -97,8 +97,9 @@ func reconcileTestNode(t *testing.T, ts *httptest.Server, name, mode string, tag
 }
 
 // In "selected" sync mode the panel never imports the unselected inbounds, so
-// reconcile must not treat their absence from the local DB as a deletion: only
-// a *selected* tag missing locally may be swept from the node.
+// reconcile must not treat their absence from the local DB as a deletion. A
+// selected tag missing locally is swept only when DelInbound left a tombstone
+// (panel deleted it while the node was unreachable).
 func TestReconcileNode_SelectedModeLeavesUnselectedRemoteInbounds(t *testing.T) {
 	setupConflictDB(t)
 
@@ -109,6 +110,7 @@ func TestReconcileNode_SelectedModeLeavesUnselectedRemoteInbounds(t *testing.T) 
 	})
 	node := reconcileTestNode(t, ts, "sel-node", "selected", []string{"keep", "selected-gone"})
 	seedInboundConflictNode(t, "keep", "", 443, model.VLESS, `{"network":"tcp"}`, `{"clients":[]}`, &node.Id)
+	tombstoneNodeInboundTag(node.Id, "selected-gone")
 
 	svc := InboundService{}
 	if err := svc.ReconcileNode(context.Background(), runtime.NewRemote(node, nil), node); err != nil {
@@ -118,6 +120,31 @@ func TestReconcileNode_SelectedModeLeavesUnselectedRemoteInbounds(t *testing.T) 
 	got := deletedIDs()
 	if len(got) != 1 || got[0] != 2 {
 		t.Fatalf("deleted remote ids = %v, want [2] (unmanaged inbound 3 must survive)", got)
+	}
+}
+
+// Selecting an existing node inbound writes it into InboundTags before any
+// central row exists. Without a deletion tombstone that must be treated as a
+// pending import — sweeping would delete the inbound the snapshot was about
+// to adopt (#6329).
+func TestReconcileNode_SelectedModeSkipsPendingImport(t *testing.T) {
+	setupConflictDB(t)
+
+	ts, deletedIDs := fakeNodePanel(t, map[string]int{
+		"keep":           1,
+		"pending-import": 2,
+		"unmanaged":      3,
+	})
+	node := reconcileTestNode(t, ts, "sel-pending-node", "selected", []string{"keep", "pending-import"})
+	seedInboundConflictNode(t, "keep", "", 443, model.VLESS, `{"network":"tcp"}`, `{"clients":[]}`, &node.Id)
+
+	svc := InboundService{}
+	if err := svc.ReconcileNode(context.Background(), runtime.NewRemote(node, nil), node); err != nil {
+		t.Fatalf("ReconcileNode: %v", err)
+	}
+
+	if got := deletedIDs(); len(got) != 0 {
+		t.Fatalf("deleted remote ids = %v, want none (pending-import must survive for snapshot adopt)", got)
 	}
 }
 
@@ -407,7 +434,8 @@ func TestEnsureInboundTagAllowed(t *testing.T) {
 }
 
 // A panel-created node inbound is stored as "n<id>-tag" and pushed to the node
-// with the prefix stripped, so the sweep's selected set must match both forms.
+// with the prefix stripped, so the sweep's selected set and deletion tombstone
+// must match both forms.
 func TestReconcileNode_SelectedModeSweepsPrefixedSelectedTag(t *testing.T) {
 	setupConflictDB(t)
 
@@ -420,6 +448,8 @@ func TestReconcileNode_SelectedModeSweepsPrefixedSelectedTag(t *testing.T) {
 	prefix := fmt.Sprintf("n%d-", node.Id)
 	node.InboundTags = []string{prefix + "keep", prefix + "selected-gone"}
 	seedInboundConflictNode(t, prefix+"keep", "", 443, model.VLESS, `{"network":"tcp"}`, `{"clients":[]}`, &node.Id)
+	// Tombstone the central (prefixed) form; the remote reports the stripped tag.
+	tombstoneNodeInboundTag(node.Id, prefix+"selected-gone")
 
 	svc := InboundService{}
 	if err := svc.ReconcileNode(context.Background(), runtime.NewRemote(node, nil), node); err != nil {

--- a/internal/web/service/inbound_node_reconcile_test.go
+++ b/internal/web/service/inbound_node_reconcile_test.go
@@ -96,10 +96,8 @@ func reconcileTestNode(t *testing.T, ts *httptest.Server, name, mode string, tag
 	return n
 }
 
-// In "selected" sync mode the panel never imports the unselected inbounds, so
-// reconcile must not treat their absence from the local DB as a deletion. A
-// selected tag missing locally is swept only when DelInbound left a tombstone
-// (panel deleted it while the node was unreachable).
+// Selected mode must not delete unselected remote inbounds.
+// A selected+missing tag is swept only when DelInbound left a tombstone.
 func TestReconcileNode_SelectedModeLeavesUnselectedRemoteInbounds(t *testing.T) {
 	setupConflictDB(t)
 
@@ -123,10 +121,8 @@ func TestReconcileNode_SelectedModeLeavesUnselectedRemoteInbounds(t *testing.T) 
 	}
 }
 
-// Selecting an existing node inbound writes it into InboundTags before any
-// central row exists. Without a deletion tombstone that must be treated as a
-// pending import — sweeping would delete the inbound the snapshot was about
-// to adopt (#6329).
+// Selecting a node inbound writes InboundTags before any central row exists.
+// Without a tombstone that is a pending import and must not be swept (#6329).
 func TestReconcileNode_SelectedModeSkipsPendingImport(t *testing.T) {
 	setupConflictDB(t)
 
@@ -433,9 +429,8 @@ func TestEnsureInboundTagAllowed(t *testing.T) {
 	}
 }
 
-// A panel-created node inbound is stored as "n<id>-tag" and pushed to the node
-// with the prefix stripped, so the sweep's selected set and deletion tombstone
-// must match both forms.
+// Panel-created node tags use n<id>- prefix centrally and stripped on the node.
+// Sweep selection and tombstones must match both forms.
 func TestReconcileNode_SelectedModeSweepsPrefixedSelectedTag(t *testing.T) {
 	setupConflictDB(t)
 

--- a/internal/web/service/node.go
+++ b/internal/web/service/node.go
@@ -758,6 +758,50 @@ func (s *NodeService) EnsureInboundTagAllowedTx(tx *gorm.DB, nodeID int, tag str
 		Updates(map[string]any{"inbound_tags": string(buf)}).Error
 }
 
+// RemoveInboundTagAllowed drops tag from a selected-mode node's InboundTags.
+// DelInbound uses this so an expired delete tombstone cannot re-adopt the row.
+func (s *NodeService) RemoveInboundTagAllowedTx(tx *gorm.DB, nodeID int, tag string) error {
+	tag = strings.TrimSpace(tag)
+	if nodeID <= 0 || tag == "" {
+		return nil
+	}
+	if tx == nil {
+		tx = database.GetDB()
+	}
+	node := &model.Node{}
+	if err := tx.Where("id = ?", nodeID).First(node).Error; err != nil {
+		return err
+	}
+	if node.InboundSyncMode != "selected" {
+		return nil
+	}
+	drop := map[string]struct{}{tag: {}}
+	prefix := nodeTagPrefix(&nodeID)
+	if prefix != "" {
+		if stripped, found := strings.CutPrefix(tag, prefix); found {
+			drop[stripped] = struct{}{}
+		} else {
+			drop[prefix+tag] = struct{}{}
+		}
+	}
+	next := make([]string, 0, len(node.InboundTags))
+	for _, t := range node.InboundTags {
+		if _, skip := drop[t]; skip {
+			continue
+		}
+		next = append(next, t)
+	}
+	if len(next) == len(node.InboundTags) {
+		return nil
+	}
+	buf, err := json.Marshal(next)
+	if err != nil {
+		return err
+	}
+	return tx.Model(model.Node{}).Where("id = ?", nodeID).
+		Updates(map[string]any{"inbound_tags": string(buf)}).Error
+}
+
 func nodeSelectedTagSet(n *model.Node) map[string]struct{} {
 	if n == nil || n.InboundSyncMode != "selected" {
 		return nil

--- a/internal/web/service/node_bulk_dispatch_test.go
+++ b/internal/web/service/node_bulk_dispatch_test.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"sync/atomic"
@@ -492,10 +493,14 @@ func TestNodeBulk_LargeDeleteFoldsToDirty(t *testing.T) {
 func TestDelInbound_NodeSelectedModeDeletesRemoteImmediately(t *testing.T) {
 	setupBulkDB(t)
 	nodeID, fake := setupNodeRuntime(t)
+	tagsJSON, err := json.Marshal([]string{"other-tag"})
+	if err != nil {
+		t.Fatalf("marshal inbound tags: %v", err)
+	}
 	if err := database.GetDB().Model(&model.Node{}).Where("id = ?", nodeID).
 		Updates(map[string]any{
 			"inbound_sync_mode": "selected",
-			"inbound_tags":      []string{"other-tag"},
+			"inbound_tags":      string(tagsJSON),
 		}).Error; err != nil {
 		t.Fatalf("set selected mode: %v", err)
 	}

--- a/internal/web/service/port_conflict_test.go
+++ b/internal/web/service/port_conflict_test.go
@@ -24,6 +24,7 @@ var portConflictLoggerOnce sync.Once
 func setupConflictDB(t *testing.T) {
 	t.Helper()
 	portConflictLoggerOnce.Do(func() { xuilogger.InitLogger(logging.ERROR) })
+	clearNodeInboundTagTombstones()
 
 	dbDir := t.TempDir()
 	t.Setenv("XUI_DB_FOLDER", dbDir)


### PR DESCRIPTION
## Summary
Fixes #6329 — selecting an existing node inbound in **Selected inbounds** mode no longer deletes it from the node.

In `ReconcileNode`, the selected-mode delete sweep treated a tag present in `Node.InboundTags` but missing a central `inbounds` row as a master-side deletion. That state is also how a *pending import* looks right after the operator selects a node-created inbound (reconcile runs before the snapshot merge that would adopt it).

## Change
- `DelInbound` records a short-lived per-node tag tombstone when a node-attached inbound is removed centrally.
- Selected-mode sweep only deletes a managed remote tag when that tombstone is present; otherwise it leaves the tag for snapshot import.
- Regression: `TestReconcileNode_SelectedModeSkipsPendingImport`; existing selected-mode delete tests now set a tombstone.

## Test plan
- [x] `go test ./internal/web/service/ -run TestReconcileNode_ `
- [ ] Manual: create inbound on node → select it in central panel Selected mode → confirm it remains on the node and appears centrally after traffic sync
- [ ] Manual: delete a selected node inbound from central while node is down → when node returns, confirm remote inbound is swept