### PR TITLE
feat(inbounds): show linked host remarks in inbound list

### DIFF
--- a/frontend/src/pages/inbounds/InboundsPage.tsx
+++ b/frontend/src/pages/inbounds/InboundsPage.tsx
@@ -803,6 +803,7 @@ export default function InboundsPage() {
                       subEnable={subSettings.enable}
                       nodesById={nodesById}
                       hasActiveNode={showNodeInfo}
+                      hosts={hosts}
                       onAddInbound={onAddInbound}
                       onGeneralAction={onGeneralAction}
                       onRowAction={({ key, dbInbound }) =>

--- a/frontend/src/pages/inbounds/list/InboundList.css
+++ b/frontend/src/pages/inbounds/list/InboundList.css
@@ -180,3 +180,34 @@
     padding: 4px;
   }
 }
+
+.inbound-remark-cell {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 2px;
+  min-width: 0;
+}
+
+.inbound-remark {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.inbound-host-remarks {
+  font-size: 11px;
+  font-weight: 400;
+  opacity: 0.65;
+  line-height: 1.2;
+  max-width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  cursor: default;
+}
+
+.tag-name .inbound-host-remarks {
+  font-weight: 400;
+}

--- a/frontend/src/pages/inbounds/list/InboundList.tsx
+++ b/frontend/src/pages/inbounds/list/InboundList.tsx
@@ -32,9 +32,20 @@ import { activateOnKey } from '@/utils/a11y';
 
 import { buildRowActionsMenu } from './RowActions';
 import { useInboundColumns } from './useInboundColumns';
+import { buildHostRemarksByInboundId, formatHostRemarksLabel } from './helpers';
 import InboundStatsModal from './InboundStatsModal';
 import type { DBInboundRecord, GeneralAction, InboundListProps, RowAction } from './types';
 import './InboundList.css';
+
+function HostRemarksSuffix({ remarks }: { remarks: string[] }) {
+  if (remarks.length === 0) return null;
+  const { display, full } = formatHostRemarksLabel(remarks);
+  return (
+    <Tooltip title={full}>
+      <span className="inbound-host-remarks"> ({display})</span>
+    </Tooltip>
+  );
+}
 
 export default function InboundList({
   dbInbounds,
@@ -48,6 +59,7 @@ export default function InboundList({
   subEnable,
   nodesById,
   hasActiveNode,
+  hosts,
   onAddInbound,
   onGeneralAction,
   onRowAction,
@@ -86,19 +98,22 @@ export default function InboundList({
     [nodesById, t],
   );
 
+  const hostRemarksByInboundId = useMemo(() => buildHostRemarksByInboundId(hosts), [hosts]);
+
   const visibleInbounds = useMemo(() => {
     let list = dbInbounds;
     if (nodeFilter === 0) list = list.filter((ib) => ib.nodeId == null);
     else if (nodeFilter !== 'all') list = list.filter((ib) => ib.nodeId === nodeFilter);
     const q = searchKey.trim().toLowerCase();
     if (!q) return list;
-    return list.filter(
-      (ib) =>
-        (ib.remark || '').toLowerCase().includes(q) ||
-        String(ib.port).includes(q) ||
-        (ib.protocol || '').toLowerCase().includes(q),
-    );
-  }, [dbInbounds, nodeFilter, searchKey]);
+    return list.filter((ib) => {
+      if ((ib.remark || '').toLowerCase().includes(q)) return true;
+      if (String(ib.port).includes(q)) return true;
+      if ((ib.protocol || '').toLowerCase().includes(q)) return true;
+      const hostRemarks = hostRemarksByInboundId.get(ib.id) ?? [];
+      return hostRemarks.some((remark) => remark.toLowerCase().includes(q));
+    });
+  }, [dbInbounds, nodeFilter, searchKey, hostRemarksByInboundId]);
 
   const onSwitchEnable = useCallback(async (dbInbound: DBInboundRecord, next: boolean) => {
     const previous = dbInbound.enable;
@@ -114,8 +129,10 @@ export default function InboundList({
   }, []);
 
   const hasAnyRemark = useMemo(
-    () => dbInbounds.some((i) => typeof i.remark === 'string' && i.remark.trim() !== ''),
-    [dbInbounds],
+    () =>
+      dbInbounds.some((i) => typeof i.remark === 'string' && i.remark.trim() !== '') ||
+      dbInbounds.some((i) => (hostRemarksByInboundId.get(i.id)?.length ?? 0) > 0),
+    [dbInbounds, hostRemarksByInboundId],
   );
 
   const hasAnySubSortIndex = useMemo(
@@ -154,6 +171,7 @@ export default function InboundList({
     hasAnySubSortIndex,
     hasActiveNode,
     nodesById,
+    hostRemarksByInboundId,
     clientCount,
     inboundSpeed,
     subEnable,
@@ -293,7 +311,10 @@ export default function InboundList({
                         onChange={(e) => toggleSelect(record.id, e.target.checked)}
                       />
                       <span className="card-id">#{record.id}</span>
-                      <span className="tag-name">{record.remark}</span>
+                      <span className="tag-name">
+                        <span className="inbound-remark">{record.remark}</span>
+                        <HostRemarksSuffix remarks={hostRemarksByInboundId.get(record.id) ?? []} />
+                      </span>
                       <div className="card-actions">
                         <Tooltip title={t('pages.inbounds.inboundInfo')}>
                           <InfoCircleOutlined

--- a/frontend/src/pages/inbounds/list/helpers.ts
+++ b/frontend/src/pages/inbounds/list/helpers.ts
@@ -1,5 +1,6 @@
 import { isSSMultiUser } from '@/lib/xray/protocol-capabilities';
 import { coerceInboundJsonField } from '@/models/dbinbound';
+import type { HostRecord } from '@/schemas/api/host';
 
 import type { DBInboundRecord, StreamHints } from './types';
 
@@ -103,4 +104,41 @@ export function showQrCodeMenu(dbInbound: DBInboundRecord): boolean {
     return !isSSMultiUser({ protocol: 'shadowsocks', settings: readSettings(dbInbound.settings) });
   }
   return false;
+}
+
+/** Max host remarks shown inline before truncating with "+N". */
+export const HOST_REMARK_VISIBLE_LIMIT = 2;
+
+/** Join Host Group remarks onto inbound ids using existing /hosts/list fields. */
+export function buildHostRemarksByInboundId(
+  hosts: Pick<HostRecord, 'remark' | 'inboundIds' | 'hosts'>[],
+): Map<number, string[]> {
+  const map = new Map<number, string[]>();
+  for (const host of hosts) {
+    const addressFallback = Array.isArray(host.hosts)
+      ? host.hosts.map((h) => (h || '').trim()).find(Boolean) || ''
+      : '';
+    const label = (host.remark || '').trim() || addressFallback;
+    if (!label) continue;
+    for (const inboundId of host.inboundIds || []) {
+      if (!Number.isFinite(inboundId)) continue;
+      const list = map.get(inboundId) ?? [];
+      if (!list.includes(label)) list.push(label);
+      map.set(inboundId, list);
+    }
+  }
+  return map;
+}
+
+export function formatHostRemarksLabel(
+  remarks: string[],
+  visibleLimit = HOST_REMARK_VISIBLE_LIMIT,
+): { display: string; full: string; truncated: boolean } {
+  const full = remarks.join(', ');
+  if (remarks.length <= visibleLimit) {
+    return { display: full, full, truncated: false };
+  }
+  const visible = remarks.slice(0, visibleLimit).join(', ');
+  const more = remarks.length - visibleLimit;
+  return { display: `${visible}, +${more}`, full, truncated: true };
 }

--- a/frontend/src/pages/inbounds/list/types.ts
+++ b/frontend/src/pages/inbounds/list/types.ts
@@ -1,4 +1,5 @@
 import type { NodeRecord } from '@/api/queries/useNodesQuery';
+import type { HostRecord } from '@/schemas/api/host';
 
 export interface StreamHints {
   network: string;
@@ -77,6 +78,7 @@ export interface InboundListProps {
   subEnable: boolean;
   nodesById: Map<number, NodeRecord>;
   hasActiveNode: boolean;
+  hosts: HostRecord[];
   onAddInbound: () => void;
   onGeneralAction: (key: GeneralAction) => void;
   onRowAction: (action: { key: RowAction; dbInbound: DBInboundRecord }) => void;

--- a/frontend/src/pages/inbounds/list/useInboundColumns.tsx
+++ b/frontend/src/pages/inbounds/list/useInboundColumns.tsx
@@ -23,6 +23,7 @@ import {
   shadowsocksNetworkLabel,
   tunnelNetworkLabel,
   mixedNetworkLabel,
+  formatHostRemarksLabel,
 } from './helpers';
 import type { ClientCountEntry, DBInboundRecord, InboundSpeedEntry, RowAction } from './types';
 
@@ -31,6 +32,7 @@ interface UseInboundColumnsParams {
   hasAnySubSortIndex: boolean;
   hasActiveNode: boolean;
   nodesById: Map<number, NodeRecord>;
+  hostRemarksByInboundId: Map<number, string[]>;
   clientCount: Record<number, ClientCountEntry>;
   inboundSpeed: Record<number, InboundSpeedEntry>;
   subEnable: boolean;
@@ -45,6 +47,7 @@ export function useInboundColumns({
   hasAnySubSortIndex,
   hasActiveNode,
   nodesById,
+  hostRemarksByInboundId,
   clientCount,
   inboundSpeed,
   subEnable,
@@ -138,8 +141,23 @@ export function useInboundColumns({
         dataIndex: 'remark',
         key: 'remark',
         align: 'center',
-        width: 90,
+        width: 140,
         sorter: (a, b) => compareText(a.remark, b.remark),
+        render: (_, record) => {
+          const hostRemarks = hostRemarksByInboundId.get(record.id) ?? [];
+          if (hostRemarks.length === 0) {
+            return record.remark || null;
+          }
+          const { display, full } = formatHostRemarksLabel(hostRemarks);
+          return (
+            <div className="inbound-remark-cell">
+              <div className="inbound-remark">{record.remark}</div>
+              <Tooltip title={full}>
+                <div className="inbound-host-remarks">({display})</div>
+              </Tooltip>
+            </div>
+          );
+        },
       });
     }
 
@@ -453,6 +471,7 @@ export function useInboundColumns({
     hasAnySubSortIndex,
     hasActiveNode,
     nodesById,
+    hostRemarksByInboundId,
     clientCount,
     inboundSpeed,
     subEnable,


### PR DESCRIPTION
## Summary
- Show linked Host Group remarks under each inbound remark in the inbound list (desktop table + mobile cards).
- Join client-side from existing `GET /panel/api/hosts/list` (`remark` + `inboundIds`); no API/schema changes.
- Truncate after 2 remarks with `+N` and a tooltip for the full list; search also matches host remarks.

Fixes #6026

## Test plan
- [ ] Open Inbounds with multiple Hosts linked to one inbound; remark cell shows inbound remark plus `(host1, host2)`.
- [ ] With 3+ hosts, list truncates and tooltip shows all remarks.
- [ ] Host with empty remark falls back to first address in `hosts`.
- [ ] Search by a host remark filters the inbound row.
- [ ] Inbounds with no linked hosts still show only the inbound remark.