### PR TITLE
feat(clients): preserve traffic counters in portable export/import

### DIFF
--- a/internal/web/service/client.go
+++ b/internal/web/service/client.go
@@ -66,9 +66,10 @@ type ClientService struct{}
 var ErrClientNotInInbound = errors.New("client not found in inbound")
 
 type ClientCreatePayload struct {
-	Client     model.Client `json:"client"`
-	InboundIds []int        `json:"inboundIds"`
-	LimitHwid  int          `json:"-"`
+	Client     model.Client           `json:"client"`
+	InboundIds []int                  `json:"inboundIds"`
+	LimitHwid  int                    `json:"-"`
+	Traffic    *ClientPortableTraffic `json:"traffic,omitempty"`
 }
 
 const sqlInChunk = 400
@@ -80,8 +81,9 @@ type clientPayloadWithHwid struct {
 
 func (p *ClientCreatePayload) UnmarshalJSON(data []byte) error {
 	var raw struct {
-		Client     clientPayloadWithHwid `json:"client"`
-		InboundIds []int                 `json:"inboundIds"`
+		Client     clientPayloadWithHwid  `json:"client"`
+		InboundIds []int                  `json:"inboundIds"`
+		Traffic    *ClientPortableTraffic `json:"traffic"`
 	}
 	if err := json.Unmarshal(data, &raw); err != nil {
 		return err
@@ -89,15 +91,18 @@ func (p *ClientCreatePayload) UnmarshalJSON(data []byte) error {
 	p.Client = raw.Client.Client
 	p.InboundIds = raw.InboundIds
 	p.LimitHwid = raw.Client.LimitHwid
+	p.Traffic = raw.Traffic
 	return nil
 }
 
 func (p ClientCreatePayload) MarshalJSON() ([]byte, error) {
 	return json.Marshal(struct {
-		Client     clientPayloadWithHwid `json:"client"`
-		InboundIds []int                 `json:"inboundIds"`
+		Client     clientPayloadWithHwid  `json:"client"`
+		InboundIds []int                  `json:"inboundIds"`
+		Traffic    *ClientPortableTraffic `json:"traffic,omitempty"`
 	}{
 		Client:     clientPayloadWithHwid{Client: p.Client, LimitHwid: p.LimitHwid},
 		InboundIds: p.InboundIds,
+		Traffic:    p.Traffic,
 	})
 }

--- a/internal/web/service/client_portable.go
+++ b/internal/web/service/client_portable.go
@@ -13,10 +13,19 @@ import (
 	"gorm.io/gorm"
 )
 
-// ExportAll returns every client in the same {client, inboundIds} shape that
-// /add and /bulkCreate accept, so an exported file round-trips straight back
-// through Import. Clients with no inbound attachment are included with an empty
-// inboundIds list so an export taken before DeleteOrphans can restore them.
+// ClientPortableTraffic is the client_traffics snapshot carried in export/import.
+// model.Client only has the limit (totalGB); usage counters live in this table.
+type ClientPortableTraffic struct {
+	Up           int64 `json:"up"`
+	Down         int64 `json:"down"`
+	Total        int64 `json:"total"`
+	ResetCount   int   `json:"resetCount"`
+	LastOnline   int64 `json:"lastOnline,omitempty"`
+	LastSubFetch int64 `json:"lastSubFetch,omitempty"`
+}
+
+// ExportAll returns every client as {client, inboundIds[, traffic]} for round-trip
+// import; orphan clients keep empty inboundIds, and traffic preserves usage (#5858).
 func (s *ClientService) ExportAll() ([]ClientCreatePayload, error) {
 	db := database.GetDB()
 	var rows []model.ClientRecord
@@ -29,8 +38,12 @@ func (s *ClientService) ExportAll() ([]ClientCreatePayload, error) {
 	}
 
 	ids := make([]int, 0, len(rows))
+	emails := make([]string, 0, len(rows))
 	for i := range rows {
 		ids = append(ids, rows[i].Id)
+		if rows[i].Email != "" {
+			emails = append(emails, rows[i].Email)
+		}
 	}
 
 	attachments := make(map[int][]int, len(rows))
@@ -41,6 +54,25 @@ func (s *ClientService) ExportAll() ([]ClientCreatePayload, error) {
 		}
 		for _, l := range links {
 			attachments[l.ClientId] = append(attachments[l.ClientId], l.InboundId)
+		}
+	}
+
+	trafficByEmail := make(map[string]*ClientPortableTraffic, len(emails))
+	for _, batch := range chunkStrings(emails, sqlInChunk) {
+		var traffics []xray.ClientTraffic
+		if err := db.Where("email IN ?", batch).Find(&traffics).Error; err != nil {
+			return nil, err
+		}
+		for i := range traffics {
+			t := traffics[i]
+			trafficByEmail[t.Email] = &ClientPortableTraffic{
+				Up:           t.Up,
+				Down:         t.Down,
+				Total:        t.Total,
+				ResetCount:   t.ResetCount,
+				LastOnline:   t.LastOnline,
+				LastSubFetch: t.LastSubFetch,
+			}
 		}
 	}
 
@@ -55,20 +87,23 @@ func (s *ClientService) ExportAll() ([]ClientCreatePayload, error) {
 			Client:     *client,
 			InboundIds: attachments[rows[i].Id],
 			LimitHwid:  rows[i].LimitHwid,
+			Traffic:    trafficByEmail[rows[i].Email],
 		})
 	}
 	return out, nil
 }
 
-// ImportClients recreates clients from an exported list. Items that carry
-// inboundIds go through the normal BulkCreate path (added to every inbound and
-// pushed to xray); items with no inboundIds are restored as bare records so an
-// orphan-inclusive export round-trips. Existing emails are never overwritten —
-// they are reported in Skipped. The boolean reports whether xray needs a restart.
+// ImportClients recreates exported clients; existing emails are Skipped.
+// Traffic is applied only for newly created emails so live counters stay intact (#5858).
 func (s *ClientService) ImportClients(inboundSvc *InboundService, items []ClientCreatePayload) (BulkCreateResult, bool, error) {
 	result := BulkCreateResult{}
 	if len(items) == 0 {
 		return result, false, nil
+	}
+
+	existingEmails, err := existingClientEmails(items)
+	if err != nil {
+		return result, false, err
 	}
 
 	attached := make([]ClientCreatePayload, 0, len(items))
@@ -173,13 +208,118 @@ func (s *ClientService) ImportClients(inboundSvc *InboundService, items []Client
 		result.Created++
 	}
 
+	if err := s.applyPortableTraffics(items, existingEmails, result.Skipped); err != nil {
+		return result, needRestart, err
+	}
+
 	return result, needRestart, nil
 }
 
-// DeleteOrphans removes every client that is not attached to any inbound,
-// together with its traffic rows, IP log, and external links. It mirrors the
-// cleanup the single-client Delete performs, batched into one transaction.
-// Returns the number of clients deleted.
+func existingClientEmails(items []ClientCreatePayload) (map[string]struct{}, error) {
+	out := make(map[string]struct{})
+	emails := make([]string, 0, len(items))
+	seen := make(map[string]struct{}, len(items))
+	for i := range items {
+		email := strings.TrimSpace(items[i].Client.Email)
+		if email == "" {
+			continue
+		}
+		le := strings.ToLower(email)
+		if _, ok := seen[le]; ok {
+			continue
+		}
+		seen[le] = struct{}{}
+		emails = append(emails, email)
+	}
+	if len(emails) == 0 {
+		return out, nil
+	}
+	db := database.GetDB()
+	for _, batch := range chunkStrings(emails, sqlInChunk) {
+		var rows []model.ClientRecord
+		if err := db.Select("email").Where("email IN ?", batch).Find(&rows).Error; err != nil {
+			return nil, err
+		}
+		for i := range rows {
+			out[strings.ToLower(rows[i].Email)] = struct{}{}
+		}
+	}
+	return out, nil
+}
+
+func (s *ClientService) applyPortableTraffics(items []ClientCreatePayload, existingEmails map[string]struct{}, skipped []BulkCreateReport) error {
+	skippedSet := make(map[string]struct{}, len(skipped))
+	for _, rep := range skipped {
+		skippedSet[strings.ToLower(rep.Email)] = struct{}{}
+	}
+	for i := range items {
+		snap := items[i].Traffic
+		if snap == nil {
+			continue
+		}
+		email := strings.TrimSpace(items[i].Client.Email)
+		if email == "" {
+			continue
+		}
+		le := strings.ToLower(email)
+		if _, existed := existingEmails[le]; existed {
+			continue
+		}
+		if _, wasSkipped := skippedSet[le]; wasSkipped {
+			continue
+		}
+		if err := applyPortableTraffic(email, snap, items[i].Client); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// applyPortableTraffic restores exported up/down onto a newly imported email's
+// client_traffics row without touching limit/expiry already set by AddClientStat.
+func applyPortableTraffic(email string, snap *ClientPortableTraffic, client model.Client) error {
+	if snap == nil {
+		return nil
+	}
+	return submitTrafficWrite(func() error {
+		db := database.GetDB()
+		updates := map[string]any{
+			"up":             snap.Up,
+			"down":           snap.Down,
+			"reset_count":    snap.ResetCount,
+			"last_online":    snap.LastOnline,
+			"last_sub_fetch": snap.LastSubFetch,
+		}
+		res := db.Model(&xray.ClientTraffic{}).Where("email = ?", email).Updates(updates)
+		if res.Error != nil {
+			return res.Error
+		}
+		if res.RowsAffected > 0 {
+			return nil
+		}
+		total := client.TotalGB
+		if snap.Total > 0 {
+			total = snap.Total
+		}
+		return db.Create(&xray.ClientTraffic{
+			Email:        email,
+			Enable:       true,
+			Up:           snap.Up,
+			Down:         snap.Down,
+			Total:        total,
+			ExpiryTime:   client.ExpiryTime,
+			Reset:        client.Reset,
+			ResetDay:     client.ResetDay,
+			ResetMax:     client.ResetMax,
+			ResetCount:   snap.ResetCount,
+			LastOnline:   snap.LastOnline,
+			LastSubFetch: snap.LastSubFetch,
+		}).Error
+	})
+}
+
+// DeleteOrphans removes every unattached client plus its traffic, IP log, and
+// external links in one transaction; returns how many clients were deleted.
 func (s *ClientService) DeleteOrphans() (int, error) {
 	db := database.GetDB()
 	sub := database.GetDB().Table("client_inbounds").Select("client_id")

--- a/internal/web/service/client_portable_test.go
+++ b/internal/web/service/client_portable_test.go
@@ -1,0 +1,137 @@
+package service
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/mhsanaei/3x-ui/v3/internal/database"
+	"github.com/mhsanaei/3x-ui/v3/internal/database/model"
+	"github.com/mhsanaei/3x-ui/v3/internal/xray"
+)
+
+func TestExportImportPreservesTrafficCounters(t *testing.T) {
+	setupBulkDB(t)
+	svc := &ClientService{}
+	inboundSvc := &InboundService{}
+
+	ib := mkInbound(t, 25001, model.VLESS, `{"clients":[]}`)
+	const email = "portable@traffic"
+	const subID = "sub-portable-traffic"
+	if _, err := svc.Create(inboundSvc, &ClientCreatePayload{
+		Client: model.Client{
+			Email: email, SubID: subID, Enable: true,
+			TotalGB: 10 << 30, ExpiryTime: 1_700_000_000_000,
+		},
+		InboundIds: []int{ib.Id},
+	}); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	db := database.GetDB()
+	if err := db.Model(&xray.ClientTraffic{}).Where("email = ?", email).Updates(map[string]any{
+		"up": 111, "down": 222, "reset_count": 3, "last_online": 999,
+	}).Error; err != nil {
+		t.Fatalf("seed traffic: %v", err)
+	}
+
+	exported, err := svc.ExportAll()
+	if err != nil {
+		t.Fatalf("ExportAll: %v", err)
+	}
+	if len(exported) != 1 {
+		t.Fatalf("ExportAll len=%d, want 1", len(exported))
+	}
+	if exported[0].Traffic == nil {
+		t.Fatal("ExportAll missing traffic snapshot")
+	}
+	if exported[0].Traffic.Up != 111 || exported[0].Traffic.Down != 222 || exported[0].Traffic.ResetCount != 3 {
+		t.Fatalf("exported traffic = %+v, want up=111 down=222 resetCount=3", exported[0].Traffic)
+	}
+
+	raw, err := json.Marshal(exported)
+	if err != nil {
+		t.Fatalf("marshal export: %v", err)
+	}
+	var roundTrip []ClientCreatePayload
+	if err := json.Unmarshal(raw, &roundTrip); err != nil {
+		t.Fatalf("unmarshal export: %v", err)
+	}
+	if roundTrip[0].Traffic == nil || roundTrip[0].Traffic.Up != 111 {
+		t.Fatalf("JSON round-trip lost traffic: %+v", roundTrip[0].Traffic)
+	}
+
+	rec := lookupClientRecord(t, email)
+	if _, err := svc.Delete(inboundSvc, rec.Id, false); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+	var gone int64
+	if err := db.Model(&xray.ClientTraffic{}).Where("email = ?", email).Count(&gone).Error; err != nil {
+		t.Fatalf("count after delete: %v", err)
+	}
+	if gone != 0 {
+		t.Fatalf("client_traffics still present after delete: %d", gone)
+	}
+
+	res, _, err := svc.ImportClients(inboundSvc, roundTrip)
+	if err != nil {
+		t.Fatalf("ImportClients: %v", err)
+	}
+	if res.Created != 1 || len(res.Skipped) != 0 {
+		t.Fatalf("ImportClients result=%+v", res)
+	}
+	var restored xray.ClientTraffic
+	if err := db.Where("email = ?", email).First(&restored).Error; err != nil {
+		t.Fatalf("lookup restored traffic: %v", err)
+	}
+	if restored.Up != 111 || restored.Down != 222 || restored.ResetCount != 3 || restored.LastOnline != 999 {
+		t.Fatalf("restored traffic = %+v, want up=111 down=222 resetCount=3 lastOnline=999", restored)
+	}
+
+	if err := db.Model(&xray.ClientTraffic{}).Where("email = ?", email).Updates(map[string]any{
+		"up": 5000, "down": 6000,
+	}).Error; err != nil {
+		t.Fatalf("bump live traffic: %v", err)
+	}
+	// Same email+subId is a BulkCreate reuse (may count as Created), not a hard
+	// skip — traffic apply must still refuse to overwrite the live counters.
+	if _, _, err := svc.ImportClients(inboundSvc, roundTrip); err != nil {
+		t.Fatalf("second ImportClients: %v", err)
+	}
+	var live xray.ClientTraffic
+	if err := db.Where("email = ?", email).First(&live).Error; err != nil {
+		t.Fatalf("lookup live traffic: %v", err)
+	}
+	if live.Up != 5000 || live.Down != 6000 {
+		t.Fatalf("re-import of existing email must leave live traffic alone, got up=%d down=%d", live.Up, live.Down)
+	}
+}
+
+func TestImportClientsAppliesTrafficForOrphans(t *testing.T) {
+	setupBulkDB(t)
+	svc := &ClientService{}
+
+	items := []ClientCreatePayload{{
+		Client: model.Client{
+			Email: "orphan@traffic", SubID: "sub-orphan-traffic", Enable: true,
+			TotalGB: 1 << 30,
+		},
+		InboundIds: nil,
+		Traffic: &ClientPortableTraffic{
+			Up: 7, Down: 8, Total: 1 << 30, ResetCount: 1,
+		},
+	}}
+	res, _, err := svc.ImportClients(&InboundService{}, items)
+	if err != nil {
+		t.Fatalf("ImportClients orphan: %v", err)
+	}
+	if res.Created != 1 {
+		t.Fatalf("created=%d, want 1", res.Created)
+	}
+	var traf xray.ClientTraffic
+	if err := database.GetDB().Where("email = ?", "orphan@traffic").First(&traf).Error; err != nil {
+		t.Fatalf("orphan traffic row missing: %v", err)
+	}
+	if traf.Up != 7 || traf.Down != 8 || traf.ResetCount != 1 {
+		t.Fatalf("orphan traffic = %+v", traf)
+	}
+}


### PR DESCRIPTION
## Summary
- Portable client export now includes a `traffic` snapshot from `client_traffics` (`up`/`down`/`total`, plus `resetCount`/`lastOnline`/`lastSubFetch`).
- Import restores those counters only for **newly created** emails; skipped or already-present emails keep their live usage untouched.
- Legacy export files without `traffic` keep the previous zero-start behavior.

Fixes #5858

## Test plan
- [x] `go test ./internal/web/service/ -run 'TestExportImportPreservesTrafficCounters|TestImportClientsAppliesTrafficForOrphans' -count=1`
- [ ] Export clients from a panel with non-zero usage, import into a fresh panel, confirm up/down match
- [ ] Re-import the same file into a panel where those emails already exist; confirm live counters are unchanged