### PR TITLE
fix(link): keep verifyPeerCertByName (vcn) on Go TLS import

### DIFF
--- a/internal/util/link/outbound.go
+++ b/internal/util/link/outbound.go
@@ -666,6 +666,7 @@ func applySecurity(stream map[string]any, p url.Values) {
 			tls["alpn"] = splitComma(alpn)
 		}
 		tls["echConfigList"] = p.Get("ech")
+		tls["verifyPeerCertByName"] = p.Get("vcn")
 		tls["pinnedPeerCertSha256"] = p.Get("pcs")
 	case "reality":
 		re := stream["realitySettings"].(map[string]any)

--- a/internal/util/link/outbound_helpers_test.go
+++ b/internal/util/link/outbound_helpers_test.go
@@ -123,12 +123,12 @@ func TestParse_RealitySecurityMapped(t *testing.T) {
 }
 
 func TestParse_TLSSecurityMapped(t *testing.T) {
-	res, err := ParseLink("trojan://pw@h.com:443?type=tcp&security=tls&sni=SNI&fp=chrome&alpn=h2,http/1.1&ech=ECH&pcs=PCS")
+	res, err := ParseLink("trojan://pw@h.com:443?type=tcp&security=tls&sni=SNI&fp=chrome&alpn=h2,http/1.1&ech=ECH&vcn=VCN&pcs=PCS")
 	if err != nil {
 		t.Fatalf("parse: %v", err)
 	}
 	tls := streamSub(t, res, "tlsSettings")
-	if tls["serverName"] != "SNI" || tls["fingerprint"] != "chrome" || tls["echConfigList"] != "ECH" || tls["pinnedPeerCertSha256"] != "PCS" {
+	if tls["serverName"] != "SNI" || tls["fingerprint"] != "chrome" || tls["echConfigList"] != "ECH" || tls["verifyPeerCertByName"] != "VCN" || tls["pinnedPeerCertSha256"] != "PCS" {
 		t.Errorf("tlsSettings fields = %#v", tls)
 	}
 	if alpn, _ := tls["alpn"].([]string); !reflect.DeepEqual(alpn, []string{"h2", "http/1.1"}) {


### PR DESCRIPTION
## Summary
- Map share-link query `vcn` to `tlsSettings.verifyPeerCertByName` in Go `applySecurity` (TLS branch), matching the TS importer and the existing Hysteria2 Go path.
- Extend `TestParse_TLSSecurityMapped` so `vcn` is asserted to survive round-trip through the Go parser.

Fixes #6477

## Test plan
- [x] `go test ./internal/util/link/`
- [ ] Import a VLESS/Trojan TLS share link that includes `vcn=<cn>` via a Go path (e.g. external JSON subscription) and confirm outbound `tlsSettings.verifyPeerCertByName` is set
- [ ] Confirm UI (TS) import of the same link still behaves as before