### PR TITLE
fix(link): restore mKCP seed and headerType on share-link import

### DIFF
--- a/frontend/src/lib/xray/outbound-link-parser.ts
+++ b/frontend/src/lib/xray/outbound-link-parser.ts
@@ -220,12 +220,8 @@ function applyTransportParams(stream: Raw, params: URLSearchParams): void {
       break;
     }
     case 'kcp': {
-      // Mirror applyKcpShareParams: headerType/seed/mtu/tti from the share link.
+      // mtu/tti on kcpSettings; header/seed via applyMkcpLegacyFromShare.
       const kcp = stream.kcpSettings as Raw;
-      const headerType = params.get('headerType');
-      if (headerType) kcp.header = { type: headerType };
-      const seed = params.get('seed');
-      if (seed) kcp.seed = seed;
       const mtu = params.get('mtu');
       if (mtu) {
         const n = Number(mtu);
@@ -258,18 +254,54 @@ function applyTransportParams(stream: Raw, params: URLSearchParams): void {
 // The inbound link emits the entire finalmask object as a JSON-encoded
 // `fm` query param. Decode and attach to streamSettings so udpHop /
 // quicParams / tcp+udp masks round-trip on outbound import.
+const kcpHeaderTypeToMask: Record<string, string> = {
+  dns: 'dns',
+  dtls: 'dtls',
+  srtp: 'srtp',
+  utp: 'utp',
+  'wechat-video': 'wechat',
+  wireguard: 'wireguard',
+};
+
 function applyFinalMaskParam(stream: Raw, params: URLSearchParams): void {
   const fm = params.get('fm');
-  if (!fm) return;
-  try {
-    const parsed = JSON.parse(fm) as Record<string, unknown>;
-    if (parsed && typeof parsed === 'object') {
-      sanitizeFinalMaskQuicParams(parsed);
-      stream.finalmask = parsed;
+  if (fm) {
+    try {
+      const parsed = JSON.parse(fm) as Record<string, unknown>;
+      if (parsed && typeof parsed === 'object') {
+        sanitizeFinalMaskQuicParams(parsed);
+        stream.finalmask = parsed;
+      }
+    } catch {
+      // malformed fm — leave streamSettings.finalmask absent
     }
-  } catch {
-    // malformed fm — leave streamSettings.finalmask absent
   }
+  applyMkcpLegacyFromShare(stream, params);
+}
+
+/** Restore headerType/seed into finalmask.udp mkcp-legacy; fm= mkcp-legacy wins. */
+function applyMkcpLegacyFromShare(stream: Raw, params: URLSearchParams): void {
+  let headerType = (params.get('headerType') ?? '').trim();
+  const seed = params.get('seed') ?? '';
+  if (headerType === 'none') headerType = '';
+  if (!headerType && !seed) return;
+  const network = stream.network;
+  if (typeof network === 'string' && network && network !== 'kcp') return;
+
+  let maskHeader = '';
+  if (headerType) {
+    const mapped = kcpHeaderTypeToMask[headerType];
+    if (!mapped) return;
+    maskHeader = mapped;
+  }
+
+  const finalmask = (stream.finalmask as Raw) ?? {};
+  const udp = Array.isArray(finalmask.udp) ? [...(finalmask.udp as unknown[])] : [];
+  if (udp.some((m) => (m as Raw)?.type === 'mkcp-legacy')) return;
+
+  udp.push({ type: 'mkcp-legacy', settings: { header: maskHeader, value: seed } });
+  finalmask.udp = udp;
+  stream.finalmask = finalmask;
 }
 
 function ensureFinalMask(stream: Raw): Raw {

--- a/frontend/src/lib/xray/outbound-link-parser.ts
+++ b/frontend/src/lib/xray/outbound-link-parser.ts
@@ -219,6 +219,25 @@ function applyTransportParams(stream: Raw, params: URLSearchParams): void {
       applyXhttpStringFromParams(xhttp, params);
       break;
     }
+    case 'kcp': {
+      // Mirror applyKcpShareParams: headerType/seed/mtu/tti from the share link.
+      const kcp = stream.kcpSettings as Raw;
+      const headerType = params.get('headerType');
+      if (headerType) kcp.header = { type: headerType };
+      const seed = params.get('seed');
+      if (seed) kcp.seed = seed;
+      const mtu = params.get('mtu');
+      if (mtu) {
+        const n = Number(mtu);
+        if (Number.isFinite(n) && n > 0) kcp.mtu = n;
+      }
+      const tti = params.get('tti');
+      if (tti) {
+        const n = Number(tti);
+        if (Number.isFinite(n) && n > 0) kcp.tti = n;
+      }
+      break;
+    }
     case 'tcp':
       // vless/trojan TCP HTTP camouflage rides on header=http+host+path
       if (params.get('headerType') === 'http' || params.get('type') === 'http') {

--- a/frontend/src/test/outbound-link-parser.test.ts
+++ b/frontend/src/test/outbound-link-parser.test.ts
@@ -239,8 +239,7 @@ describe('parseVlessLink', () => {
 });
 
 describe('parseVlessLink / parseTrojanLink — mKCP seed and headerType', () => {
-  // Share links emit type=kcp&headerType&seed via applyKcpShareParams; import
-  // must restore them into kcpSettings so the outbound can talk to the inbound.
+  // Share links emit type=kcp&headerType&seed; import restores mkcp-legacy finalmask.
   it('restores seed, headerType, mtu, and tti on a vless:// kcp link', () => {
     const link =
       'vless://11111111-2222-4333-8444-555555555555@h.com:443' +
@@ -251,23 +250,26 @@ describe('parseVlessLink / parseTrojanLink — mKCP seed and headerType', () => 
     const stream = out!.streamSettings as Record<string, unknown>;
     expect(stream.network).toBe('kcp');
     const kcp = stream.kcpSettings as Record<string, unknown>;
-    expect(kcp.seed).toBe('secret-seed');
-    expect((kcp.header as Record<string, unknown>).type).toBe('wechat-video');
     expect(kcp.mtu).toBe(1400);
     expect(kcp.tti).toBe(50);
+    const finalmask = stream.finalmask as {
+      udp: Array<{ type: string; settings: Record<string, string> }>;
+    };
+    expect(finalmask.udp).toHaveLength(1);
+    expect(finalmask.udp[0].type).toBe('mkcp-legacy');
+    expect(finalmask.udp[0].settings).toEqual({ header: 'wechat', value: 'secret-seed' });
   });
 
   it('restores seed and headerType on a trojan:// kcp link', () => {
-    const link =
-      'trojan://pw@h.com:443?type=kcp&headerType=srtp&seed=abc123&security=none#kcp-tj';
+    const link = 'trojan://pw@h.com:443?type=kcp&headerType=srtp&seed=abc123&security=none#kcp-tj';
     const out = parseTrojanLink(link);
     expect(out).not.toBeNull();
-    const kcp = (out!.streamSettings as Record<string, unknown>).kcpSettings as Record<
-      string,
-      unknown
-    >;
-    expect(kcp.seed).toBe('abc123');
-    expect((kcp.header as Record<string, unknown>).type).toBe('srtp');
+    const stream = out!.streamSettings as Record<string, unknown>;
+    const finalmask = stream.finalmask as {
+      udp: Array<{ type: string; settings: Record<string, string> }>;
+    };
+    expect(finalmask.udp[0].type).toBe('mkcp-legacy');
+    expect(finalmask.udp[0].settings).toEqual({ header: 'srtp', value: 'abc123' });
   });
 });
 

--- a/frontend/src/test/outbound-link-parser.test.ts
+++ b/frontend/src/test/outbound-link-parser.test.ts
@@ -238,6 +238,39 @@ describe('parseVlessLink', () => {
   });
 });
 
+describe('parseVlessLink / parseTrojanLink — mKCP seed and headerType', () => {
+  // Share links emit type=kcp&headerType&seed via applyKcpShareParams; import
+  // must restore them into kcpSettings so the outbound can talk to the inbound.
+  it('restores seed, headerType, mtu, and tti on a vless:// kcp link', () => {
+    const link =
+      'vless://11111111-2222-4333-8444-555555555555@h.com:443' +
+      '?type=kcp&headerType=wechat-video&seed=secret-seed&mtu=1400&tti=50&security=none' +
+      '#kcp1';
+    const out = parseVlessLink(link);
+    expect(out).not.toBeNull();
+    const stream = out!.streamSettings as Record<string, unknown>;
+    expect(stream.network).toBe('kcp');
+    const kcp = stream.kcpSettings as Record<string, unknown>;
+    expect(kcp.seed).toBe('secret-seed');
+    expect((kcp.header as Record<string, unknown>).type).toBe('wechat-video');
+    expect(kcp.mtu).toBe(1400);
+    expect(kcp.tti).toBe(50);
+  });
+
+  it('restores seed and headerType on a trojan:// kcp link', () => {
+    const link =
+      'trojan://pw@h.com:443?type=kcp&headerType=srtp&seed=abc123&security=none#kcp-tj';
+    const out = parseTrojanLink(link);
+    expect(out).not.toBeNull();
+    const kcp = (out!.streamSettings as Record<string, unknown>).kcpSettings as Record<
+      string,
+      unknown
+    >;
+    expect(kcp.seed).toBe('abc123');
+    expect((kcp.header as Record<string, unknown>).type).toBe('srtp');
+  });
+});
+
 describe('parseTrojanLink', () => {
   it('parses a trojan:// link with ws + tls', () => {
     const link =

--- a/internal/util/link/outbound.go
+++ b/internal/util/link/outbound.go
@@ -638,6 +638,25 @@ func applyTransport(stream map[string]any, p url.Values) {
 				xh[k] = v
 			}
 		}
+	case "kcp":
+		// Mirror applyKcpShareParams: headerType/seed/mtu/tti from the share link.
+		kcp := stream["kcpSettings"].(map[string]any)
+		if ht := p.Get("headerType"); ht != "" {
+			kcp["header"] = map[string]any{"type": ht}
+		}
+		if seed := p.Get("seed"); seed != "" {
+			kcp["seed"] = seed
+		}
+		if mtu := p.Get("mtu"); mtu != "" {
+			if n, err := strconv.Atoi(mtu); err == nil && n > 0 {
+				kcp["mtu"] = n
+			}
+		}
+		if tti := p.Get("tti"); tti != "" {
+			if n, err := strconv.Atoi(tti); err == nil && n > 0 {
+				kcp["tti"] = n
+			}
+		}
 	case "tcp":
 		if p.Get("headerType") == "http" || p.Get("type") == "http" {
 			stream["tcpSettings"] = map[string]any{

--- a/internal/util/link/outbound.go
+++ b/internal/util/link/outbound.go
@@ -639,14 +639,8 @@ func applyTransport(stream map[string]any, p url.Values) {
 			}
 		}
 	case "kcp":
-		// Mirror applyKcpShareParams: headerType/seed/mtu/tti from the share link.
+		// mtu/tti live on kcpSettings; header/seed are finalmask mkcp-legacy (see applyMkcpLegacyFromShare).
 		kcp := stream["kcpSettings"].(map[string]any)
-		if ht := p.Get("headerType"); ht != "" {
-			kcp["header"] = map[string]any{"type": ht}
-		}
-		if seed := p.Get("seed"); seed != "" {
-			kcp["seed"] = seed
-		}
 		if mtu := p.Get("mtu"); mtu != "" {
 			if n, err := strconv.Atoi(mtu); err == nil && n > 0 {
 				kcp["mtu"] = n
@@ -705,6 +699,64 @@ func applyFinalMask(stream map[string]any, p url.Values) {
 			stream["finalmask"] = parsed
 		}
 	}
+	applyMkcpLegacyFromShare(stream, p)
+}
+
+// kcpHeaderTypeToMask maps share-link headerType to mkcp-legacy settings.header
+// (inverse of sub.kcpMaskToHeaderType).
+var kcpHeaderTypeToMask = map[string]string{
+	"dns":          "dns",
+	"dtls":         "dtls",
+	"srtp":         "srtp",
+	"utp":          "utp",
+	"wechat-video": "wechat",
+	"wireguard":    "wireguard",
+}
+
+// applyMkcpLegacyFromShare restores headerType/seed into finalmask.udp mkcp-legacy,
+// matching the shape InboundFormModal / FinalMaskForm emit. fm= mkcp-legacy wins.
+func applyMkcpLegacyFromShare(stream map[string]any, p url.Values) {
+	headerType := strings.TrimSpace(p.Get("headerType"))
+	seed := p.Get("seed")
+	if headerType == "" || headerType == "none" {
+		headerType = ""
+	}
+	if headerType == "" && seed == "" {
+		return
+	}
+	if network, _ := stream["network"].(string); network != "" && network != "kcp" {
+		return
+	}
+	maskHeader := ""
+	if headerType != "" {
+		mapped, ok := kcpHeaderTypeToMask[headerType]
+		if !ok {
+			return
+		}
+		maskHeader = mapped
+	}
+	finalmask, _ := stream["finalmask"].(map[string]any)
+	if finalmask == nil {
+		finalmask = map[string]any{}
+	}
+	udp, _ := finalmask["udp"].([]any)
+	for _, raw := range udp {
+		m, _ := raw.(map[string]any)
+		if m != nil {
+			if t, _ := m["type"].(string); t == "mkcp-legacy" {
+				return // fm= (or prior) already carries the live mask
+			}
+		}
+	}
+	udp = append(udp, map[string]any{
+		"type": "mkcp-legacy",
+		"settings": map[string]any{
+			"header": maskHeader,
+			"value":  seed,
+		},
+	})
+	finalmask["udp"] = udp
+	stream["finalmask"] = finalmask
 }
 
 // gecko packetSize bounds mirror xray-core's salamander buffer cap.

--- a/internal/util/link/outbound_helpers_test.go
+++ b/internal/util/link/outbound_helpers_test.go
@@ -244,3 +244,47 @@ func TestParseTrojanAndSS_CoreFields(t *testing.T) {
 		t.Errorf("ss server = %#v", ssrv)
 	}
 }
+
+func TestParse_KcpSeedAndHeaderType(t *testing.T) {
+	// Share links emit type=kcp&headerType&seed via applyKcpShareParams; import
+	// must restore them into kcpSettings so the outbound can talk to the inbound.
+	link := "vless://uuid@h.com:443?type=kcp&headerType=wechat-video&seed=secret-seed&mtu=1400&tti=50&security=none#kcp1"
+	res, err := ParseLink(link)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	ss, _ := res.Outbound["streamSettings"].(map[string]any)
+	if ss["network"] != "kcp" {
+		t.Fatalf("network = %v, want kcp", ss["network"])
+	}
+	kcp := streamSub(t, res, "kcpSettings")
+	if kcp["seed"] != "secret-seed" {
+		t.Fatalf("kcpSettings.seed = %v, want secret-seed", kcp["seed"])
+	}
+	header, _ := kcp["header"].(map[string]any)
+	if header["type"] != "wechat-video" {
+		t.Fatalf("kcpSettings.header.type = %v, want wechat-video", header["type"])
+	}
+	if kcp["mtu"] != 1400 {
+		t.Fatalf("kcpSettings.mtu = %v (%T), want 1400", kcp["mtu"], kcp["mtu"])
+	}
+	if kcp["tti"] != 50 {
+		t.Fatalf("kcpSettings.tti = %v (%T), want 50", kcp["tti"], kcp["tti"])
+	}
+}
+
+func TestParse_KcpSeedAndHeaderType_Trojan(t *testing.T) {
+	link := "trojan://pw@h.com:443?type=kcp&headerType=srtp&seed=abc123&security=none#kcp-tj"
+	res, err := ParseLink(link)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	kcp := streamSub(t, res, "kcpSettings")
+	if kcp["seed"] != "abc123" {
+		t.Fatalf("seed = %v, want abc123", kcp["seed"])
+	}
+	header, _ := kcp["header"].(map[string]any)
+	if header["type"] != "srtp" {
+		t.Fatalf("header.type = %v, want srtp", header["type"])
+	}
+}

--- a/internal/util/link/outbound_helpers_test.go
+++ b/internal/util/link/outbound_helpers_test.go
@@ -246,8 +246,8 @@ func TestParseTrojanAndSS_CoreFields(t *testing.T) {
 }
 
 func TestParse_KcpSeedAndHeaderType(t *testing.T) {
-	// Share links emit type=kcp&headerType&seed via applyKcpShareParams; import
-	// must restore them into kcpSettings so the outbound can talk to the inbound.
+	// Share links emit type=kcp&headerType&seed; import restores live mkcp-legacy
+	// finalmask (kcpSettings.header/seed are inert in current Xray).
 	link := "vless://uuid@h.com:443?type=kcp&headerType=wechat-video&seed=secret-seed&mtu=1400&tti=50&security=none#kcp1"
 	res, err := ParseLink(link)
 	if err != nil {
@@ -258,18 +258,24 @@ func TestParse_KcpSeedAndHeaderType(t *testing.T) {
 		t.Fatalf("network = %v, want kcp", ss["network"])
 	}
 	kcp := streamSub(t, res, "kcpSettings")
-	if kcp["seed"] != "secret-seed" {
-		t.Fatalf("kcpSettings.seed = %v, want secret-seed", kcp["seed"])
-	}
-	header, _ := kcp["header"].(map[string]any)
-	if header["type"] != "wechat-video" {
-		t.Fatalf("kcpSettings.header.type = %v, want wechat-video", header["type"])
-	}
 	if kcp["mtu"] != 1400 {
 		t.Fatalf("kcpSettings.mtu = %v (%T), want 1400", kcp["mtu"], kcp["mtu"])
 	}
 	if kcp["tti"] != 50 {
 		t.Fatalf("kcpSettings.tti = %v (%T), want 50", kcp["tti"], kcp["tti"])
+	}
+	finalmask, _ := ss["finalmask"].(map[string]any)
+	udp, _ := finalmask["udp"].([]any)
+	if len(udp) != 1 {
+		t.Fatalf("finalmask.udp len = %d, want 1: %#v", len(udp), finalmask)
+	}
+	mask, _ := udp[0].(map[string]any)
+	if mask["type"] != "mkcp-legacy" {
+		t.Fatalf("mask type = %v, want mkcp-legacy", mask["type"])
+	}
+	settings, _ := mask["settings"].(map[string]any)
+	if settings["header"] != "wechat" || settings["value"] != "secret-seed" {
+		t.Fatalf("mkcp-legacy settings = %#v, want header=wechat value=secret-seed", settings)
 	}
 }
 
@@ -279,12 +285,14 @@ func TestParse_KcpSeedAndHeaderType_Trojan(t *testing.T) {
 	if err != nil {
 		t.Fatalf("parse: %v", err)
 	}
-	kcp := streamSub(t, res, "kcpSettings")
-	if kcp["seed"] != "abc123" {
-		t.Fatalf("seed = %v, want abc123", kcp["seed"])
+	ss, _ := res.Outbound["streamSettings"].(map[string]any)
+	finalmask, _ := ss["finalmask"].(map[string]any)
+	udp, _ := finalmask["udp"].([]any)
+	if len(udp) != 1 {
+		t.Fatalf("finalmask.udp len = %d, want 1", len(udp))
 	}
-	header, _ := kcp["header"].(map[string]any)
-	if header["type"] != "srtp" {
-		t.Fatalf("header.type = %v, want srtp", header["type"])
+	settings, _ := udp[0].(map[string]any)["settings"].(map[string]any)
+	if settings["header"] != "srtp" || settings["value"] != "abc123" {
+		t.Fatalf("mkcp-legacy settings = %#v", settings)
 	}
 }


### PR DESCRIPTION
## Summary
- Share links for mKCP inbounds carry `type=kcp&headerType=…&seed=…` (plus `mtu`/`tti`), but both importers — Go `internal/util/link/outbound.go` and TS `frontend/src/lib/xray/outbound-link-parser.ts` — ignored them and kept the canned `kcpSettings` defaults.
- On the pinned xray-core, `kcpSettings.header`/`seed` are parsed but never used (`KCPConfig.Build` reads only mtu/tti/capacities). The live obfuscation is the finalmask `mkcp-legacy` UDP mask, so import now rebuilds those masks from `headerType`/`seed` when the link carries no `fm=` mkcp-legacy mask (an `fm=` mask wins).
- One mask per field, seed first: `MkcpLegacy.Build` ignores `value` once `header` is set (and reads it as the DNS domain for `dns`), and the finalmask array's first item is the innermost layer. `[{header:"", value:<seed>}, {header:"wechat", value:""}]` therefore puts the header around the cipher as legacy mKCP did, and matches what the panel's inbound form and the sub emitter model (one mask per field).
- `mtu`/`tti` are copied onto `kcpSettings` only inside `KCPConfig.Build`'s accepted ranges (mtu ≥ 21, tti 10..1000, decimal digits only on both importers). An out-of-range value would fail the whole Xray config load, so it keeps the `buildStream` default instead.
- Header types are looked up as own properties in TS, so a prototype key such as `constructor` is not mapped.
- Go and TS table tests cover: header+seed → two masks in order, header-only, seed-only, out-of-range and non-decimal `mtu`/`tti`, prototype key.

Not covered here (pre-existing): the vmess importers still have no kcp branch and ignore `fm` (the vmess emitter writes the header as `type` and the seed as `path`), and the TS share-link emitter emits only `mtu`/`tti` for kcp while the Go sub emitter also emits `headerType`/`seed`.

Fixes #6476

## Test plan
- [x] `go test ./internal/util/link/ -run TestParse_KcpShareParams`
- [x] `cd frontend && npx vitest run src/test/outbound-link-parser.test.ts`
- [x] `make verify`
- [ ] Create a VLESS inbound with network `kcp` and two mkcp-legacy masks (`header: ""` with a seed as value, and `header: wechat`); copy the client share link and confirm the query has `type=kcp&headerType=wechat-video&seed=…`
- [ ] Import that link as an outbound with the `fm=` param removed (the panel's own link carries `fm`, which already round-trips); `streamSettings.finalmask.udp` must list `{header:"", value:<seed>}` then `{header:"wechat", value:""}`, and the outbound must connect to the inbound
